### PR TITLE
@craigspaeth Allow admin to add auction_id to an article

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -65,6 +65,7 @@ schema = (->
   featured_artwork_ids: @array().items(@objectId()).allow(null)
   fair_id: @objectId().allow('', null)
   partner_ids: @array().items(@objectId()).allow(null)
+  auction_id: @objectId().allow('', null)
   featured: @boolean().default(false)
 ).call Joi
 
@@ -77,6 +78,7 @@ querySchema = (->
   artwork_id: @objectId()
   fair_ids: @array()
   partner_id: @objectId()
+  auction_ids: @array()
   sort: @string()
   tier: @number()
   featured: @boolean()

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -12,6 +12,7 @@ module.exports = class EditAdmin extends Backbone.View
     @setupAuthorAutocomplete()
     @setupFairAutocomplete()
     @setupPartnerAutocomplete()
+    @setupAuctionAutocomplete()
 
   setupAuthorAutocomplete: ->
     Autocomplete = require '../../../../components/autocomplete/index.coffee'
@@ -59,6 +60,25 @@ module.exports = class EditAdmin extends Backbone.View
     if id = @article.get('partner_ids')?[0]
       request
         .get("#{sd.ARTSY_URL}/api/v1/partner/#{id}")
+        .set('X-Access-Token': sd.USER.access_token).end (err, res) ->
+          select.setState value: res.body.name, loading: false
+    else
+      select.setState loading: false
+
+  setupAuctionAutocomplete: ->
+    AutocompleteSelect = require '../../../../components/autocomplete_select/index.coffee'
+    select = AutocompleteSelect @$('#edit-admin-auction .edit-admin-right')[0],
+      url: "#{sd.ARTSY_URL}/api/v1/match/sales?term=%QUERY"
+      placeholder: 'Search auction by name...'
+      filter: (res) -> for r in res
+        { id: r._id, value: r.name }
+      selected: (e, item) =>
+        @article.save auction_id: item.id
+      cleared: =>
+        @article.save auction_id: null
+    if id = @article.get 'auction_id'
+      request
+        .get("#{sd.ARTSY_URL}/api/v1/sale/#{id}")
         .set('X-Access-Token': sd.USER.access_token).end (err, res) ->
           select.setState value: res.body.name, loading: false
     else

--- a/client/apps/edit/components/admin/index.jade
+++ b/client/apps/edit/components/admin/index.jade
@@ -41,6 +41,11 @@ section#edit-admin
       h1 Partner
       h2 Add this article to a partner&rsquo;s profile page.
     .edit-admin-right
+  section#edit-admin-auction
+    .edit-admin-left
+      h1 Auction
+      h2 Add this article to an auction&rsquo;s page.
+    .edit-admin-right
   section#edit-admin-feature
     .edit-admin-left
       h1 Artists & Artworks

--- a/client/apps/edit/components/admin/index.styl
+++ b/client/apps/edit/components/admin/index.styl
@@ -131,3 +131,5 @@ gutter-size = 30px
 #edit-admin-fair input
 #edit-admin-partner input
   width 100%
+#edit-admin-auction input
+  width 100%

--- a/client/apps/edit/components/admin/test/index.coffee
+++ b/client/apps/edit/components/admin/test/index.coffee
@@ -22,6 +22,7 @@ describe 'EditAdmin', ->
         EditAdmin::setupAuthorAutocomplete = sinon.stub()
         EditAdmin::setupFairAutocomplete = sinon.stub()
         EditAdmin::setupPartnerAutocomplete = sinon.stub()
+        EditAdmin::setupAuctionAutocomplete = sinon.stub()
         @view = new EditAdmin el: $('#edit-admin'), article: @article
         done()
 


### PR DESCRIPTION
Autosaves when you click on the auction and retrieves the auction when you come back to page. 

![positron_auction_autocomplete](https://cloud.githubusercontent.com/assets/2236794/6792444/96ed789e-d18e-11e4-95a3-eb240bf06fea.gif)
