### PR TITLE
@kanaabe: Refactor Autocomplete to move out typeahead

### DIFF
--- a/client/apps/edit/components/section_artworks/index.coffee
+++ b/client/apps/edit/components/section_artworks/index.coffee
@@ -10,7 +10,7 @@ React = require 'react'
 ByUrls = require './by_urls.coffee'
 imagesLoaded = require 'imagesloaded'
 sd = require('sharify').data
-Autocomplete = -> require('../../../../components/autocomplete/index.coffee') arguments...
+Autocomplete = require '../../../../components/autocomplete/index.coffee'
 { div, nav, section, label, input, a, h1, textarea, button, form, ul,
   li, img, p, strong, span } = React.DOM
 icons = -> require('./icons.jade') arguments...

--- a/client/apps/edit/components/section_artworks/index.styl
+++ b/client/apps/edit/components/section_artworks/index.styl
@@ -145,6 +145,11 @@ wide-input-width = 640px
   color black
   input
     padding-left 8px
+  .tt-dropdown-menu
+    margin-top 0
+    border 1px solid gray-lighter-color
+    p
+      line-height 1.2em
 
 //
 // Varying layouts

--- a/client/components/autocomplete/index.coffee
+++ b/client/components/autocomplete/index.coffee
@@ -4,7 +4,6 @@
 
 _ = require 'underscore'
 Backbone = require 'backbone'
-require 'typeahead.js'
 
 module.exports = class Autocomplete extends Backbone.View
 

--- a/client/components/layout/client.coffee
+++ b/client/components/layout/client.coffee
@@ -14,6 +14,7 @@ Modal = require 'simple-modal'
 
 # Add jquery plugins
 require 'jquery-autosize'
+require 'typeahead.js'
 
 module.exports.init = ->
   Backbone.$ = $


### PR DESCRIPTION
I think the reason my `-> require('') arguments...` trick didn't work is because this is a class using the `new` keyword. I need to figure on a better trick, but for the time being I just moved the problematic typeahead out of that component and along side other jquery plugins ¯\_(ツ)_/¯