### PR TITLE
@dzucconi: Can find articles associated to partners

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -109,7 +109,6 @@ toQuery = (input, callback) ->
     query.author_id = ObjectId input.author_id if input.author_id
     query.fair_id = { $in: _.map(input.fair_ids, ObjectId) } if input.fair_ids
     query.partner_ids = ObjectId input.partner_id if input.partner_id
-    console.log query
     # Convert query for articles featured to an artist or artwork
     query.$or = [
       { primary_featured_artist_ids: ObjectId(input.artist_id) }

--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -75,6 +75,7 @@ querySchema = (->
   artist_id: @objectId()
   artwork_id: @objectId()
   fair_ids: @array()
+  partner_id: @objectId()
   sort: @string()
 ).call Joi
 
@@ -106,6 +107,7 @@ toQuery = (input, callback) ->
       'fair_ids'
     # Type cast IDs
     query.author_id = ObjectId input.author_id if input.author_id
+    query.partner_id = ObjectId input.partner_id if input.partner_id
     query.fair_id = { $in: _.map(input.fair_ids, ObjectId) } if input.fair_ids
     # Convert query for articles featured to an artist or artwork
     query.$or = [

--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -30,8 +30,6 @@ schema = (->
   published: @boolean().default(false)
   lead_paragraph: @string().allow('', null)
   gravity_id: @objectId().allow('', null)
-  fair_id: @objectId().allow('', null)
-  partner_id: @objectId().allow('', null)
   sections: @array().includes([
     @object().keys
       type: @string().valid('image')
@@ -65,6 +63,8 @@ schema = (->
   primary_featured_artist_ids: @array().includes @objectId()
   featured_artist_ids: @array().includes @objectId()
   featured_artwork_ids: @array().includes @objectId()
+  fair_id: @objectId().allow('', null)
+  partner_ids: @array().includes @objectId()
 ).call Joi
 
 querySchema = (->
@@ -104,11 +104,12 @@ toQuery = (input, callback) ->
     # Separate "find" query from sort/offest/limit
     { limit, offset, sort } = input
     query = _.omit input, 'limit', 'offset', 'sort', 'artist_id', 'artwork_id',
-      'fair_ids'
+      'fair_ids', 'partner_id'
     # Type cast IDs
     query.author_id = ObjectId input.author_id if input.author_id
-    query.partner_id = ObjectId input.partner_id if input.partner_id
     query.fair_id = { $in: _.map(input.fair_ids, ObjectId) } if input.fair_ids
+    query.partner_ids = ObjectId input.partner_id if input.partner_id
+    console.log query
     # Convert query for articles featured to an artist or artwork
     query.$or = [
       { primary_featured_artist_ids: ObjectId(input.artist_id) }

--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -31,6 +31,7 @@ schema = (->
   lead_paragraph: @string().allow('', null)
   gravity_id: @objectId().allow('', null)
   fair_id: @objectId().allow('', null)
+  partner_id: @objectId().allow('', null)
   sections: @array().includes([
     @object().keys
       type: @string().valid('image')

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -133,6 +133,19 @@ describe 'Article', ->
             done()
         )
 
+    it 'can find articles added to a partner', (done) ->
+      fabricate 'articles', [
+        { title: 'Foo', partner_ids: [ObjectId('4dc98d149a96300001003033')] }
+        { title: 'Bar', partner_ids: [ObjectId('4dc98d149a96300001003033')] }
+        { title: 'Baz', partner_ids: [ObjectId('4dc98d149a96300001003031')] }
+      ], ->
+        Article.where(
+          { partner_id: '4dc98d149a96300001003033' }
+          (err, { results }) ->
+            _.pluck(results, 'title').sort().join('').should.equal 'BarFoo'
+            done()
+        )
+
   describe '#find', ->
 
     it 'finds an article by an id string', (done) ->

--- a/api/lib/migrate.coffee
+++ b/api/lib/migrate.coffee
@@ -135,18 +135,18 @@ postsToArticles = (posts, callback) ->
               return cb() unless organizer?
               gravity.fairs.findOne { organizer_id: organizer._id }, cb
           )
-      # Related partner
+      # Related partners
       (cb) ->
         findPostProfiles post, 'PartnerGallery', (err, profiles) ->
           return cb err if err
-          gravity.partners.findOne(
+          gravity.partners.find(
             { _id: $in: _.pluck(profiles, 'owner_id') }, cb
           )
       # Author
       (cb) ->
         User.find post.author_id, cb
     ], (err, results) ->
-      [artistFeatures, artworkFeatures, artworks, fair, partner, author] = results
+      [artistFeatures, artworkFeatures, artworks, fair, partners, author] = results
       # Map Gravity data into a Positron schema
       data =
         _id: post._id
@@ -221,7 +221,7 @@ postsToArticles = (posts, callback) ->
         featured_artwork_ids: (f.artwork_id for f in artworkFeatures)
         gravity_id: post._id
         fair_id: fair?._id
-        partner_id: partner?._id
+        partner_ids: _.pluck(partners, '_id') if partners?.length
         tier: 2
       # Callback with mapped data
       debug "Mapped #{_.last post._slugs}"


### PR DESCRIPTION
This allows querying by `?partner_id={partner._id}` and updates the post -> articles migration script to accommodate this. The admin UI part of this is TBD as it still needs to be designed.