### PR TITLE
@craigspaeth Fixes a small case in slug saving

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -181,12 +181,13 @@ update = (article, input, callback) ->
 addSlug = (article, input, author, callback) ->
   titleSlug = _s.slugify(article.title).split('-')[0..7].join('-')
   article.slugs ?= []
+  #Don't change the article slug unless it's unpublished or a new slug is added
   if input.slug? and (input.slug != _.last(article.slugs))
     slug = input.slug
-  else if author
-    slug = _s.slugify(author.user.name) + '-' + titleSlug
+  else if article.published is false
+    slug = if author then _s.slugify(author.user.name) + '-' + titleSlug else titleSlug
   else
-    slug = titleSlug
+    return article
   article.slugs = _.unique(article.slugs).concat [slug]
   article
 

--- a/client/apps/edit/components/header/index.coffee
+++ b/client/apps/edit/components/header/index.coffee
@@ -16,6 +16,7 @@ module.exports = class EditHeader extends Backbone.View
 
   saving: =>
     @$('#edit-save').addClass 'is-saving'
+    @$('#edit-save').removeClass 'attention'
 
   doneSaving: =>
     @$('#edit-save').removeClass 'is-saving'


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/312

And generally: 
Slug is changed if Admin changes it
If the article is unpublished, the slug will be generated by the author and title (unless an Admin input is present as well)
Slug does not change automatically if article is published