### PR TITLE
@broskoski: Level up Scribe

### DIFF
--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -50,6 +50,7 @@ module.exports = class EditLayout extends Backbone.View
         p: true
         b: true
         i: true
+        br: true
         a: { href: true, target: '_blank' }
     @toggleLeadParagraphPlaceholder()
 

--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -10,9 +10,17 @@ try
   scribePluginToolbar = require 'scribe-plugin-toolbar'
   scribePluginSanitizer = require '../../lib/sanitizer.coffee'
   scribePluginLinkTooltip = require 'scribe-plugin-link-tooltip'
+  scribePluginKeyboardShortcuts = require 'scribe-plugin-keyboard-shortcuts'
 React = require 'react'
 icons = -> require('./icons.jade') arguments...
 { div, nav, button } = React.DOM
+
+keyboardShortcutsMap =
+  bold: (e) -> e.metaKey and e.keyCode is 66
+  italic: (e) -> e.metaKey and e.keyCode is 73
+  removeFormat: (e) -> e.altKey and e.shiftKey and e.keyCode is 65
+  linkPrompt: (e) -> e.metaKey and not e.shiftKey and e.keyCode is 75
+  unlink: (e) -> e.metaKey and e.shiftKey and e.keyCode is 75
 
 module.exports = React.createClass
 
@@ -28,10 +36,12 @@ module.exports = React.createClass
         p: true
         b: true
         i: true
+        br: true
         a: { href: true, target: '_blank' }
     }
     @scribe.use scribePluginToolbar @refs.toolbar.getDOMNode()
     @scribe.use scribePluginLinkTooltip()
+    @scribe.use scribePluginKeyboardShortcuts keyboardShortcutsMap
     $(@refs.editable.getDOMNode()).focus()
 
   componentDidMount: ->

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,7 +5,7 @@
     "antigravity": {
       "version": "0.0.4",
       "from": "antigravity@git://github.com/artsy/antigravity.git",
-      "resolved": "git://github.com/artsy/antigravity.git#2a4b7319a40cdf01becbf2b7956b8d8ac66c17b5",
+      "resolved": "git://github.com/artsy/antigravity.git#5fdce766a2d49c368fd0977bc0b8b020e3f0925c",
       "dependencies": {
         "express": {
           "version": "4.9.5",
@@ -221,207 +221,160 @@
     },
     "async": {
       "version": "0.9.0",
-      "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+      "from": "async@*",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
     },
     "backbone": {
       "version": "1.1.2",
-      "from": "http://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz",
+      "from": "backbone@*",
       "resolved": "http://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz"
     },
     "backbone-super-sync": {
-      "version": "0.0.14",
-      "from": "https://registry.npmjs.org/backbone-super-sync/-/backbone-super-sync-0.0.14.tgz",
-      "resolved": "https://registry.npmjs.org/backbone-super-sync/-/backbone-super-sync-0.0.14.tgz",
+      "version": "0.0.21",
+      "from": "backbone-super-sync@*",
+      "resolved": "https://registry.npmjs.org/backbone-super-sync/-/backbone-super-sync-0.0.21.tgz",
       "dependencies": {
-        "superagent": {
-          "version": "0.15.7",
-          "from": "https://registry.npmjs.org/superagent/-/superagent-0.15.7.tgz",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.15.7.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "0.6.5",
-              "from": "http://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
-              "resolved": "http://registry.npmjs.org/qs/-/qs-0.6.5.tgz"
-            },
-            "formidable": {
-              "version": "1.0.14",
-              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
-            },
-            "mime": {
-              "version": "1.2.5",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz"
-            },
-            "emitter-component": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz"
-            },
-            "methods": {
-              "version": "0.0.1",
-              "from": "http://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
-              "resolved": "http://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
-            },
-            "cookiejar": {
-              "version": "1.3.0",
-              "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.0.tgz"
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            },
-            "reduce-component": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
-            }
-          }
-        },
         "q": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+          "version": "1.1.2",
+          "from": "q@*",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
         }
       }
     },
     "benv": {
       "version": "0.1.6",
-      "from": "https://registry.npmjs.org/benv/-/benv-0.1.6.tgz",
+      "from": "benv@*",
       "resolved": "https://registry.npmjs.org/benv/-/benv-0.1.6.tgz",
       "dependencies": {
         "jsdom": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/jsdom/-/jsdom-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-1.0.3.tgz",
+          "version": "1.4.1",
+          "from": "jsdom@*",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-1.4.1.tgz",
           "dependencies": {
             "contextify": {
               "version": "0.1.9",
-              "from": "https://registry.npmjs.org/contextify/-/contextify-0.1.9.tgz",
+              "from": "contextify@>= 0.1.9 < 0.2.0",
               "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.9.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+                  "from": "bindings@*",
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz",
+                  "from": "nan@~1.3.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
                 }
               }
             },
             "cssom": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz",
+              "from": "cssom@>= 0.3.0 < 0.4.0",
               "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
             },
             "cssstyle": {
-              "version": "0.2.21",
-              "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.21.tgz",
-              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.21.tgz"
+              "version": "0.2.22",
+              "from": "cssstyle@>= 0.2.21 < 0.3.0",
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.22.tgz"
             },
             "htmlparser2": {
-              "version": "3.7.3",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+              "version": "3.8.2",
+              "from": "htmlparser2@>= 3.7.3 < 4.0.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.0.tgz"
+                  "version": "2.3.0",
+                  "from": "domhandler@2.3",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz",
+                  "from": "domutils@1.5",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
                 },
                 "domelementtype": {
-                  "version": "1.1.1",
-                  "from": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz",
-                  "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
+                  "version": "1.1.3",
+                  "from": "domelementtype@1",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "from": "entities@1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "nwmatcher": {
               "version": "1.3.3",
-              "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.3.tgz",
+              "from": "nwmatcher@>= 1.3.3 < 2.0.0",
               "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.3.tgz"
             },
             "parse5": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/parse5/-/parse5-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.1.6.tgz"
+              "version": "1.2.0",
+              "from": "parse5@>= 1.2.0 < 2.0.0",
+              "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.2.0.tgz"
             },
             "request": {
-              "version": "2.45.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.45.0.tgz",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.45.0.tgz",
+              "version": "2.51.0",
+              "from": "request@>= 2.44.0 < 3.0.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.3",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+                  "from": "bl@~0.9.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.0.33-1",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33-1.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33-1.tgz",
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.26",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@~2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -429,217 +382,224 @@
                   }
                 },
                 "caseless": {
-                  "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                  "version": "0.8.0",
+                  "from": "caseless@~0.8.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "from": "forever-agent@~0.5.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
-                "qs": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@~0.2.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.4",
+                      "from": "mime-types@~2.0.3",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.3.0",
+                          "from": "mime-db@~1.3.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+                  "from": "json-stringify-safe@~5.0.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "from": "mime-types@~1.0.1",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.1",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                  "version": "1.4.2",
+                  "from": "node-uuid@~1.4.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@~2.3.1",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                  "from": "tunnel-agent@~0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-                },
-                "form-data": {
-                  "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-                  "dependencies": {
-                    "combined-stream": {
-                      "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                          "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                        }
-                      }
-                    },
-                    "mime": {
-                      "version": "1.2.11",
-                      "from": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-                      "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                    }
-                  }
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "from": "tough-cookie@>=0.12.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
-                      "version": "1.3.1",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.0",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                  "from": "http-signature@~0.10.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
+                      "from": "assert-plus@0.1.2",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
+                      "from": "ctype@0.5.2",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
-                  "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                  "version": "0.5.0",
+                  "from": "oauth-sign@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "from": "hawk@1.1.1",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "from": "hoek@0.9.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "from": "boom@0.4.x",
                       "resolved": "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "from": "cryptiles@0.2.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "http://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "from": "sntp@0.2.x",
                       "resolved": "http://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@~0.5.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@~0.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
                 }
               }
             },
             "xmlhttprequest": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.6.0.tgz",
+              "from": "xmlhttprequest@>= 1.6.0 < 2.0.0",
               "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.6.0.tgz"
             },
             "browser-request": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.2.tgz"
+              "version": "0.3.3",
+              "from": "browser-request@>= 0.3.1 < 0.4.0",
+              "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
             }
           }
         }
       }
     },
     "body-parser": {
-      "version": "1.9.2",
-      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.2.tgz",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.2.tgz",
+      "version": "1.10.0",
+      "from": "body-parser@*",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.0.tgz",
       "dependencies": {
         "bytes": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+          "from": "bytes@1.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
         },
         "depd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+          "from": "depd@~1.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "iconv-lite": {
-          "version": "0.4.4",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+          "version": "0.4.5",
+          "from": "iconv-lite@0.4.5",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
         },
         "media-typer": {
           "version": "0.3.0",
-          "from": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+          "from": "media-typer@0.3.0",
           "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
         },
         "on-finished": {
           "version": "2.1.1",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
+          "from": "on-finished@~2.1.1",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+              "from": "ee-first@1.1.0",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
         },
         "qs": {
-          "version": "2.3.2",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz"
+          "version": "2.3.3",
+          "from": "qs@2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "raw-body": {
-          "version": "1.3.0",
-          "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
+          "version": "1.3.1",
+          "from": "raw-body@1.3.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.1.tgz"
         },
         "type-is": {
-          "version": "1.5.2",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.2.tgz",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.2.tgz",
+          "version": "1.5.4",
+          "from": "type-is@~1.5.3",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.4.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.2.tgz",
+              "version": "2.0.4",
+              "from": "mime-types@~2.0.4",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
+                  "version": "1.3.0",
+                  "from": "mime-db@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.0.tgz"
                 }
               }
             }
@@ -649,59 +609,59 @@
     },
     "browserify": {
       "version": "5.13.1",
-      "from": "https://registry.npmjs.org/browserify/-/browserify-5.13.1.tgz",
+      "from": "browserify@5.x",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-5.13.1.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.8.4",
-          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+          "from": "JSONStream@~0.8.3",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+              "from": "jsonparse@0.0.5",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+              "from": "through@>=2.2.7 <3",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "assert": {
           "version": "1.1.2",
-          "from": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
+          "from": "assert@~1.1.0",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
         },
         "browser-pack": {
           "version": "3.2.0",
-          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
+          "from": "browser-pack@^3.0.0",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
           "dependencies": {
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+              "from": "combine-source-map@~0.3.0",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz",
+                  "from": "inline-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                  "from": "convert-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.40",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                  "from": "source-map@~0.1.31",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -710,78 +670,85 @@
             },
             "through2": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "from": "through2@~0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
             }
           }
         },
         "browser-resolve": {
-          "version": "1.3.2",
-          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.3.2.tgz"
+          "version": "1.5.0",
+          "from": "browser-resolve@^1.3.0",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.5.0.tgz",
+          "dependencies": {
+            "resolve": {
+              "version": "1.0.0",
+              "from": "resolve@1.0.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz"
+            }
+          }
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "from": "browserify-zlib@~0.1.2",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
               "version": "0.2.5",
-              "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
+              "from": "pako@~0.2.0",
               "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
             }
           }
         },
         "buffer": {
-          "version": "2.7.0",
-          "from": "https://registry.npmjs.org/buffer/-/buffer-2.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.7.0.tgz",
+          "version": "2.8.2",
+          "from": "buffer@^2.3.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz",
+              "from": "base64-js@0.0.7",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
             },
             "ieee754": {
               "version": "1.1.4",
-              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz",
+              "from": "ieee754@^1.1.4",
               "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+              "from": "is-array@^1.0.1",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+          "from": "builtins@~0.0.3",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+          "from": "commondir@0.0.1",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
-          "version": "1.4.6",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.6.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.6.tgz",
+          "version": "1.4.7",
+          "from": "concat-stream@~1.4.1",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@~0.0.5",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@~1.1.9",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 }
               }
@@ -790,88 +757,190 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "from": "console-browserify@^1.1.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "from": "date-now@^0.1.4",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+          "from": "constants-browserify@~0.0.1",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
-          "version": "3.2.8",
-          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+          "version": "3.6.0",
+          "from": "crypto-browserify@^3.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.6.0.tgz",
           "dependencies": {
+            "browserify-aes": {
+              "version": "0.6.0",
+              "from": "browserify-aes@0.6.0",
+              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.6.0.tgz"
+            },
+            "browserify-sign": {
+              "version": "2.4.0",
+              "from": "browserify-sign@2.4.0",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.4.0.tgz",
+              "dependencies": {
+                "asn1.js": {
+                  "version": "0.6.5",
+                  "from": "asn1.js@^0.6.4",
+                  "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.5.tgz"
+                },
+                "asn1.js-rfc3280": {
+                  "version": "0.5.1",
+                  "from": "asn1.js-rfc3280@^0.5.1",
+                  "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-0.5.1.tgz"
+                },
+                "bn.js": {
+                  "version": "0.15.2",
+                  "from": "bn.js@^0.15.2",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.2.tgz"
+                },
+                "elliptic": {
+                  "version": "0.15.15",
+                  "from": "elliptic@^0.15.14",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.15.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@^1.0.1",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    },
+                    "hash.js": {
+                      "version": "0.2.1",
+                      "from": "hash.js@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-0.2.1.tgz"
+                    }
+                  }
+                },
+                "pemstrip": {
+                  "version": "0.0.1",
+                  "from": "pemstrip@0.0.1",
+                  "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                }
+              }
+            },
+            "create-ecdh": {
+              "version": "1.0.0",
+              "from": "create-ecdh@1.0.0",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.0.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "0.15.2",
+                  "from": "bn.js@^0.15.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.2.tgz"
+                },
+                "elliptic": {
+                  "version": "0.15.15",
+                  "from": "elliptic@^0.15.14",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.15.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@^1.0.1",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    },
+                    "hash.js": {
+                      "version": "0.2.1",
+                      "from": "hash.js@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-0.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "diffie-hellman": {
+              "version": "2.2.0",
+              "from": "diffie-hellman@2.2.0",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.0.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "0.15.2",
+                  "from": "bn.js@0.15.2",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.2.tgz"
+                },
+                "miller-rabin": {
+                  "version": "1.1.1",
+                  "from": "miller-rabin@^1.1.1",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.1.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@^1.0.1",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
             "pbkdf2-compat": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+              "from": "pbkdf2-compat@2.0.1",
               "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
             },
             "ripemd160": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+              "from": "ripemd160@0.2.0",
               "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
             },
             "sha.js": {
-              "version": "2.2.6",
-              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+              "version": "2.3.0",
+              "from": "sha.js@2.3.0",
+              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.0.tgz"
             }
           }
         },
         "deep-equal": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
+          "from": "deep-equal@~0.2.1",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "from": "defined@~0.0.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
           "version": "1.3.5",
-          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+          "from": "deps-sort@^1.3.5",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+              "from": "minimist@~0.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "through2": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "from": "through2@~0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
             }
           }
         },
         "domain-browser": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz",
+          "from": "domain-browser@~1.1.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz"
         },
         "duplexer2": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "from": "duplexer2@~0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@~1.1.9",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 }
               }
@@ -880,44 +949,58 @@
         },
         "events": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+          "from": "events@~1.0.0",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
-          "version": "4.0.6",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+          "version": "4.3.1",
+          "from": "glob@^4.0.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.1.tgz",
           "dependencies": {
-            "graceful-fs": {
-              "version": "3.0.4",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz"
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@^1.0.4",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
             },
             "minimatch": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "version": "2.0.1",
+              "from": "minimatch@^2.0.1",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                "brace-expansion": {
+                  "version": "1.0.1",
+                  "from": "brace-expansion@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.0.1.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.0",
+                      "from": "concat-map@0.0.0",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.0.tgz"
+                    }
+                  }
                 }
               }
             },
             "once": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "from": "once@^1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -926,56 +1009,56 @@
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "from": "http-browserify@^1.4.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+              "from": "Base64@~0.2.0",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+          "from": "https-browserify@~0.0.0",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@~2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
           "version": "6.1.0",
-          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.1.0.tgz",
+          "from": "insert-module-globals@^6.1.0",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.1.0.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "from": "JSONStream@~0.7.1",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 }
               }
             },
             "lexical-scope": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+              "from": "lexical-scope@~1.1.0",
               "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
               "dependencies": {
                 "astw": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                  "from": "astw@~1.1.0",
                   "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "3001.1.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                     }
                   }
@@ -984,51 +1067,51 @@
             },
             "process": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
+              "from": "process@~0.6.0",
               "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
             },
             "through": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+              "from": "through@~2.3.4",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "from": "isarray@0.0.1",
           "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "labeled-stream-splicer": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.0.tgz",
+          "version": "1.0.2",
+          "from": "labeled-stream-splicer@^1.0.0",
+          "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+              "from": "stream-splicer@^1.1.0",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@^1.1.13-1",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                  "from": "readable-wrap@^1.0.0",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "from": "indexof@0.0.1",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
@@ -1036,127 +1119,127 @@
           }
         },
         "module-deps": {
-          "version": "3.5.6",
-          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.5.6.tgz",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.5.6.tgz",
+          "version": "3.6.1",
+          "from": "module-deps@^3.5.0",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.6.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "from": "JSONStream@~0.7.1",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+                  "from": "through@>=2.2.7 <3",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "detective": {
-              "version": "3.1.0",
-              "from": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
+              "version": "4.0.0",
+              "from": "detective@^4.0.0",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
               "dependencies": {
+                "acorn": {
+                  "version": "0.9.0",
+                  "from": "acorn@~0.9.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                },
                 "escodegen": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+                  "version": "1.4.1",
+                  "from": "escodegen@^1.4.1",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.4.1.tgz",
                   "dependencies": {
-                    "esprima": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                    },
                     "estraverse": {
-                      "version": "1.5.1",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                      "version": "1.9.0",
+                      "from": "estraverse@^1.5.1",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.0.tgz"
                     },
                     "esutils": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+                      "version": "1.1.6",
+                      "from": "esutils@^1.1.4",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                    },
+                    "esprima": {
+                      "version": "1.2.2",
+                      "from": "esprima@^1.2.2",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
                     },
                     "source-map": {
                       "version": "0.1.40",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                      "from": "source-map@~0.1.37",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
                     }
                   }
-                },
-                "esprima-fb": {
-                  "version": "3001.1.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                 }
               }
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+              "from": "minimist@~0.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "parents": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/parents/-/parents-1.0.0.tgz",
+              "from": "parents@^1.0.0",
               "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.0.tgz",
               "dependencies": {
                 "path-platform": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
+                  "from": "path-platform@^0.0.1",
                   "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
                 }
               }
             },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "from": "stream-combiner2@~1.0.0",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                 }
               }
             },
             "subarg": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+              "from": "subarg@0.0.1",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@~0.0.7",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+              "from": "through2@~0.4.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
                 "xtend": {
                   "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "from": "xtend@~2.1.1",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "dependencies": {
                     "object-keys": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                      "from": "object-keys@~0.4.0",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
@@ -1167,76 +1250,76 @@
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+          "from": "os-browserify@~0.1.1",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "0.0.3",
-          "from": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+          "from": "parents@~0.0.1",
           "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
+              "from": "path-platform@^0.0.1",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+          "from": "path-browserify@~0.0.0",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.7.0",
-          "from": "https://registry.npmjs.org/process/-/process-0.7.0.tgz",
+          "from": "process@^0.7.0",
           "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+          "from": "punycode@~1.2.3",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+          "from": "querystring-es3@~0.2.0",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
-          "version": "1.0.33-1",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33-1.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33-1.tgz",
+          "version": "1.0.33",
+          "from": "readable-stream@^1.0.27-1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@~1.0.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.7.4",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
+          "from": "resolve@~0.7.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+          "from": "shallow-copy@0.0.1",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.0.tgz",
+          "from": "shasum@^1.0.0",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.0.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+              "from": "json-stable-stringify@~0.0.0",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "from": "jsonify@~0.0.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
@@ -1245,136 +1328,136 @@
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+          "from": "shell-quote@~0.0.1",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "from": "stream-browserify@^1.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "from": "string_decoder@~0.10.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "from": "subarg@^1.0.0",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
+              "from": "minimist@^1.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
             }
           }
         },
         "syntax-error": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.1.tgz",
+          "version": "1.1.2",
+          "from": "syntax-error@^1.1.1",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
           "dependencies": {
-            "esprima-fb": {
-              "version": "3001.1.0-dev-harmony-fb",
-              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
-              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+            "acorn": {
+              "version": "0.9.0",
+              "from": "acorn@~0.9.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "from": "through2@^1.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.1.0.tgz",
+          "from": "timers-browserify@^1.0.1",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.1.0.tgz",
           "dependencies": {
             "process": {
               "version": "0.5.2",
-              "from": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+              "from": "process@~0.5.1",
               "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
             }
           }
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+          "from": "tty-browserify@~0.0.0",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "umd": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
+          "from": "umd@~2.1.0",
           "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
           "dependencies": {
             "rfile": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+              "from": "rfile@~1.0.0",
               "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
               "dependencies": {
                 "callsite": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                  "from": "callsite@~1.0.0",
                   "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                 },
                 "resolve": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+                  "from": "resolve@~0.3.0",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
                 }
               }
             },
             "ruglify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+              "from": "ruglify@~1.0.0",
               "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "2.2.5",
-                  "from": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                  "from": "uglify-js@~2.2",
                   "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.1.40",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                      "from": "source-map@~0.1.7",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "from": "optimist@~0.3.5",
                       "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "from": "wordwrap@~0.0.2",
                           "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
@@ -1385,77 +1468,77 @@
             },
             "through": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+              "from": "through@~2.3.4",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "url": {
           "version": "0.10.1",
-          "from": "https://registry.npmjs.org/url/-/url-0.10.1.tgz",
+          "from": "url@~0.10.1",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.1.tgz"
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@~0.10.1",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "from": "vm-browserify@~0.0.1",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+              "from": "indexof@0.0.1",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "from": "xtend@^3.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "browserify-dev-middleware": {
       "version": "0.0.6",
-      "from": "https://registry.npmjs.org/browserify-dev-middleware/-/browserify-dev-middleware-0.0.6.tgz",
+      "from": "browserify-dev-middleware@*",
       "resolved": "https://registry.npmjs.org/browserify-dev-middleware/-/browserify-dev-middleware-0.0.6.tgz"
     },
     "caching-coffeeify": {
       "version": "0.4.0",
-      "from": "https://registry.npmjs.org/caching-coffeeify/-/caching-coffeeify-0.4.0.tgz",
+      "from": "caching-coffeeify@*",
       "resolved": "https://registry.npmjs.org/caching-coffeeify/-/caching-coffeeify-0.4.0.tgz",
       "dependencies": {
         "coffeeify": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/coffeeify/-/coffeeify-0.6.0.tgz",
+          "from": "coffeeify@~0.6.0",
           "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-0.6.0.tgz",
           "dependencies": {
             "coffee-script": {
               "version": "1.7.1",
-              "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+              "from": "coffee-script@~1.7.0",
               "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                  "from": "mkdirp@~0.3.5",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
             },
             "convert-source-map": {
               "version": "0.3.5",
-              "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+              "from": "convert-source-map@~0.3.3",
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
             }
           }
         },
         "through": {
           "version": "2.3.6",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+          "from": "through@~2.3.4",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
         }
       }
@@ -1569,112 +1652,117 @@
     },
     "coffee-script": {
       "version": "1.8.0",
-      "from": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
+      "from": "coffee-script@*",
       "resolved": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
       "dependencies": {
         "mkdirp": {
           "version": "0.3.5",
-          "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+          "from": "mkdirp@~0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
         }
       }
     },
     "cookie-parser": {
       "version": "1.3.3",
-      "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.3.tgz",
+      "from": "cookie-parser@*",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.3.tgz",
       "dependencies": {
         "cookie": {
           "version": "0.1.2",
-          "from": "http://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-          "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+          "from": "cookie@0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
         },
         "cookie-signature": {
           "version": "1.0.5",
-          "from": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
+          "from": "cookie-signature@1.0.5",
           "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
         }
       }
     },
     "cookie-session": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.0.2.tgz",
+      "version": "1.1.0",
+      "from": "cookie-session@*",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.1.0.tgz",
       "dependencies": {
         "cookies": {
-          "version": "0.4.1",
-          "from": "https://registry.npmjs.org/cookies/-/cookies-0.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.4.1.tgz",
+          "version": "0.5.0",
+          "from": "cookies@0.5.0",
+          "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.5.0.tgz",
           "dependencies": {
             "keygrip": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz",
+              "from": "keygrip@~1.0.0",
               "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz"
             }
           }
         },
         "debug": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+          "from": "debug@~2.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
+        },
+        "on-headers": {
+          "version": "1.0.0",
+          "from": "on-headers@~1.0.0",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
         }
       }
     },
     "cron": {
       "version": "1.0.5",
-      "from": "https://registry.npmjs.org/cron/-/cron-1.0.5.tgz",
+      "from": "cron@*",
       "resolved": "https://registry.npmjs.org/cron/-/cron-1.0.5.tgz"
     },
     "deamdify": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/deamdify/-/deamdify-0.1.1.tgz",
+      "from": "deamdify@*",
       "resolved": "https://registry.npmjs.org/deamdify/-/deamdify-0.1.1.tgz",
       "dependencies": {
         "through": {
           "version": "2.3.6",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+          "from": "through@2.x.x",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
         },
         "esprima": {
           "version": "1.2.2",
-          "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "from": "esprima@1.x.x",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
         },
         "estraverse": {
-          "version": "1.7.0",
-          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.7.0.tgz"
+          "version": "1.9.0",
+          "from": "estraverse@1.x.x",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.0.tgz"
         },
         "escodegen": {
           "version": "0.0.28",
-          "from": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+          "from": "escodegen@0.0.x",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@~1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "estraverse": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+              "from": "estraverse@~1.3.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
             },
             "source-map": {
               "version": "0.1.40",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+              "from": "source-map@>= 0.1.2",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -1684,188 +1772,188 @@
       }
     },
     "express": {
-      "version": "4.10.1",
-      "from": "https://registry.npmjs.org/express/-/express-4.10.1.tgz",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.10.1.tgz",
+      "version": "4.10.5",
+      "from": "express@*",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.10.5.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.2.tgz",
+          "version": "1.1.4",
+          "from": "accepts@~1.1.4",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.2.tgz",
+              "version": "2.0.4",
+              "from": "mime-types@~2.0.4",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
+                  "version": "1.3.0",
+                  "from": "mime-db@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.4.9",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+              "from": "negotiator@0.4.9",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
             }
           }
         },
         "content-disposition": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
+          "from": "content-disposition@0.5.0",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
         },
         "cookie-signature": {
           "version": "1.0.5",
-          "from": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
+          "from": "cookie-signature@1.0.5",
           "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
         },
         "debug": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+          "from": "debug@~2.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+          "from": "depd@~1.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "escape-html": {
           "version": "1.0.1",
-          "from": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+          "from": "escape-html@1.0.1",
           "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
-          "version": "1.5.0",
-          "from": "https://registry.npmjs.org/etag/-/etag-1.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.0.tgz",
+          "version": "1.5.1",
+          "from": "etag@~1.5.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
           "dependencies": {
             "crc": {
-              "version": "3.0.0",
-              "from": "http://registry.npmjs.org/crc/-/crc-3.0.0.tgz",
-              "resolved": "http://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+              "version": "3.2.1",
+              "from": "crc@3.2.1",
+              "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
             }
           }
         },
         "finalhandler": {
           "version": "0.3.2",
-          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.2.tgz",
+          "from": "finalhandler@0.3.2",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.2.tgz"
         },
         "fresh": {
           "version": "0.2.4",
-          "from": "http://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
+          "from": "fresh@0.2.4",
           "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
         },
         "media-typer": {
           "version": "0.3.0",
-          "from": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+          "from": "media-typer@0.3.0",
           "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
         },
         "methods": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz",
+          "from": "methods@1.1.0",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
         },
         "on-finished": {
           "version": "2.1.1",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
+          "from": "on-finished@~2.1.1",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+              "from": "ee-first@1.1.0",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
+          "from": "parseurl@~1.3.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.3",
-          "from": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz",
+          "from": "path-to-regexp@0.1.3",
           "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
         },
         "proxy-addr": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.3.tgz",
+          "version": "1.0.4",
+          "from": "proxy-addr@~1.0.4",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.4.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+              "from": "forwarded@~0.1.0",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
-              "version": "0.1.3",
-              "from": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.3.tgz",
-              "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.3.tgz"
+              "version": "0.1.5",
+              "from": "ipaddr.js@0.1.5",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.5.tgz"
             }
           }
         },
         "qs": {
-          "version": "2.3.2",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz"
+          "version": "2.3.3",
+          "from": "qs@2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "range-parser": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz",
+          "from": "range-parser@~1.0.2",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
         },
         "send": {
           "version": "0.10.1",
-          "from": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
+          "from": "send@0.10.1",
           "resolved": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.3",
-              "from": "http://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
+              "from": "destroy@1.0.3",
               "resolved": "http://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
             },
             "mime": {
               "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+              "from": "mime@1.2.11",
+              "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "ms": {
               "version": "0.6.2",
-              "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.7.1",
-          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.1.tgz",
+          "from": "serve-static@~1.7.1",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.1.tgz"
         },
         "type-is": {
-          "version": "1.5.2",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.2.tgz",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.2.tgz",
+          "version": "1.5.4",
+          "from": "type-is@~1.5.4",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.4.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.2.tgz",
+              "version": "2.0.4",
+              "from": "mime-types@~2.0.4",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
+                  "version": "1.3.0",
+                  "from": "mime-db@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.0.tgz"
                 }
               }
             }
@@ -1873,34 +1961,34 @@
         },
         "vary": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz",
+          "from": "vary@~1.0.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
         },
         "cookie": {
           "version": "0.1.2",
-          "from": "http://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-          "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+          "from": "cookie@0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
         },
         "merge-descriptors": {
           "version": "0.0.2",
-          "from": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+          "from": "merge-descriptors@0.0.2",
           "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
         },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "from": "utils-merge@1.0.0",
           "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         }
       }
     },
     "express-force-ssl": {
-      "version": "0.2.8",
-      "from": "https://registry.npmjs.org/express-force-ssl/-/express-force-ssl-0.2.8.tgz",
-      "resolved": "https://registry.npmjs.org/express-force-ssl/-/express-force-ssl-0.2.8.tgz"
+      "version": "0.2.9",
+      "from": "express-force-ssl@*",
+      "resolved": "https://registry.npmjs.org/express-force-ssl/-/express-force-ssl-0.2.9.tgz"
     },
     "ezel-assets": {
       "version": "0.0.5",
-      "from": "ezel-assets@0.0.5",
+      "from": "ezel-assets@*",
       "resolved": "https://registry.npmjs.org/ezel-assets/-/ezel-assets-0.0.5.tgz"
     },
     "gemup": {
@@ -1910,39 +1998,39 @@
     },
     "glossary": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/glossary/-/glossary-0.1.1.tgz",
+      "from": "glossary@*",
       "resolved": "https://registry.npmjs.org/glossary/-/glossary-0.1.1.tgz",
       "dependencies": {
         "natural": {
-          "version": "0.1.28",
-          "from": "https://registry.npmjs.org/natural/-/natural-0.1.28.tgz",
-          "resolved": "https://registry.npmjs.org/natural/-/natural-0.1.28.tgz",
+          "version": "0.1.29",
+          "from": "natural@>=0.0.28",
+          "resolved": "https://registry.npmjs.org/natural/-/natural-0.1.29.tgz",
           "dependencies": {
             "sylvester": {
               "version": "0.0.21",
-              "from": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
+              "from": "sylvester@>= 0.0.12",
               "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz"
             },
             "apparatus": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.8.tgz",
+              "from": "apparatus@>= 0.0.6",
               "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.8.tgz"
             },
             "underscore": {
               "version": "1.7.0",
-              "from": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+              "from": "underscore@>=1.3.1",
               "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
             }
           }
         },
         "pos": {
-          "version": "0.1.7",
-          "from": "https://registry.npmjs.org/pos/-/pos-0.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/pos/-/pos-0.1.7.tgz"
+          "version": "0.1.7-1",
+          "from": "pos@0.1.x",
+          "resolved": "https://registry.npmjs.org/pos/-/pos-0.1.7-1.tgz"
         },
         "underscore": {
           "version": "1.1.7",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+          "from": "underscore@1.1.x",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
         }
       }
@@ -1954,77 +2042,98 @@
     },
     "imagesloaded": {
       "version": "3.1.8",
-      "from": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-3.1.8.tgz",
+      "from": "imagesloaded@*",
       "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-3.1.8.tgz",
       "dependencies": {
         "wolfy87-eventemitter": {
-          "version": "4.2.9",
-          "from": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-4.2.9.tgz",
-          "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-4.2.9.tgz"
+          "version": "4.2.11",
+          "from": "wolfy87-eventemitter@4.x",
+          "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-4.2.11.tgz"
         },
         "eventie": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/eventie/-/eventie-1.0.5.tgz",
+          "from": "eventie@>=1.0.4 <2",
           "resolved": "https://registry.npmjs.org/eventie/-/eventie-1.0.5.tgz"
         }
       }
     },
     "jade": {
-      "version": "1.7.0",
-      "from": "https://registry.npmjs.org/jade/-/jade-1.7.0.tgz",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-1.7.0.tgz",
+      "version": "1.8.1",
+      "from": "jade@*",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-1.8.1.tgz",
       "dependencies": {
         "character-parser": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.0.tgz"
+          "version": "1.2.1",
+          "from": "character-parser@1.2.1",
+          "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
         },
         "commander": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+          "version": "2.5.0",
+          "from": "commander@~2.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.0.tgz"
         },
         "constantinople": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/constantinople/-/constantinople-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-2.0.1.tgz"
+          "version": "3.0.1",
+          "from": "constantinople@~3.0.1",
+          "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.1.tgz",
+          "dependencies": {
+            "acorn-globals": {
+              "version": "1.0.1",
+              "from": "acorn-globals@^1.0.0",
+              "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.1.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "0.8.0",
+                  "from": "acorn@^0.8.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.8.0.tgz"
+                }
+              }
+            }
+          }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@~0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "monocle": {
           "version": "1.1.51",
-          "from": "https://registry.npmjs.org/monocle/-/monocle-1.1.51.tgz",
+          "from": "monocle@1.1.51",
           "resolved": "https://registry.npmjs.org/monocle/-/monocle-1.1.51.tgz",
           "dependencies": {
             "readdirp": {
               "version": "0.2.5",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
+              "from": "readdirp@~0.2.3",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
               "dependencies": {
                 "minimatch": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "version": "2.0.1",
+                  "from": "minimatch@>=0.2.4",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    "brace-expansion": {
+                      "version": "1.0.1",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.0.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.0",
+                          "from": "concat-map@0.0.0",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.0.tgz"
+                        }
+                      }
                     }
                   }
                 }
@@ -2034,63 +2143,63 @@
         },
         "transformers": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+          "from": "transformers@2.1.0",
           "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
           "dependencies": {
             "promise": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+              "from": "promise@~2.0",
               "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
               "dependencies": {
                 "is-promise": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                  "from": "is-promise@~1",
                   "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                 }
               }
             },
             "css": {
               "version": "1.0.8",
-              "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+              "from": "css@~1.0.8",
               "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
               "dependencies": {
                 "css-parse": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+                  "from": "css-parse@1.0.4",
                   "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                 },
                 "css-stringify": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+                  "from": "css-stringify@1.0.5",
                   "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.2.5",
-              "from": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+              "from": "uglify-js@~2.2.5",
               "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.40",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                  "from": "source-map@~0.1.7",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "from": "optimist@~0.3.5",
                   "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@~0.0.2",
                       "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
@@ -2101,171 +2210,183 @@
         },
         "void-elements": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/void-elements/-/void-elements-1.0.0.tgz",
+          "from": "void-elements@~1.0.0",
           "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-1.0.0.tgz"
         },
         "with": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/with/-/with-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/with/-/with-3.0.1.tgz"
+          "version": "4.0.0",
+          "from": "with@~4.0.0",
+          "resolved": "https://registry.npmjs.org/with/-/with-4.0.0.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "0.8.0",
+              "from": "acorn@^0.8.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.8.0.tgz"
+            },
+            "acorn-globals": {
+              "version": "1.0.1",
+              "from": "acorn-globals@^1.0.0",
+              "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.1.tgz"
+            }
+          }
         }
       }
     },
     "jadeify": {
-      "version": "3.0.0",
-      "from": "https://registry.npmjs.org/jadeify/-/jadeify-3.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/jadeify/-/jadeify-3.0.0.tgz",
+      "version": "3.1.0",
+      "from": "jadeify@*",
+      "resolved": "https://registry.npmjs.org/jadeify/-/jadeify-3.1.0.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "2.3.10",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.10.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.10.tgz"
+          "version": "2.3.11",
+          "from": "bluebird@^2.3.10",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.11.tgz"
         },
         "find-parent-dir": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+          "from": "find-parent-dir@0.3.0",
           "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz"
         },
         "through": {
           "version": "2.3.6",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+          "from": "through@2.x.x",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
         }
       }
     },
     "joi": {
-      "version": "4.7.0",
-      "from": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
+      "version": "5.0.2",
+      "from": "joi@*",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-5.0.2.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.8.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.8.0.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.8.0.tgz"
+          "version": "2.10.0",
+          "from": "hoek@^2.2.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "from": "topo@1.x.x",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "isemail": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+          "from": "isemail@1.x.x",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         }
       }
     },
     "joi-objectid": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/joi-objectid/-/joi-objectid-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/joi-objectid/-/joi-objectid-1.0.0.tgz"
+      "version": "1.1.0",
+      "from": "joi-objectid@*",
+      "resolved": "https://registry.npmjs.org/joi-objectid/-/joi-objectid-1.1.0.tgz"
     },
     "jquery": {
       "version": "2.1.1",
-      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.1.tgz",
+      "from": "jquery@*",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.1.tgz"
     },
     "jquery-autosize": {
-      "version": "1.18.13",
-      "from": "https://registry.npmjs.org/jquery-autosize/-/jquery-autosize-1.18.13.tgz",
-      "resolved": "https://registry.npmjs.org/jquery-autosize/-/jquery-autosize-1.18.13.tgz"
+      "version": "1.18.16",
+      "from": "jquery-autosize@*",
+      "resolved": "https://registry.npmjs.org/jquery-autosize/-/jquery-autosize-1.18.16.tgz"
     },
     "mocha": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
+      "from": "mocha@*",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "from": "commander@2.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "debug": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "from": "debug@2.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "diff": {
           "version": "1.0.8",
-          "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+          "from": "diff@1.0.8",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "from": "escape-string-regexp@1.0.2",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "from": "glob@3.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@~0.2.11",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "from": "graceful-fs@~2.0.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "growl": {
           "version": "1.8.1",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "from": "growl@1.8.1",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
         },
         "jade": {
           "version": "0.26.3",
-          "from": "http://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-          "resolved": "http://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "from": "jade@0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
-              "from": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "from": "commander@0.6.1",
               "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "from": "mkdirp@0.3.0",
               "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@~0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
@@ -2273,92 +2394,92 @@
       }
     },
     "moment": {
-      "version": "2.8.3",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz"
+      "version": "2.8.4",
+      "from": "moment@*",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
     },
     "mongojs": {
-      "version": "0.15.1",
-      "from": "https://registry.npmjs.org/mongojs/-/mongojs-0.15.1.tgz",
-      "resolved": "https://registry.npmjs.org/mongojs/-/mongojs-0.15.1.tgz",
+      "version": "0.18.0",
+      "from": "mongojs@*",
+      "resolved": "https://registry.npmjs.org/mongojs/-/mongojs-0.18.0.tgz",
       "dependencies": {
         "thunky": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+          "from": "thunky@~0.1.0",
           "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@~1.1.9",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@~1.0.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@~0.10.x",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "mongodb": {
-          "version": "1.4.18",
-          "from": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.18.tgz",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.18.tgz",
+          "version": "1.4.19",
+          "from": "mongodb@1.4.19",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.19.tgz",
           "dependencies": {
             "bson": {
               "version": "0.2.15",
-              "from": "https://registry.npmjs.org/bson/-/bson-0.2.15.tgz",
+              "from": "bson@~0.2",
               "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.15.tgz",
               "dependencies": {
                 "nan": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz",
+                  "from": "nan@1.3.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
                 }
               }
             },
             "kerberos": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.4.tgz",
+              "from": "kerberos@0.0.4",
               "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.4.tgz"
             },
             "readable-stream": {
-              "version": "1.0.33-1",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33-1.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33-1.tgz",
+              "version": "1.0.33",
+              "from": "readable-stream@^1.0.27-1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2368,40 +2489,40 @@
       }
     },
     "morgan": {
-      "version": "1.4.1",
-      "from": "https://registry.npmjs.org/morgan/-/morgan-1.4.1.tgz",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.4.1.tgz",
+      "version": "1.5.0",
+      "from": "morgan@*",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.0.tgz",
       "dependencies": {
         "basic-auth": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz",
+          "from": "basic-auth@1.0.0",
           "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
         },
         "debug": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+          "from": "debug@~2.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+          "from": "depd@~1.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "on-finished": {
           "version": "2.1.1",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
+          "from": "on-finished@2.1.1",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+              "from": "ee-first@1.1.0",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
@@ -2409,14 +2530,14 @@
       }
     },
     "newrelic": {
-      "version": "1.13.4",
-      "from": "https://registry.npmjs.org/newrelic/-/newrelic-1.13.4.tgz",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.13.4.tgz",
+      "version": "1.14.1",
+      "from": "newrelic@*",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.14.1.tgz",
       "dependencies": {
         "continuation-local-storage": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "from": "continuation-local-storage@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.2.tgz",
           "dependencies": {
             "emitter-listener": {
               "version": "1.0.1",
@@ -2463,64 +2584,64 @@
     },
     "nib": {
       "version": "1.0.4",
-      "from": "https://registry.npmjs.org/nib/-/nib-1.0.4.tgz",
+      "from": "nib@*",
       "resolved": "https://registry.npmjs.org/nib/-/nib-1.0.4.tgz",
       "dependencies": {
         "stylus": {
           "version": "0.45.1",
-          "from": "https://registry.npmjs.org/stylus/-/stylus-0.45.1.tgz",
+          "from": "stylus@0.45.x",
           "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.45.1.tgz",
           "dependencies": {
             "css-parse": {
               "version": "1.7.0",
-              "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
+              "from": "css-parse@1.7.x",
               "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz"
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+              "from": "mkdirp@0.3.x",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "debug": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+              "from": "debug@*",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                  "from": "ms@0.6.2",
                   "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "sax": {
               "version": "0.5.8",
-              "from": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+              "from": "sax@0.5.x",
               "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
             },
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@3.2.x",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2533,27 +2654,27 @@
     },
     "node-env-file": {
       "version": "0.1.4",
-      "from": "https://registry.npmjs.org/node-env-file/-/node-env-file-0.1.4.tgz",
+      "from": "node-env-file@*",
       "resolved": "https://registry.npmjs.org/node-env-file/-/node-env-file-0.1.4.tgz",
       "dependencies": {
         "chai": {
-          "version": "1.9.2",
-          "from": "https://registry.npmjs.org/chai/-/chai-1.9.2.tgz",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.2.tgz",
+          "version": "1.10.0",
+          "from": "chai@latest",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+              "from": "assertion-error@1.0.0",
               "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "from": "deep-eql@0.1.3",
               "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                  "from": "type-detect@0.1.1",
                   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
@@ -2564,18 +2685,18 @@
     },
     "passport": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/passport/-/passport-0.2.1.tgz",
+      "from": "passport@*",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.2.1.tgz",
       "dependencies": {
         "passport-strategy": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+          "from": "passport-strategy@1.x.x",
           "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
         },
         "pause": {
           "version": "0.0.1",
-          "from": "http://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-          "resolved": "http://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+          "from": "pause@0.0.1",
+          "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
         }
       }
     },
@@ -2602,60 +2723,43 @@
       }
     },
     "react": {
-      "version": "0.12.0",
-      "from": "https://registry.npmjs.org/react/-/react-0.12.0.tgz",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.12.0.tgz",
+      "version": "0.12.1",
+      "from": "react@*",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.12.1.tgz",
       "dependencies": {
         "envify": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/envify/-/envify-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/envify/-/envify-3.0.0.tgz",
+          "version": "3.2.0",
+          "from": "envify@^3.0.0",
+          "resolved": "https://registry.npmjs.org/envify/-/envify-3.2.0.tgz",
           "dependencies": {
-            "xtend": {
-              "version": "2.1.2",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "dependencies": {
-                "object-keys": {
-                  "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-                }
-              }
-            },
             "through": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+              "from": "through@~2.3.4",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             },
-            "esprima-fb": {
-              "version": "4001.3001.0-dev-harmony-fb",
-              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-4001.3001.0-dev-harmony-fb.tgz",
-              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-4001.3001.0-dev-harmony-fb.tgz"
-            },
             "jstransform": {
-              "version": "6.3.2",
-              "from": "https://registry.npmjs.org/jstransform/-/jstransform-6.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-6.3.2.tgz",
+              "version": "7.0.0",
+              "from": "jstransform@^7.0.0",
+              "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-7.0.0.tgz",
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+                  "from": "base62@0.1.1",
                   "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
-                  "version": "6001.1.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-6001.1.0-dev-harmony-fb.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-6001.1.0-dev-harmony-fb.tgz"
+                  "version": "7001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@~7001.0001.0000-dev-harmony-fb",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-7001.1.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.31",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+                  "from": "source-map@0.1.31",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -2668,13 +2772,30 @@
     },
     "rewire": {
       "version": "2.1.3",
-      "from": "https://registry.npmjs.org/rewire/-/rewire-2.1.3.tgz",
+      "from": "rewire@*",
       "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.1.3.tgz"
     },
     "scribe-editor": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "scribe-editor@git://github.com/guardian/scribe.git",
-      "resolved": "git://github.com/guardian/scribe.git#9a57e0def5cb24ff455f9ae9e219fd1583afc6d0",
+      "resolved": "git://github.com/guardian/scribe.git#fc17c2f7a1c52529104a93a0567c65c6159c7db5",
+      "dependencies": {
+        "lodash-amd": {
+          "version": "2.4.1",
+          "from": "lodash-amd@~2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash-amd/-/lodash-amd-2.4.1.tgz"
+        },
+        "immutable": {
+          "version": "3.2.1",
+          "from": "immutable@~3.2.1",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.2.1.tgz"
+        }
+      }
+    },
+    "scribe-plugin-keyboard-shortcuts": {
+      "version": "0.1.1",
+      "from": "scribe-plugin-keyboard-shortcuts@*",
+      "resolved": "https://registry.npmjs.org/scribe-plugin-keyboard-shortcuts/-/scribe-plugin-keyboard-shortcuts-0.1.1.tgz",
       "dependencies": {
         "lodash-amd": {
           "version": "2.4.1",
@@ -2685,35 +2806,54 @@
     },
     "scribe-plugin-link-tooltip": {
       "version": "0.0.3",
-      "from": "scribe-plugin-link-tooltip@0.0.3",
+      "from": "scribe-plugin-link-tooltip@*",
       "resolved": "https://registry.npmjs.org/scribe-plugin-link-tooltip/-/scribe-plugin-link-tooltip-0.0.3.tgz"
     },
     "scribe-plugin-toolbar": {
       "version": "0.1.4",
-      "from": "https://registry.npmjs.org/scribe-plugin-toolbar/-/scribe-plugin-toolbar-0.1.4.tgz",
+      "from": "scribe-plugin-toolbar@*",
       "resolved": "https://registry.npmjs.org/scribe-plugin-toolbar/-/scribe-plugin-toolbar-0.1.4.tgz",
       "dependencies": {
         "lodash-amd": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash-amd/-/lodash-amd-2.4.1.tgz",
+          "from": "lodash-amd@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash-amd/-/lodash-amd-2.4.1.tgz"
         }
       }
     },
     "sharify": {
       "version": "0.1.6",
-      "from": "https://registry.npmjs.org/sharify/-/sharify-0.1.6.tgz",
+      "from": "sharify@*",
       "resolved": "https://registry.npmjs.org/sharify/-/sharify-0.1.6.tgz"
     },
     "should": {
-      "version": "4.1.0",
-      "from": "https://registry.npmjs.org/should/-/should-4.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/should/-/should-4.1.0.tgz",
+      "version": "4.3.1",
+      "from": "should@*",
+      "resolved": "https://registry.npmjs.org/should/-/should-4.3.1.tgz",
       "dependencies": {
         "should-equal": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/should-equal/-/should-equal-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.0.1.tgz"
+          "version": "0.1.0",
+          "from": "should-equal@0.1.0",
+          "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.1.0.tgz",
+          "dependencies": {
+            "should-type": {
+              "version": "0.0.1",
+              "from": "should-type@0.0.1",
+              "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.1.tgz"
+            }
+          }
+        },
+        "should-format": {
+          "version": "0.0.2",
+          "from": "should-format@0.0.2",
+          "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.0.2.tgz",
+          "dependencies": {
+            "should-type": {
+              "version": "0.0.1",
+              "from": "should-type@0.0.1",
+              "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.1.tgz"
+            }
+          }
         }
       }
     },
@@ -2751,7 +2891,7 @@
           "dependencies": {
             "through": {
               "version": "2.3.6",
-              "from": "through@~2.3.4",
+              "from": "through@2.x",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
@@ -2785,7 +2925,7 @@
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@~2.3.4",
+                  "from": "through@>=2.2.7 <3",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
@@ -2920,7 +3060,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -3158,7 +3298,7 @@
                         },
                         "source-map": {
                           "version": "0.1.40",
-                          "from": "source-map@~0.1.7",
+                          "from": "source-map@~0.1.30",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
                           "dependencies": {
                             "amdefine": {
@@ -3195,7 +3335,7 @@
                         "isarray": {
                           "version": "0.0.1",
                           "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
@@ -3241,7 +3381,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -3363,7 +3503,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -3507,96 +3647,101 @@
       }
     },
     "sinon": {
-      "version": "1.11.1",
-      "from": "https://registry.npmjs.org/sinon/-/sinon-1.11.1.tgz",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.11.1.tgz",
+      "version": "1.12.1",
+      "from": "sinon@*",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.12.1.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "from": "formatio@~1.1.1",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "dependencies": {
             "samsam": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.1.tgz"
+              "version": "1.1.2",
+              "from": "samsam@~1.1",
+              "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@>=0.10.3 <1",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
+        },
+        "lolex": {
+          "version": "1.1.0",
+          "from": "lolex@1.1.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
         }
       }
     },
     "sqwish": {
       "version": "0.2.2",
-      "from": "https://registry.npmjs.org/sqwish/-/sqwish-0.2.2.tgz",
+      "from": "sqwish@*",
       "resolved": "https://registry.npmjs.org/sqwish/-/sqwish-0.2.2.tgz"
     },
     "stylus": {
-      "version": "0.49.2",
-      "from": "https://registry.npmjs.org/stylus/-/stylus-0.49.2.tgz",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.49.2.tgz",
+      "version": "0.49.3",
+      "from": "stylus@*",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.49.3.tgz",
       "dependencies": {
         "css-parse": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
+          "from": "css-parse@1.7.x",
           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz"
         },
         "mkdirp": {
           "version": "0.3.5",
-          "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+          "from": "mkdirp@0.3.x",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
         },
         "debug": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+          "from": "debug@*",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "sax": {
           "version": "0.5.8",
-          "from": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "from": "sax@0.5.x",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
         },
         "glob": {
           "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@3.2.x",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -3605,12 +3750,12 @@
         },
         "source-map": {
           "version": "0.1.40",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+          "from": "source-map@0.1.x",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+              "from": "amdefine@>=0.0.4",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
@@ -3618,75 +3763,75 @@
       }
     },
     "superagent": {
-      "version": "0.20.0",
-      "from": "https://registry.npmjs.org/superagent/-/superagent-0.20.0.tgz",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.20.0.tgz",
+      "version": "0.21.0",
+      "from": "superagent@*",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz",
       "dependencies": {
         "qs": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
+          "from": "qs@1.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz"
         },
         "formidable": {
           "version": "1.0.14",
-          "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+          "from": "formidable@1.0.14",
           "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "from": "mime@1.2.11",
           "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "component-emitter": {
           "version": "1.1.2",
-          "from": "http://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "from": "component-emitter@1.1.2",
           "resolved": "http://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
         },
         "methods": {
           "version": "1.0.1",
-          "from": "http://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
+          "from": "methods@1.0.1",
           "resolved": "http://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
         },
         "cookiejar": {
           "version": "2.0.1",
-          "from": "http://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz",
+          "from": "cookiejar@2.0.1",
           "resolved": "http://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
         },
         "debug": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "version": "2.1.0",
+          "from": "debug@~2.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "reduce-component": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+          "from": "reduce-component@1.0.1",
           "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
         },
         "extend": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+          "from": "extend@~1.2.1",
           "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
         },
         "form-data": {
           "version": "0.1.3",
-          "from": "http://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
+          "from": "form-data@0.1.3",
           "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
           "dependencies": {
             "combined-stream": {
-              "version": "0.0.5",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+              "version": "0.0.7",
+              "from": "combined-stream@~0.0.4",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "from": "delayed-stream@0.0.5",
                   "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
@@ -3695,27 +3840,27 @@
         },
         "readable-stream": {
           "version": "1.0.27-1",
-          "from": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+          "from": "readable-stream@1.0.27-1",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@~1.0.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@~0.10.x",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -3725,220 +3870,220 @@
     "typeahead.js": {
       "version": "0.10.5",
       "from": "typeahead.js@*",
-      "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.10.5.tgz"
+      "resolved": "git://github.com/twitter/typeahead.js.git#0fd2467baa3e0593b91794b485be0bd725b7d2cb"
     },
     "uglify-js": {
-      "version": "2.4.15",
-      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
+      "version": "2.4.16",
+      "from": "uglify-js@*",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@~0.2.6",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "source-map": {
           "version": "0.1.34",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+          "from": "source-map@0.1.34",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+              "from": "amdefine@>=0.0.4",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
         },
         "optimist": {
           "version": "0.3.7",
-          "from": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "from": "optimist@~0.3.5",
           "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "from": "wordwrap@~0.0.2",
               "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "from": "uglify-to-browserify@~1.0.0",
           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
         }
       }
     },
     "uglifyify": {
       "version": "2.6.0",
-      "from": "https://registry.npmjs.org/uglifyify/-/uglifyify-2.6.0.tgz",
+      "from": "uglifyify@*",
       "resolved": "https://registry.npmjs.org/uglifyify/-/uglifyify-2.6.0.tgz",
       "dependencies": {
         "convert-source-map": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.2.6.tgz",
+          "from": "convert-source-map@~0.2.3",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.2.6.tgz"
         },
         "extend": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
+          "from": "extend@^1.2.1",
           "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz"
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "from": "minimatch@^0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "through": {
           "version": "2.3.6",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+          "from": "through@2.x.x",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
         }
       }
     },
     "underscore": {
       "version": "1.7.0",
-      "from": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "from": "underscore@*",
       "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "underscore.string": {
-      "version": "2.3.3",
-      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+      "version": "2.4.0",
+      "from": "underscore.string@*",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
     },
     "zombie": {
       "version": "2.0.3",
-      "from": "https://registry.npmjs.org/zombie/-/zombie-2.0.3.tgz",
+      "from": "zombie@2.0.3",
       "resolved": "https://registry.npmjs.org/zombie/-/zombie-2.0.3.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "2.3.6",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.6.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.6.tgz"
+          "version": "2.3.11",
+          "from": "bluebird@^2.3.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.11.tgz"
         },
         "debug": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+          "from": "debug@^2.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz"
         },
         "eventsource": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.3.tgz",
+          "from": "eventsource@0.1.3",
           "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.3.tgz"
         },
         "iconv-lite": {
-          "version": "0.4.4",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+          "version": "0.4.5",
+          "from": "iconv-lite@^0.4.4",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
         },
         "jsdom": {
           "version": "1.0.0-pre.7",
-          "from": "https://registry.npmjs.org/jsdom/-/jsdom-1.0.0-pre.7.tgz",
+          "from": "jsdom@1.0.0-pre.7",
           "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-1.0.0-pre.7.tgz",
           "dependencies": {
             "htmlparser2": {
-              "version": "3.7.3",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+              "version": "3.8.2",
+              "from": "htmlparser2@>= 3.1.5 <4",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.0.tgz"
+                  "version": "2.3.0",
+                  "from": "domhandler@2.3",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz",
+                  "from": "domutils@1.5",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
                 },
                 "domelementtype": {
-                  "version": "1.1.1",
-                  "from": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz",
-                  "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
+                  "version": "1.1.3",
+                  "from": "domelementtype@1",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "from": "entities@1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "parse5": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/parse5/-/parse5-1.0.1.tgz",
+              "from": "parse5@~1.0.1",
               "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.0.1.tgz"
             },
             "nwmatcher": {
               "version": "1.3.3",
-              "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.3.tgz",
+              "from": "nwmatcher@~1.3.2",
               "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.3.tgz"
             },
             "xmlhttprequest": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.6.0.tgz",
+              "from": "xmlhttprequest@>=1.5.0",
               "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.6.0.tgz"
             },
             "cssom": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz",
+              "from": "cssom@~0.3.0",
               "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
             },
             "cssstyle": {
-              "version": "0.2.21",
-              "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.21.tgz",
-              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.21.tgz"
+              "version": "0.2.22",
+              "from": "cssstyle@~0.2.9",
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.22.tgz"
             },
             "contextify": {
               "version": "0.1.9",
-              "from": "https://registry.npmjs.org/contextify/-/contextify-0.1.9.tgz",
+              "from": "contextify@~0.1.5",
               "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.9.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+                  "from": "bindings@*",
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz",
+                  "from": "nan@~1.3.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
                 }
               }
@@ -3947,47 +4092,47 @@
         },
         "mime": {
           "version": "1.2.11",
-          "from": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "from": "mime@^1.2.11",
           "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "ms": {
           "version": "0.6.2",
-          "from": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+          "from": "ms@^0.6.2",
           "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
         },
         "request": {
-          "version": "2.45.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.45.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.45.0.tgz",
+          "version": "2.51.0",
+          "from": "request@^2.44.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.3",
-              "from": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+              "from": "bl@~0.9.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.0.33-1",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33-1.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33-1.tgz",
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.26",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -3995,160 +4140,172 @@
               }
             },
             "caseless": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+              "version": "0.8.0",
+              "from": "caseless@~0.8.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "from": "forever-agent@~0.5.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
-            "qs": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.0",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-            },
-            "mime-types": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-            },
-            "node-uuid": {
-              "version": "1.4.1",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-            },
             "form-data": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "version": "0.2.0",
+              "from": "form-data@~0.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
-                "combined-stream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                "mime-types": {
+                  "version": "2.0.4",
+                  "from": "mime-types@~2.0.3",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                   "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                      "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    "mime-db": {
+                      "version": "1.3.0",
+                      "from": "mime-db@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.0.tgz"
                     }
                   }
                 }
               }
             },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@~5.0.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "mime-types@~1.0.1",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.2",
+              "from": "node-uuid@~1.4.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "qs@~2.3.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@~0.4.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
             "http-signature": {
               "version": "0.10.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+              "from": "http-signature@~0.10.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
+                  "from": "assert-plus@0.1.2",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
+                  "from": "ctype@0.5.2",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                 }
               }
             },
             "oauth-sign": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+              "version": "0.5.0",
+              "from": "oauth-sign@~0.5.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
             },
             "hawk": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "from": "hawk@1.1.1",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                  "from": "hoek@0.9.x",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                  "from": "boom@0.4.x",
                   "resolved": "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                  "from": "cryptiles@0.2.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "http://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                  "from": "sntp@0.2.x",
                   "resolved": "http://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "from": "aws-sign2@~0.5.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "from": "stringstream@~0.0.4",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@~0.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
             }
           }
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "from": "tough-cookie@^0.12.1",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+              "version": "1.3.2",
+              "from": "punycode@>=0.2.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "ws": {
           "version": "0.4.32",
-          "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+          "from": "ws@0.4.32",
           "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
           "dependencies": {
             "commander": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+              "from": "commander@~2.1.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
             },
             "nan": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+              "from": "nan@~1.0.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
             },
             "tinycolor": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+              "from": "tinycolor@0.x",
               "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
             },
             "options": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+              "from": "options@>=0.0.5",
               "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
             }
           }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "scribe-editor": "git://github.com/guardian/scribe.git",
     "scribe-plugin-toolbar": "*",
     "scribe-plugin-link-tooltip": "*",
+    "scribe-plugin-keyboard-shortcuts": "*",
     "html-janitor": "git://github.com/gaearon/html-janitor.git#patch-1",
     "imagesloaded": "*",
     "jquery-autosize": "*",


### PR DESCRIPTION
This updates node modules and adds some [Scribe](https://github.com/guardian/scribe) plugin features. Most importantly allowing shift + enter to add breaks instead of full paragraphs and keyboard shortcuts like CMD + K for links.

![cap](https://cloud.githubusercontent.com/assets/555859/5404577/169beacc-8166-11e4-89a9-0b4e4c1da36f.gif)
