### PR TITLE
@dzucconi: Denormalize author data into the article on publish

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -195,7 +195,10 @@ getSlug = (article, callback) ->
       return callback err if err = err or res.body.error
       post = res.body
       # Ensure the article is linked to the Gravity post
-      @save _.extend(article, { gravity_id: post._id, slug: post.id }), (err, article) ->
+      @save _.extend(article, {
+        gravity_id: post._id
+        slug: post.id
+      }), (err, article) ->
         return callback err if err
         # Delete any existing attachments/artworks
         async.parallel [

--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -151,12 +151,13 @@ validate = (input, callback) ->
   Joi.validate whitelisted, schema, callback
 
 update = (article, input, callback) ->
+  publishing = input.published and not article.published
   article = _.extend article, input, updated_at: new Date
   getSlug article, (err, slug) ->
     return callback err if err
     article.slugs ?= []
     article.slugs.push slug unless slug in article.slugs
-    onPublish article, callback
+    if publishing then onPublish(article, callback) else callback null, article
 
 getSlug = (article, callback) ->
   return callback null, article.slug if article.slug

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -241,6 +241,22 @@ describe 'Article', ->
           .equal moment().format('YYYY')
         done()
 
+    it 'denormalizes the author into the article on publish', (done) ->
+      fabricate 'users', {
+        _id: ObjectId('5086df098523e60002000018')
+        user: { name: 'Molly' }
+        profile: { handle: 'molly' }
+      }, (err, @user) ->
+        Article.save {
+          title: 'Top Ten Shows'
+          thumbnail_title: 'Ten Shows'
+          author_id: '5086df098523e60002000018'
+          published: true
+        }, (err, article) ->
+          article.author.name.should.equal 'Molly'
+          article.author.profile_handle.should.equal 'molly'
+          done()
+
     it 'doesnt save a fair unless explictly set', (done) ->
       Article.save {
         title: 'Top Ten Shows'


### PR DESCRIPTION
It's alright for the client to fetch the author on the fly for an individual article, but for list views like /magazine it would be crazy to blast out a bunch of Gravity fetches to render the author's name. This saves denormalized author data to the article when publishing. I'll follow up with a migration strategy for old posts/articles.