### PR TITLE
@broskoski: Sync to Post features to artist & artwork pages

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -60,11 +60,11 @@ schema = (->
           id: @string()
       ]
   ]).default([])
-  primary_featured_artist_ids: @array().includes @objectId()
-  featured_artist_ids: @array().includes @objectId()
-  featured_artwork_ids: @array().includes @objectId()
+  primary_featured_artist_ids: @array().includes(@objectId()).allow(null)
+  featured_artist_ids: @array().includes(@objectId()).allow(null)
+  featured_artwork_ids: @array().includes(@objectId()).allow(null)
   fair_id: @objectId().allow('', null)
-  partner_ids: @array().includes @objectId()
+  partner_ids: @array().includes(@objectId()).allow(null)
 ).call Joi
 
 querySchema = (->
@@ -233,63 +233,66 @@ onPublish = (article, callback) =>
           artistIds = (article.featured_artist_ids or []).concat(
             article.primary_featured_artist_ids
           )
-          async.map artistIds, (id, cb) ->
+          async.map artistIds.map(String), (id, cb) ->
             request
-              .get("#{ARTSY_URL}/api/v1/partner/#{id.toString()}")
+              .post("#{ARTSY_URL}/api/v1/post/#{post.id}/artist/#{id}/feature")
               .set('X-Access-Token', accessToken)
-              .end (err, res) ->
-                return cb err if err = err or res.body.error
-                request
-                  .post("#{ARTSY_URL}/api/v1/repost")
-                  .send(post_id: post.id, profile_id: res.body.default_profile_id)
-                  .set('X-Access-Token', accessToken)
-                  .end (err, res) -> cb err or res.body.error
+              .end (err, res) -> cb (err or res.body.error), res.body
           , (err) =>
             return callback err if err
 
-          # Delete any existing attachments/artworks
-          async.parallel [
-            (cb) ->
-              async.map post.attachments or [], ((a, cb2) ->
-                request
-                  .del("#{ARTSY_URL}/api/v1/post/#{post._id}/link/#{a.id}")
-                  .set('X-Access-Token', accessToken)
-                  .end (err, res) -> cb2()
-              ), cb
-            (cb) ->
-              async.map post.artworks or [], ((a, cb2) ->
-                request
-                  .del("#{ARTSY_URL}/api/v1/post/#{post._id}/artwork/#{a.id}")
-                  .set('X-Access-Token', accessToken)
-                  .end (err, res) -> cb2()
-              ), cb
-          ], (err) ->
-            return callback err if err
-
-            # Add artworks, images and video from the article to the post
-            async.mapSeries article.sections, ((section, cb) ->
-              switch section.type
-                when 'artworks'
-                  async.mapSeries section.ids, ((id, cb2) ->
-                    request
-                      .post("#{ARTSY_URL}/api/v1/post/#{post._id}/artwork/#{id}")
-                      .set('X-Access-Token', accessToken)
-                      .end (err, res) -> cb2 (err or res.body.error), res.body
-                  ), cb
-                when 'image', 'video'
-                  request
-                    .post("#{ARTSY_URL}/api/v1/post/#{post._id}/link")
-                    .set('X-Access-Token', accessToken)
-                    .send(url: section.url)
-                    .end (err, res) -> cb (err or res.body.error), res.body
-                else
-                  cb()
-            ), (err) ->
-              return callback err if err
+            # Feature to artwork pages
+            async.map article.featured_artwork_ids.map(String), (id, cb) ->
               request
-                .get("#{ARTSY_URL}/api/v1/post/#{post._id}")
+                .post("#{ARTSY_URL}/api/v1/post/#{post.id}/artwork/#{id}/feature")
                 .set('X-Access-Token', accessToken)
-                .end (err, res) -> callback (err or res.body.error), res.body
+                .end (err, res) -> cb (err or res.body.error), res.body
+            , (err) =>
+              return callback err if err
+
+              # Delete any existing attachments/artworks
+              async.parallel [
+                (cb) ->
+                  async.map post.attachments or [], ((a, cb2) ->
+                    request
+                      .del("#{ARTSY_URL}/api/v1/post/#{post._id}/link/#{a.id}")
+                      .set('X-Access-Token', accessToken)
+                      .end (err, res) -> cb2()
+                  ), cb
+                (cb) ->
+                  async.map post.artworks or [], ((a, cb2) ->
+                    request
+                      .del("#{ARTSY_URL}/api/v1/post/#{post._id}/artwork/#{a.id}")
+                      .set('X-Access-Token', accessToken)
+                      .end (err, res) -> cb2()
+                  ), cb
+              ], (err) ->
+                return callback err if err
+
+                # Add artworks, images and video from the article to the post
+                async.mapSeries article.sections, ((section, cb) ->
+                  switch section.type
+                    when 'artworks'
+                      async.mapSeries section.ids, ((id, cb2) ->
+                        request
+                          .post("#{ARTSY_URL}/api/v1/post/#{post._id}/artwork/#{id}")
+                          .set('X-Access-Token', accessToken)
+                          .end (err, res) -> cb2 (err or res.body.error), res.body
+                      ), cb
+                    when 'image', 'video'
+                      request
+                        .post("#{ARTSY_URL}/api/v1/post/#{post._id}/link")
+                        .set('X-Access-Token', accessToken)
+                        .send(url: section.url)
+                        .end (err, res) -> cb (err or res.body.error), res.body
+                    else
+                      cb()
+                ), (err) ->
+                  return callback err if err
+                  request
+                    .get("#{ARTSY_URL}/api/v1/post/#{post._id}")
+                    .set('X-Access-Token', accessToken)
+                    .end (err, res) -> callback (err or res.body.error), res.body
 
 @destroy = (id, callback) ->
   db.articles.remove { _id: ObjectId(id) }, (err, res) ->

--- a/api/lib/migrate.coffee
+++ b/api/lib/migrate.coffee
@@ -212,8 +212,8 @@ postsToArticles = (posts, callback) ->
           sections.push { type: 'text', body: post.body } if bodyText
           sections
         )
-        featured_artist_ids: (f.artist_id for f in artistFeatures)
-        featured_artwork_ids: (f.artwork_id for f in artworkFeatures)
+        featured_artist_ids: (f.artist_id for f in artistFeatures or [])
+        featured_artwork_ids: (f.artwork_id for f in artworkFeatures or [])
         gravity_id: post._id
         fair_id: fair?._id
         partner_ids: _.pluck(partners, '_id') if partners?.length

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -115,7 +115,7 @@ module.exports = class EditAdmin extends Backbone.View
     id = _.last $t.val().split('/')
     $t.parent().addClass 'bordered-input-loading'
     @article['featured' + resource].getOrFetchIds [id],
-      complete: ->
+      complete: =>
         $t.val('').parent().removeClass 'bordered-input-loading'
         @article.save()
 

--- a/client/apps/edit/components/admin/index.jade
+++ b/client/apps/edit/components/admin/index.jade
@@ -41,8 +41,8 @@ section#edit-admin
     .edit-admin-right
   section#edit-admin-feature
     .edit-admin-left
-      h1 Feature
-      h2 Featuring this article will highlight it on selected artist and artwork pages.
+      h1 Artist & Artworks
+      h2 Select artist and artwork pages for this article to appear highlighted on.
     .edit-admin-right
       h3 Primary Artists
       +featuredList('eaf-primary-artists', 'artist')

--- a/client/apps/edit/components/admin/index.jade
+++ b/client/apps/edit/components/admin/index.jade
@@ -41,7 +41,7 @@ section#edit-admin
     .edit-admin-right
   section#edit-admin-feature
     .edit-admin-left
-      h1 Artist & Artworks
+      h1 Artists & Artworks
       h2 Select artist and artwork pages for this article to appear highlighted on.
     .edit-admin-right
       h3 Primary Artists

--- a/client/apps/edit/components/admin/index.styl
+++ b/client/apps/edit/components/admin/index.styl
@@ -33,6 +33,9 @@ gutter-size = 30px
   .edit-admin-right
     padding-top 87px
 
+#edit-admin-feature .edit-admin-right
+  padding-top 46px
+
 .edit-admin-left, .edit-admin-right
   display inline-block
   vertical-align top

--- a/client/apps/edit/components/admin/index.styl
+++ b/client/apps/edit/components/admin/index.styl
@@ -30,6 +30,8 @@ gutter-size = 30px
       padding-right gutter-size
   input
     margin 0 10px 0 0
+  .edit-admin-right
+    padding-top 87px
 
 .edit-admin-left, .edit-admin-right
   display inline-block

--- a/client/apps/edit/components/layout/content.jade
+++ b/client/apps/edit/components/layout/content.jade
@@ -6,7 +6,8 @@ section#edit-content
     contenteditable=true
   )!= article.get('lead_paragraph')
   #edit-author-section
-    p= user.get('user').name
+    if article.get('author')
+      p= article.get('author').name
     p= moment(article.get('created_at') || moment()).format('MMM D, YYYY h:mm a')
   .edit-body-container
   #edit-sections.edit-body-container


### PR DESCRIPTION
Currently Editorial has to "Sync to Post" then go and feature through the old UI. This moves more of their workflow exclusively inside Writer. Also adds some random cleanups here and there.