### PR TITLE
@dzucconi: Update migration script to keep slugs in sync

### DIFF
--- a/api/lib/migrate.coffee
+++ b/api/lib/migrate.coffee
@@ -37,7 +37,7 @@ setup = (callback) ->
   ], (err, counts) ->
     return callback err if err
     debug "Merging #{counts[0]} posts into #{counts[1]} articles."
-    # Remove any posts with slideshows & gravity_ids b/c we know those 
+    # Remove any posts with slideshows & gravity_ids b/c we know those
     # originated in Gravity and will be replaced.
     query = {'sections.0.type': 'slideshow', gravity_id: { $ne: null } }
     db.articles.remove query, callback
@@ -121,7 +121,7 @@ postsToArticles = (posts, callback) ->
                   artwork?.image_urls?.large
                   _.sample(artwork?.image_urls ? [])
                   (("http://static.artsy.net/additional_images/#{img._id}/" +
-                   "#{if v = img.image_version then v + '/' else ''}" + 
+                   "#{if v = img.image_version then v + '/' else ''}" +
                    "large.jpg") if img)
                 ])[0]
               when 'PostImage'


### PR DESCRIPTION
When editorial uses the "Sync to Post" feature they will often follow up by changing the author of the post to another account. This updates the slug from `casey-my-post` to `editorial-my-post` causing the slug from the article to get out of sync. This PR adds a step to the migration script to merge the slugs from the synced post back into the article.
