### PR TITLE
@broskoski: An admin can add an article to a partner's profile

### DIFF
--- a/api/apps/users/test/model.coffee
+++ b/api/apps/users/test/model.coffee
@@ -59,7 +59,7 @@ describe 'User', ->
           done()
 
     it 'returns 10 results by default', (done) ->
-      fabricate 'users', _.times(20, -> { user: { name: 'Mark'} }), ->
+      fabricate 'users', _.times(20, -> {}), ->
         User.where {}, (err, { results }) ->
           results.length.should.equal 10
           done()

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -11,6 +11,7 @@ module.exports = class EditAdmin extends Backbone.View
     @article.on 'open:tab2', @onOpen
     @setupAuthorAutocomplete()
     @setupFairAutocomplete()
+    @setupPartnerAutocomplete()
 
   setupAuthorAutocomplete: ->
     Autocomplete = require '../../../../components/autocomplete/index.coffee'
@@ -29,6 +30,7 @@ module.exports = class EditAdmin extends Backbone.View
     AutocompleteSelect = require '../../../../components/autocomplete_select/index.coffee'
     select = AutocompleteSelect @$('#edit-admin-fair .edit-admin-right')[0],
       url: "#{sd.ARTSY_URL}/api/v1/match/fairs?term=%QUERY"
+      placeholder: 'Search fair by name...'
       filter: (res) -> for r in res
         { id: r._id, value: r.name }
       selected: (e, item) =>
@@ -38,6 +40,25 @@ module.exports = class EditAdmin extends Backbone.View
     if id = @article.get 'fair_id'
       request
         .get("#{sd.ARTSY_URL}/api/v1/fair/#{id}")
+        .set('X-Access-Token': sd.USER.access_token).end (err, res) ->
+          select.setState value: res.body.name, loading: false
+    else
+      select.setState loading: false
+
+  setupPartnerAutocomplete: ->
+    AutocompleteSelect = require '../../../../components/autocomplete_select/index.coffee'
+    select = AutocompleteSelect @$('#edit-admin-partner .edit-admin-right')[0],
+      url: "#{sd.ARTSY_URL}/api/v1/match/partners?term=%QUERY"
+      placeholder: 'Search partner by name...'
+      filter: (res) -> for r in res
+        { id: r._id, value: r.name }
+      selected: (e, item) =>
+        @article.save partner_ids: [item.id]
+      cleared: =>
+        @article.save partner_ids: null
+    if id = @article.get('partner_ids')?[0]
+      request
+        .get("#{sd.ARTSY_URL}/api/v1/partner/#{id}")
         .set('X-Access-Token': sd.USER.access_token).end (err, res) ->
           select.setState value: res.body.name, loading: false
     else

--- a/client/apps/edit/components/admin/index.jade
+++ b/client/apps/edit/components/admin/index.jade
@@ -32,7 +32,12 @@ section#edit-admin
   section#edit-admin-fair
     .edit-admin-left
       h1 Fair
-      h2 Add this article to a fair's article feed and year round page.
+      h2 Add this article to a fair's magazine and year round page.
+    .edit-admin-right
+  section#edit-admin-partner
+    .edit-admin-left
+      h1 Partner
+      h2 Add this article to a partner's profile page.
     .edit-admin-right
   section#edit-admin-feature
     .edit-admin-left

--- a/client/apps/edit/components/admin/index.styl
+++ b/client/apps/edit/components/admin/index.styl
@@ -138,5 +138,7 @@ gutter-size = 20px
   width 100%
   margin-bottom 30px
 
-#edit-admin-change-author input, #edit-admin-fair input
+#edit-admin-change-author input
+#edit-admin-fair input
+#edit-admin-partner input
   width 100%

--- a/client/apps/edit/components/admin/test/index.coffee
+++ b/client/apps/edit/components/admin/test/index.coffee
@@ -21,6 +21,7 @@ describe 'EditAdmin', ->
           ['featuredListTemplate']
         EditAdmin::setupAuthorAutocomplete = sinon.stub()
         EditAdmin::setupFairAutocomplete = sinon.stub()
+        EditAdmin::setupPartnerAutocomplete = sinon.stub()
         @view = new EditAdmin el: $('#edit-admin'), article: @article
         done()
 

--- a/client/components/autocomplete_select/index.coffee
+++ b/client/components/autocomplete_select/index.coffee
@@ -40,5 +40,5 @@ module.exports.AutocompleteSelect = AutocompleteSection = React.createClass
         input {
           ref: 'input'
           className: 'bordered-input'
-          placeholder: 'Search by fair name...'
+          placeholder: @props.placeholder
         }


### PR DESCRIPTION
For now just re-uses the fair assigning UI to associate articles to partners. I need to address [some](https://github.com/artsy/positron/issues/122#issuecomment-76294392) larger refactors for Positron users so that when a user with access to a partner publishes an article, it automatically get associate to that partner's profile.

For the time being, admins do this featuring manually for the most part anyways, so this will suffice for shipping Magazine.

![cap](https://cloud.githubusercontent.com/assets/555859/6404637/1b4e2378-bde8-11e4-98fa-1ea5b66355e5.gif)
