### PR TITLE
@broskoski: Re-render text sections only when not editing

### DIFF
--- a/client/apps/edit/components/section_artworks/index.coffee
+++ b/client/apps/edit/components/section_artworks/index.coffee
@@ -149,7 +149,7 @@ module.exports = React.createClass
           (@props.section.artworks.map (artwork, i) =>
             li { key: i },
               div { className: 'esa-img-container' },
-                img { src: artwork.get('image_urls')?.large or artwork.attributes.images[0]?.image_urls?.large }
+                img { src: artwork.get('image_urls')?.large or artwork.attributes.images?[0]?.image_urls?.large }
               p {},
                 strong {}, artwork.get('artists')?[0]?.name
               p {}, artwork.get('artwork')?.title or artwork.attributes?.title

--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -40,7 +40,7 @@ module.exports = React.createClass
   onClickOff: ->
     @props.section.destroy() if $(@props.section.get('body')).text() is ''
 
-  onKeyUp: ->
+  setBody: ->
     @props.section.set body: $(@refs.editable.getDOMNode()).html()
 
   attachScribe: ->
@@ -65,6 +65,7 @@ module.exports = React.createClass
       nav {
         ref: 'toolbar'
         className: 'edit-section-controls est-nav edit-scribe-nav'
+        onClick: @setBody
       },
         button {
           'data-command-name': 'bold'
@@ -96,5 +97,5 @@ module.exports = React.createClass
           dangerouslySetInnerHTML: __html: @props.section.get('body')
           onClick: @props.setEditing(on)
           onFocus: @props.setEditing(on)
-          onKeyUp: @onKeyUp
+          onKeyUp: @setBody
         }

--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -29,9 +29,13 @@ module.exports = React.createClass
 
   componentDidMount: ->
     @attachScribe()
+    @componentDidUpdate()
 
-  shouldComponentUpdate: ->
-    false
+  componentDidUpdate: ->
+    $(@refs.editable.getDOMNode()).focus() if @props.editing
+
+  shouldComponentUpdate: (nextProps) ->
+    not (nextProps.editing and @props.editing)
 
   onClickOff: ->
     @props.section.destroy() if $(@props.section.get('body')).text() is ''
@@ -55,7 +59,6 @@ module.exports = React.createClass
     @scribe.use scribePluginLinkTooltip()
     @scribe.use scribePluginKeyboardShortcuts keyboardShortcutsMap
     @scribe.use scribePluginHeadingCommand(2)
-    $(@refs.editable.getDOMNode()).focus() if @props.editing
 
   render: ->
     div { className: 'edit-section-text-container' },

--- a/client/apps/edit/components/section_text/test/index.coffee
+++ b/client/apps/edit/components/section_text/test/index.coffee
@@ -35,9 +35,9 @@ describe 'SectionText', ->
   afterEach ->
     benv.teardown()
 
-  it "updates the section's body on keyup", ->
+  it "updates the section's body", ->
     $(@component.refs.editable.getDOMNode()).html 'Hello'
-    @component.onKeyUp()
+    @component.setBody()
     @component.props.section.get('body').should.equal 'Hello'
 
   it 'removes the section if they click off and its empty', ->

--- a/client/apps/edit/components/section_text/test/index.coffee
+++ b/client/apps/edit/components/section_text/test/index.coffee
@@ -45,3 +45,7 @@ describe 'SectionText', ->
     @component.props.section.set body: ''
     @component.onClickOff()
     @component.props.section.destroy.called.should.be.ok
+
+  it 'doesnt update while editing b/c Scribe will jump around all weird', ->
+    @component.props.editing = true
+    @component.shouldComponentUpdate({ editing: true }).should.not.be.ok


### PR DESCRIPTION
I set `shouldComponentUpdate` to return false for text sections b/c React & Scribe don't play very nicely together, so I though I would just take a sledge hammer to the re-renders in text sections. This fixed a lot of issues with weird things jumping around while trying to edit text sections, but unsurprisingly caused other bugs with surrounding text sections, see: https://github.com/artsy/positron/issues/216.

After toying around a bit the secret sauce seems to be to not let the component re-render while you're in "editing" mode. So now `shouldComponentUpdate` checks against whether you're in that editing mode.