### PR TITLE
@dzucconi: Add link tooltip plugin

### DIFF
--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -9,7 +9,7 @@ try
   Scribe = require 'scribe-editor'
   scribePluginToolbar = require 'scribe-plugin-toolbar'
   scribePluginSanitizer = require './sanitizer.coffee'
-  scribePluginLinkPromptCommand = require 'scribe-plugin-link-prompt-command'
+  scribePluginLinkTooltip = require 'scribe-plugin-link-tooltip'
 React = require 'react'
 icons = -> require('./icons.jade') arguments...
 { div, nav, button } = React.DOM
@@ -31,7 +31,7 @@ module.exports = React.createClass
         a: { href: true, target: '_blank' }
     }
     @scribe.use scribePluginToolbar @refs.toolbar.getDOMNode()
-    @scribe.use scribePluginLinkPromptCommand({})
+    @scribe.use scribePluginLinkTooltip()
     $(@refs.editable.getDOMNode()).focus()
 
   componentDidMount: ->
@@ -63,10 +63,11 @@ module.exports = React.createClass
           dangerouslySetInnerHTML:
             __html: "&nbsp;" + $(icons()).filter('.remove-formatting').html()
         }
-      div {
-        className: 'edit-section-text-editable'
-        ref: 'editable'
-        dangerouslySetInnerHTML: __html: @props.section.get('body')
-        onClick: @props.setEditing(on)
-        onFocus: @props.setEditing(on)
-      }
+      div { className: 'est-editable-container' },
+        div {
+          className: 'edit-section-text-editable'
+          ref: 'editable'
+          dangerouslySetInnerHTML: __html: @props.section.get('body')
+          onClick: @props.setEditing(on)
+          onFocus: @props.setEditing(on)
+        }

--- a/client/apps/edit/components/section_text/index.styl
+++ b/client/apps/edit/components/section_text/index.styl
@@ -95,3 +95,42 @@
 .edit-section-container[data-state-editing=true]
   nav
     display block
+
+.scribe-plugin-link-tooltip
+  background black
+  position absolute
+  padding 12px
+  z-index 2
+  width 400px
+  margin-left -(@width / 2)
+  &::after
+    content '.'
+    width 0
+    height 0
+    border-left 7px solid transparent
+    border-right 7px solid transparent
+    border-bottom 7px solid black
+    position absolute
+    top -7px
+    left 200px
+  input
+    background white
+    color black
+    border 0
+    padding 0 10px
+    width 296px
+  button
+    background gray-darker-color
+    color white
+    font-size small-avant-garde-font-size + 1
+    border 0
+    padding 0
+    width 80px
+    text-align center
+    &:hover
+      color white
+      background gray-dark-color
+  input, button
+    height 30px
+    display inline-block
+    vertical-align top

--- a/client/components/layout/stylesheets/form_elements.styl
+++ b/client/components/layout/stylesheets/form_elements.styl
@@ -124,3 +124,9 @@ label.bordered-input-loading
   background purple-color
   min-width 10%
   transition width 0.5s
+
+.scribe-plugin-link-tooltip button
+  @extend .avant-garde-button
+
+.scribe-plugin-link-tooltip input
+  @extend .bordered-input

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,7 +5,7 @@
     "antigravity": {
       "version": "0.0.4",
       "from": "antigravity@git://github.com/artsy/antigravity.git",
-      "resolved": "git://github.com/artsy/antigravity.git#490f09f3e0b368f7eed7b790fec74495837c8139",
+      "resolved": "git://github.com/artsy/antigravity.git#b4696204206850462ba70be4676a1cc7db98d8bb",
       "dependencies": {
         "express": {
           "version": "4.9.5",
@@ -2469,7 +2469,7 @@
     "scribe-editor": {
       "version": "0.1.25",
       "from": "scribe-editor@git://github.com/guardian/scribe.git",
-      "resolved": "git://github.com/guardian/scribe.git#46f6fdf87ed39be8a3d81f70157e37e5c4598ece",
+      "resolved": "git://github.com/guardian/scribe.git#9effa16217a6123fb856b1c79efba46be2bdd14b",
       "dependencies": {
         "lodash-amd": {
           "version": "2.4.1",
@@ -2483,17 +2483,9 @@
         }
       }
     },
-    "scribe-plugin-link-prompt-command": {
-      "version": "0.1.2",
-      "from": "scribe-plugin-link-prompt-command@*",
-      "resolved": "https://registry.npmjs.org/scribe-plugin-link-prompt-command/-/scribe-plugin-link-prompt-command-0.1.2.tgz",
-      "dependencies": {
-        "lodash-amd": {
-          "version": "2.4.1",
-          "from": "lodash-amd@~2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash-amd/-/lodash-amd-2.4.1.tgz"
-        }
-      }
+    "scribe-plugin-link-tooltip": {
+      "version": "0.0.2",
+      "from": "scribe-plugin-link-tooltip@*"
     },
     "scribe-plugin-toolbar": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "deamdify": "*",
     "scribe-editor": "git://github.com/guardian/scribe.git",
     "scribe-plugin-toolbar": "*",
-    "scribe-plugin-link-prompt-command": "*",
+    "scribe-plugin-link-tooltip": "*",
     "html-janitor": "git://github.com/gaearon/html-janitor.git#patch-1",
     "imagesloaded": "*",
 


### PR DESCRIPTION
This replaces a default javascript prompt with a [custom Artsy Scribe plugin](https://github.com/artsy/scribe-plugin-link-tooltip)

![cap](https://cloud.githubusercontent.com/assets/555859/4926747/ef89bc9e-6535-11e4-92f2-e6ec4405f556.gif)
