### PR TITLE
@kanaabe: Vertical Admin UI

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -97,6 +97,7 @@ querySchema = (->
   sort: @string()
   tier: @number()
   featured: @boolean()
+  q: @string()
 ).call Joi
 
 #
@@ -124,7 +125,7 @@ toQuery = (input, callback) ->
     # Separate "find" query from sort/offest/limit
     { limit, offset, sort } = input
     query = _.omit input, 'limit', 'offset', 'sort', 'artist_id', 'artwork_id',
-      'fair_ids', 'partner_id', 'auction_id', 'show_id'
+      'fair_ids', 'partner_id', 'auction_id', 'show_id', 'q'
     # Type cast IDs
     # TODO: https://github.com/pebble/joi-objectid/issues/2#issuecomment-75189638
     query.author_id = ObjectId input.author_id if input.author_id
@@ -137,9 +138,10 @@ toQuery = (input, callback) ->
     query.$or = [
       { primary_featured_artist_ids: ObjectId(input.artist_id) }
       { featured_artist_ids: ObjectId(input.artist_id) }
-
     ] if input.artist_id
     query.featured_artwork_ids = ObjectId input.artwork_id if input.artwork_id
+    # Allow regex searching through the q param
+    query.thumbnail_title = { $regex: new RegExp(input.q, 'i') } if input.q
     callback null, query, limit, offset, sortParamToQuery(sort)
 
 sortParamToQuery = (input) ->

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -155,6 +155,19 @@ describe 'Article', ->
             done()
         )
 
+    it 'can find articles by query', (done) ->
+      fabricate 'articles', [
+        { thumbnail_title: 'Foo' }
+        { thumbnail_title: 'Bar' }
+        { thumbnail_title: 'Baz' }
+      ], ->
+        Article.where(
+          { q: 'fo' }
+          (err, { results }) ->
+            results[0].thumbnail_title.should.equal 'Foo'
+            done()
+        )
+
   describe '#find', ->
 
     it 'finds an article by an id string', (done) ->

--- a/api/apps/verticals/model.coffee
+++ b/api/apps/verticals/model.coffee
@@ -55,6 +55,7 @@ querySchema = (->
     cursor = db.verticals
       .find(query)
       .limit(input.limit or 10)
+      .sort($natural: -1)
       .skip(input.offset or 0)
     async.parallel [
       (cb) -> cursor.toArray cb

--- a/client/apps/article_list/index.jade
+++ b/client/apps/article_list/index.jade
@@ -1,5 +1,6 @@
+include ../../components/paginated_list/index
+
 extend ../../components/layout/templates/index
-include ../../../node_modules/artsy-ezel-components/pagination/paginator
 
 block header
   if published
@@ -13,41 +14,15 @@ block header
 block content
   #article-list-items.max-width-container
     if articles.length == 0
-        section.article-list-empty
-          p You haven&rsquo;t #{emptyMessage} yet.
-          p Artsy Writer is a tool for writing stories about art on Artsy.
-            br
-            | Get started by writing an article or&nbsp;
-            a.article-list-empty-chat chatting with a liason
-            | &nbsp;for help.
-          a.avant-garde-button.avant-garde-button-black.article-new-button( href='/articles/new' )
-            include ../../components/layout/public/icons/layout_new_article.svg
-            .article-new-text Write An Article
-    ul
-      for article in articles
-        li
-          section
-            a( href="/articles/#{article.get('id')}/edit" )
-              .article-list-item-left
-                if article.get('thumbnail_image')
-                  - url = resize(article.get('thumbnail_image'), { width: 150 })
-                  .article-list-img(
-                    style="background-image: url(#{url})"
-                  )
-                else
-                  .article-list-item-placeholder Missing
-                    br
-                    | thumbnail
-              .article-list-item-right
-                if article.get('thumbnail_title')
-                  h1= article.get('thumbnail_title')
-                else
-                  h1.article-list-missing Missing title
-                .article-list-items-dates
-                  if article.get('published_at')
-                    strong Published #{moment(article.get('published_at')).fromNow()}
-                    | Last saved #{moment(article.get('updated_at')).fromNow()}
-                  else
-                    strong Last saved #{moment(article.get('updated_at')).fromNow()}
-    #article-list-pagination
-      +paginate(page, totalPages, '?published=' + published + '&')
+      section.article-list-empty
+        p You haven&rsquo;t #{emptyMessage} yet.
+        p Artsy Writer is a tool for writing stories about art on Artsy.
+          br
+          | Get started by writing an article or&nbsp;
+          a.article-list-empty-chat chatting with a liason
+          | &nbsp;for help.
+        a.avant-garde-button.avant-garde-button-black.article-new-button( href='/articles/new' )
+          include ../../components/layout/public/icons/layout_new_article.svg
+          .article-new-text Write An Article
+    else
+      +paginated-list(page, totalPages, articles.toPaginatedListItems(), '?published=' + published + '&')

--- a/client/apps/article_list/index.jade
+++ b/client/apps/article_list/index.jade
@@ -10,7 +10,6 @@ block header
     | Drafts
     - var emptyMessage = "written any drafts"
 
-
 block content
   #article-list-items.max-width-container
     if articles.length == 0

--- a/client/apps/article_list/routes.coffee
+++ b/client/apps/article_list/routes.coffee
@@ -14,7 +14,7 @@ Articles = require '../../collections/articles.coffee'
     error: res.backboneError
     success: (articles) ->
       res.render 'index',
-        articles: articles.models
+        articles: articles
         published: published
         page: page or 1
         totalPages: Math.ceil(articles.count / size)

--- a/client/apps/article_list/routes.coffee
+++ b/client/apps/article_list/routes.coffee
@@ -8,9 +8,9 @@ Articles = require '../../collections/articles.coffee'
     data:
       offset: if page then (page - 1) * size else 0
       limit: size
-      author_id: req.user.get('id')
+      author_id: req.user?.get('id')
       published: published = req.query.published is 'true'
-    headers: 'x-access-token': req.user.get('access_token')
+    headers: 'x-access-token': req.user?.get('access_token')
     error: res.backboneError
     success: (articles) ->
       res.render 'index',

--- a/client/apps/article_list/test/routes.coffee
+++ b/client/apps/article_list/test/routes.coffee
@@ -22,7 +22,7 @@ describe 'routes', ->
       Backbone.sync.args[0][2].success {
         results: [_.extend(fixtures().articles, title: "mooo")]
       }
-      @res.render.args[0][1].articles[0].get('title').should.equal 'mooo'
+      @res.render.args[0][1].articles.first().get('title').should.equal 'mooo'
 
     it 'can filter based on query params', ->
       @req.query.published = 'true'

--- a/client/apps/article_list/test/templates.coffee
+++ b/client/apps/article_list/test/templates.coffee
@@ -19,4 +19,4 @@ describe 'article list template', ->
   it 'renders an article thumbnail_title', ->
     articles = new Articles [fixtures().articles]
     articles.first().set thumbnail_title: 'Hello Blue World'
-    render(articles: articles.models).should.containEql 'Hello Blue World'
+    render(articles: articles).should.containEql 'Hello Blue World'

--- a/client/apps/edit/components/header/index.styl
+++ b/client/apps/edit/components/header/index.styl
@@ -37,7 +37,6 @@
 
 #edit-tabs a, #edit-header-right a
   padding 10px 18px
-  font-size default-avant-garde-font-size - 2
 
 #edit-save
   position relative

--- a/client/apps/edit/components/section_artworks/index.styl
+++ b/client/apps/edit/components/section_artworks/index.styl
@@ -22,7 +22,7 @@ wide-input-width = 640px
   fill-container()
   background black
   z-index 3
-  height 294px
+  height 334px
   top -(@height)
   text-align center
   display none

--- a/client/apps/edit/components/section_image/index.styl
+++ b/client/apps/edit/components/section_image/index.styl
@@ -14,7 +14,7 @@
 .edit-section-image .edit-section-controls
   fill-container()
   background black
-  height 188px
+  height 218px
   top -(@height + controls-padding)
   left -(controls-padding)
   padding controls-padding

--- a/client/apps/edit/components/section_tool/index.styl
+++ b/client/apps/edit/components/section_tool/index.styl
@@ -79,6 +79,7 @@ section-btn-height = 130px
   max-height 0
   background gray-lightest-color
   li
+    avant-garde()
     width 25%
     height section-btn-height
     background white
@@ -86,7 +87,6 @@ section-btn-height = 130px
     border-bottom 1px solid gray-color
     vertical-align top
     line-height @height + 50px
-    avant-garde()
     font-size small-avant-garde-font-size
     display inline-block
     text-align center

--- a/client/apps/edit/components/section_video/index.styl
+++ b/client/apps/edit/components/section_video/index.styl
@@ -6,7 +6,7 @@ play-button-size = 30px
   background black
   color white
   fill-container()
-  height 216px
+  height 246px
   top -(@height)
   padding controls-padding
   z-index 3

--- a/client/apps/edit/components/thumbnail/form.jade
+++ b/client/apps/edit/components/thumbnail/form.jade
@@ -2,18 +2,4 @@ label
   span.edit-required(
     data-hidden=article.get('thumbnail_image') ? 'true' : 'false'
   ) Thumbnail Image
-  #edit-thumbnail-upload.dashed-file-upload-container
-    | Drag &&nbsp;
-    span.dashed-file-upload-container-drop Drop&nbsp;
-    | or&nbsp;
-    span.dashed-file-upload-container-click click<br>
-    | to upload your thumbnail
-    if article.get('thumbnail_image')
-      - url = resize(article.get('thumbnail_image'), { width: 260 })
-      #edit-thumbnail-preview(
-        style="background-image: url(#{url})"
-      )
-      #edit-thumbnail-remove ×
-    input#edit-thumbnail-image( type='file' )
-    .upload-progress-container
-      .upload-progress
+  #edit-thumbnail-upload

--- a/client/apps/edit/components/thumbnail/index.coffee
+++ b/client/apps/edit/components/thumbnail/index.coffee
@@ -2,53 +2,35 @@ _ = require 'underscore'
 Backbone = require 'backbone'
 gemup = require 'gemup'
 sd = require('sharify').data
+ImageUploadForm = require '../../../../components/image_upload_form/index.coffee'
 thumbnailFormTemplate = -> require('./form.jade') arguments...
 
 module.exports = class EditThumbnail extends Backbone.View
 
   initialize: (options) ->
     { @article } = options
-    @article.on 'change:thumbnail_image', @renderThumbnailForm
     @article.on 'change:title', _.debounce @prefillThumbnailTitle, 3000
     @checkTitleTextarea()
+    @renderThumbnailForm()
 
   renderThumbnailForm: =>
-    @$('#edit-thumbnail-inputs-left').html thumbnailFormTemplate
-      article: @article
+    new ImageUploadForm
+      el: $('#edit-thumbnail-upload')
+      src: @article.get('thumbnail_image')
+      remove: =>
+        console.log 'remove'
+        @article.save thumbnail_image: null
+      done: (src) =>
+        console.log 'done', src
+        @article.save thumbnail_image: src
 
   prefillThumbnailTitle: =>
     if @article.get('title') and not @article.get('thumbnail_title')
       @useArticleTitle()
 
   events:
-    'change #edit-thumbnail-image': 'uploadThumbnail'
-    'drop #edit-thumbnail-upload': 'toggleThumbnailDragover'
-    'click #edit-thumbnail-remove': 'removeThumbnail'
     'click .edit-use-article-title': 'useArticleTitle'
     'change .edit-title-textarea': 'checkTitleTextarea'
-
-  uploadThumbnail: (e) ->
-    gemup e.target.files[0],
-      key: sd.GEMINI_KEY
-      progress: (percent) =>
-        @$('#edit-thumbnail-upload .upload-progress-container')
-          .show().find('.upload-progress').width "#{percent * 100}%"
-        @$('#edit-thumbnail-preview').css opacity: percent
-      add: (src) =>
-        @article.set 'thumbnail_image', src
-        @$('#edit-thumbnail-preview').css opacity: 0.1
-        @$('#edit-thumbnail-upload').addClass 'is-uploading'
-      done: (src) =>
-        img = new Image()
-        img.src = src
-        img.onload = =>
-          @article.save thumbnail_image: src
-          @$('#edit-thumbnail-upload .upload-progress-container').hide()
-          @$('#edit-thumbnail-upload').removeClass 'is-uploading'
-
-  removeThumbnail: (e) ->
-    e.preventDefault()
-    @article.save thumbnail_image: null
 
   useArticleTitle: (e) ->
     e?.preventDefault()

--- a/client/apps/edit/components/thumbnail/index.styl
+++ b/client/apps/edit/components/thumbnail/index.styl
@@ -24,19 +24,6 @@ inputs-margin = 15px
 #edit-thumbnail-inputs
   width 860px
   margin 30px auto
-  .dashed-file-upload-container
-    width 270px
-    height 180px
-    garamond()
-    color gray-lighter-color
-    text-transform none
-    letter-spacing 0
-    padding-top 66px
-    color gray-dark-color
-    text-align center
-    font-size default-garamond-font-size
-    line-height 1.2em
-    transition color 0.3s, border-color 0.3s
   label
     avant-garde()
     font-size default-avant-garde-font-size - 2
@@ -59,6 +46,12 @@ error-placeholder()
   display inline-block
   vertical-align top
 
+#edit-thumbnail-inputs-left .image-upload-form
+  height 180px
+  width 270px
+  h1
+    margin-top 60px
+
 #edit-thumbnail-inputs-right
   width 590px
   padding-left inputs-margin
@@ -79,40 +72,6 @@ error-placeholder()
     font-size 15px
     faux-underline(gray-dark-color, 2px, 2px)
     margin-top -1px
-
-#edit-thumbnail-preview
-  width calc(100% + 4px)
-  height calc(100% + 4px)
-  top -2px
-  left -2px
-  position absolute
-  background center center
-  background-size cover
-
-#edit-thumbnail-remove
-  background #000
-  top -2px
-  left -2px
-  height 30px
-  width @height
-  line-height @height
-  color #fff
-  position absolute
-  font-size 18px
-  font-weight bold
-  font-family Helvetica, sans-serif
-  cursor pointer
-  transition color 0.3s, background-color 0.3s
-  z-index 3
-  &:hover
-    background-color red-color
-    color white
-
-#edit-thumbnail-upload.is-uploading
-  color transparent
-  span
-    color transparent
-  border-color transparent
 
 .edit-title-textarea
   padding 12px 15px

--- a/client/apps/edit/components/thumbnail/test/index.coffee
+++ b/client/apps/edit/components/thumbnail/test/index.coffee
@@ -22,37 +22,13 @@ describe 'EditThumbnail', ->
           ['thumbnailFormTemplate']
         )
         EditThumbnail.__set__ 'gemup', @gemup = sinon.stub()
+        EditThumbnail.__set__ 'ImageUploadForm', @ImageUploadForm = sinon.stub()
         @view = new EditThumbnail el: $('#edit-thumbnail'), article: @article
         done()
 
   afterEach ->
     benv.teardown()
     Backbone.sync.restore()
-
-  describe '#renderThumbnailForm', ->
-
-    it 'renders the thumbnail image on change', ->
-      @view.article.set thumbnail_image: 'http://kittens.com/foo.jpg'
-      @view.$el.html().should.containEql 'http://kittens.com/foo.jpg'
-
-  describe '#removeThumbnail', ->
-
-    it 'empties the thumbnail image', ->
-      @view.removeThumbnail({ preventDefault: -> })
-      (@view.article.get('thumbnail_image')?).should.not.be.ok
-
-  describe '#uploadThumbnail', ->
-
-    it 'uses gemup to upload an image and shows it in the DOM', ->
-      @view.uploadThumbnail target: files: ['foo.jpg']
-      @gemup.args[0][0].should.equal 'foo.jpg'
-      img = null
-      class global.Image
-        constructor: -> img = this
-      @gemup.args[0][1].done 'moo.jpg'
-      img.onload()
-      Backbone.sync.args[0][0].should.equal 'create'
-      delete global.Image
 
   describe '#useArticleTitle', ->
 

--- a/client/apps/verticals/edit.jade
+++ b/client/apps/verticals/edit.jade
@@ -29,7 +29,8 @@ block header
 block content
   .max-width-container
     form.admin-form-container(
-      action="/verticals/#{vertical.get('id')}" method='post'
+      action=(vertical.isNew() ?  "/verticals" : "/verticals/#{vertical.get('id')}")
+      method='post'
     )
       .admin-form-section
         .admin-form-left Vertical Details
@@ -64,6 +65,5 @@ block content
       button.avant-garde-button.avant-garde-button-black.verticals-save(
         type='submit' href="/verticals/new"
       ) Save Changes
-      a.avant-garde-button.verticals-delete(
-        href="/verticals/#{vertical.get('id')}/delete"
-      ) Delete Vertical
+      unless vertical.isNew()
+        a.avant-garde-button.verticals-delete Delete Vertical

--- a/client/apps/verticals/edit.jade
+++ b/client/apps/verticals/edit.jade
@@ -1,0 +1,69 @@
+include ../../components/paginated_list/index
+
+mixin form-elements(items)
+  each item in items
+    label
+      = _s.humanize(item.attr)
+      if item.type == 'input'
+        input.bordered-input( value=vertical.get(item.attr) name=item.attr )
+      else if item.type == 'date'
+        input.bordered-input(
+          value=moment(vertical.get(item.attr)).format('MM/DD/YYYY')
+          name=item.attr
+        )
+      else if item.type == 'textarea'
+        textarea.bordered-input( name=item.attr )=vertical.get(item.attr)
+      else if item.type == 'image'
+        .verticals-image-placeholder( data-attr=item.attr name=item.attr )
+
+mixin article-input(i)
+  label
+    | Article #{i + 1}
+    input.bordered-input
+
+extend ../../components/layout/templates/index
+
+block header
+  | Verticals
+
+block content
+  .max-width-container
+    form.admin-form-container(
+      action="/verticals/#{vertical.get('id')}" method='post'
+    )
+      .admin-form-section
+        .admin-form-left Vertical Details
+        .admin-form-center
+          +form-elements([
+            { attr: 'title', type: 'input' },
+            { attr: 'meta_title', type: 'input' },
+            { attr: 'slug', type: 'input' },
+            { attr: 'description', type: 'textarea' }
+          ])
+        .admin-form-right
+          +form-elements([
+            { attr: 'start_at', type: 'date' },
+            { attr: 'end_at', type: 'date' },
+            { attr: 'thumbnail_url', type: 'image' }
+          ])
+      .admin-form-section
+        .admin-form-left Partner Logo
+        .admin-form-center
+          +form-elements([
+            { attr: 'partner_logo_url', type: 'image' },
+            { attr: 'partner_website_url', type: 'input' }
+          ])
+      .admin-form-section
+        .admin-form-left Featured Articles
+        .admin-form-center
+          +article-input(0)
+          +article-input(1)
+        .admin-form-right
+          +article-input(2)
+          +article-input(3)
+      button.avant-garde-button.avant-garde-button-black.verticals-save(
+        type='submit' href="/verticals/new"
+      ) Save Changes
+      a.avant-garde-button.verticals-delete(
+        href="/verticals/#{vertical.get('id')}/delete"
+      ) Delete Vertical

--- a/client/apps/verticals/edit.jade
+++ b/client/apps/verticals/edit.jade
@@ -16,11 +16,6 @@ mixin form-elements(items)
       else if item.type == 'image'
         .verticals-image-placeholder( data-attr=item.attr name=item.attr )
 
-mixin article-input(i)
-  label
-    | Article #{i + 1}
-    input.bordered-input
-
 extend ../../components/layout/templates/index
 
 block header
@@ -57,11 +52,11 @@ block content
       .admin-form-section
         .admin-form-left Featured Articles
         .admin-form-center
-          +article-input(0)
-          +article-input(1)
+          .verticals-article-input: input.bordered-input
+          .verticals-article-input: input.bordered-input
         .admin-form-right
-          +article-input(2)
-          +article-input(3)
+          .verticals-article-input: input.bordered-input
+          .verticals-article-input: input.bordered-input
       button.avant-garde-button.avant-garde-button-black.verticals-save(
         type='submit' href="/verticals/new"
       ) Save Changes

--- a/client/apps/verticals/edit_client.coffee
+++ b/client/apps/verticals/edit_client.coffee
@@ -1,9 +1,15 @@
+Vertical = require '../../models/vertical.coffee'
 ImageUploadForm = require '../../components/image_upload_form/index.coffee'
 sd = require('sharify').data
 
 @init = ->
+  vertical = new Vertical sd.VERTICAL
   $('.verticals-image-placeholder').each (i, el) ->
     new ImageUploadForm
       el: $(el)
-      src: sd.VERTICAL[$(el).attr('data-attr')]
+      src: vertical.get($(el).attr 'data-attr')
       name: $(el).attr('data-attr')
+  $('.verticals-delete').click (e) ->
+    e.preventDefault()
+    return unless confirm "Are you sure you want to delete this vertical?"
+    vertical.destroy success: -> location.assign '/verticals'

--- a/client/apps/verticals/edit_client.coffee
+++ b/client/apps/verticals/edit_client.coffee
@@ -1,0 +1,9 @@
+ImageUploadForm = require '../../components/image_upload_form/index.coffee'
+sd = require('sharify').data
+
+@init = ->
+  $('.verticals-image-placeholder').each (i, el) ->
+    new ImageUploadForm
+      el: $(el)
+      src: sd.VERTICAL[$(el).attr('data-attr')]
+      name: $(el).attr('data-attr')

--- a/client/apps/verticals/edit_client.coffee
+++ b/client/apps/verticals/edit_client.coffee
@@ -1,15 +1,61 @@
+Backbone = require 'backbone'
 Vertical = require '../../models/vertical.coffee'
+Article = require '../../models/article.coffee'
 ImageUploadForm = require '../../components/image_upload_form/index.coffee'
+AutocompleteSelect = require '../../components/autocomplete_select/index.coffee'
 sd = require('sharify').data
 
-@init = ->
-  vertical = new Vertical sd.VERTICAL
-  $('.verticals-image-placeholder').each (i, el) ->
-    new ImageUploadForm
-      el: $(el)
-      src: vertical.get($(el).attr 'data-attr')
-      name: $(el).attr('data-attr')
-  $('.verticals-delete').click (e) ->
+class VerticalEditView extends Backbone.View
+
+  initialize: ({ @vertical }) ->
+    @attachUploadForms()
+    @attachAutocompleteSelects()
+
+  attachUploadForms: ->
+    @$('.verticals-image-placeholder').each (i, el) =>
+      new ImageUploadForm
+        el: $(el)
+        src: @vertical.get($(el).attr 'data-attr')
+        name: $(el).attr('data-attr')
+
+  attachAutocompleteSelects: ->
+    @$('.verticals-article-input').each (i, el) =>
+      select = AutocompleteSelect el,
+        label: "Article #{i + 1}"
+        name: "featured_article_ids[#{i}]"
+        url: "#{sd.API_URL}/articles?q=%QUERY"
+        placeholder: 'Search article by title...'
+        filter: (res) -> for a in res.results
+          { id: a.id, value: a.thumbnail_title + ' – ' + a.author?.name }
+      id = @vertical.get('featured_article_ids')?[i]
+      if id
+        new Article(id: id).fetch
+          success: (a) ->
+            select.setState
+              loading: false
+              value: a.get('thumbnail_title') + ' – ' + a.get('author')?.name
+              id: id
+      else
+        select.setState loading: false, value: null
+
+  events:
+    'click .verticals-delete': 'destroy'
+    'change :input': 'unsaved'
+    'submit form': 'ignoreUnsaved'
+
+  destroy: (e) ->
     e.preventDefault()
     return unless confirm "Are you sure you want to delete this vertical?"
-    vertical.destroy success: -> location.assign '/verticals'
+    @vertical.destroy success: -> location.assign '/verticals'
+
+  unsaved: ->
+    window.onbeforeunload = ->
+      "You have unsaved changes, do you wish to continue?"
+
+  ignoreUnsaved: ->
+    window.onbeforeunload = ->
+
+@init = ->
+  new VerticalEditView
+    vertical: new Vertical(sd.VERTICAL)
+    el: $('body')

--- a/client/apps/verticals/index.coffee
+++ b/client/apps/verticals/index.coffee
@@ -1,0 +1,14 @@
+#
+# CRUD for verticals.
+#
+
+express = require 'express'
+routes = require './routes'
+
+app = module.exports = express()
+app.set 'views', __dirname
+app.set 'view engine', 'jade'
+
+app.get '/verticals', routes.index
+app.get '/verticals/:id/edit', routes.edit
+app.post '/verticals/:id', routes.save

--- a/client/apps/verticals/index.coffee
+++ b/client/apps/verticals/index.coffee
@@ -11,4 +11,6 @@ app.set 'view engine', 'jade'
 
 app.get '/verticals', routes.index
 app.get '/verticals/:id/edit', routes.edit
+app.get '/verticals/new', routes.edit
 app.post '/verticals/:id', routes.save
+app.post '/verticals', routes.save

--- a/client/apps/verticals/index.jade
+++ b/client/apps/verticals/index.jade
@@ -1,0 +1,13 @@
+include ../../components/paginated_list/index
+
+extend ../../components/layout/templates/index
+
+block header
+  | Verticals
+
+block content
+  .max-width-container
+    a.avant-garde-button.avant-garde-button-black.verticals-add(
+      href="/verticals/new"
+    ) Add Vertical
+    +paginated-list(page, totalPages, verticals.toPaginatedListItems())

--- a/client/apps/verticals/index.styl
+++ b/client/apps/verticals/index.styl
@@ -1,0 +1,15 @@
+@import '../../components/stylus_lib'
+
+.verticals-add, .verticals-save
+  width 100%
+  padding 15px 0
+  margin-top 20px
+
+.verticals-delete
+  margin-top 10px
+  color gray-dark-color
+  border 0
+  text-align left
+  padding 20px 0
+  &:hover
+    color red-color

--- a/client/apps/verticals/routes.coffee
+++ b/client/apps/verticals/routes.coffee
@@ -1,0 +1,25 @@
+_ = require 'underscore'
+Verticals = require '../../collections/verticals'
+Vertical = require '../../models/vertical'
+
+@index = (req, res) ->
+  new Verticals().fetch
+    data: limit: 100
+    error: res.backboneError
+    success: (verticals) ->
+      res.render 'index', verticals: verticals
+
+@edit = (req, res) ->
+  new Vertical(id: req.params.id).fetch
+    error: res.backboneError
+    success: (vertical) ->
+      res.locals.sd.VERTICAL = vertical.toJSON()
+      res.render 'edit', vertical: vertical
+
+@save = (req, res) ->
+  data = _.pick req.body, _.identity
+  new Vertical(id: req.params.id).save data,
+    headers: 'X-Access-Token': req.user?.get('access_token')
+    error: res.backboneError
+    success: ->
+      res.redirect '/verticals'

--- a/client/apps/verticals/routes.coffee
+++ b/client/apps/verticals/routes.coffee
@@ -17,8 +17,7 @@ Vertical = require '../../models/vertical'
       res.render 'edit', vertical: vertical
 
 @save = (req, res) ->
-  data = _.pick req.body, _.identity
-  new Vertical(id: req.params.id).save data,
+  new Vertical(id: req.params.id).save _.pick(req.body, _.identity),
     headers: 'X-Access-Token': req.user?.get('access_token')
     error: res.backboneError
     success: ->

--- a/client/apps/verticals/routes.coffee
+++ b/client/apps/verticals/routes.coffee
@@ -17,7 +17,9 @@ Vertical = require '../../models/vertical'
       res.render 'edit', vertical: vertical
 
 @save = (req, res) ->
-  new Vertical(id: req.params.id).save _.pick(req.body, _.identity),
+  data = _.pick req.body, _.identity
+  data.featured_article_ids = _.compact data.featured_article_ids
+  new Vertical(id: req.params.id).save data,
     headers: 'X-Access-Token': req.user?.get('access_token')
     error: res.backboneError
     success: ->

--- a/client/apps/verticals/test/routes.coffee
+++ b/client/apps/verticals/test/routes.coffee
@@ -1,0 +1,38 @@
+routes = require '../routes'
+_ = require 'underscore'
+Backbone = require 'backbone'
+sinon = require 'sinon'
+fixtures = require '../../../../test/helpers/fixtures'
+User = require '../../../models/user'
+
+describe 'routes', ->
+
+  beforeEach ->
+    sinon.stub Backbone, 'sync'
+    @req = { query: {}, user: new User(fixtures().users), params: {} }
+    @res = { render: sinon.stub(), locals: fixtures().locals }
+
+  afterEach ->
+    Backbone.sync.restore()
+
+  describe '#save', ->
+
+    it 'saves the serialized form data to the vertical', ->
+      @req.body =
+        title: 'Foobar'
+        featured_article_ids: ['foo', 'bar', '', '']
+      routes.save @req, @res
+      Backbone.sync.args[0][1].toJSON().title.should.equal 'Foobar'
+      Backbone.sync.args[0][1].toJSON().featured_article_ids.length
+        .should.equal 2
+      Backbone.sync.args[0][1].toJSON().featured_article_ids.join('')
+        .should.equal 'foobar'
+
+  describe '#edit', ->
+
+    it 'renders the edit page', ->
+      routes.edit @req, @res
+      Backbone.sync.args[0][2].success fixtures().verticals
+      @res.render.args[0][0].should.equal 'edit'
+      @res.render.args[0][1].vertical.get('id')
+        .should.equal '55356a9deca560a0137aa4b7'

--- a/client/assets/main.coffee
+++ b/client/assets/main.coffee
@@ -3,10 +3,23 @@
 # can break this up into self-initializing app-level asset packages like Force.
 #
 
-sd = require('sharify').data
+Backbone = require 'backbone'
 window.jQuery = window.$ = $ = require 'jquery'
 
+class Router extends Backbone.Router
+
+  routes:
+    'articles/new': 'articleEdit'
+    'articles/:id/edit': 'articleEdit'
+    'verticals/new': 'verticalEdit'
+    'verticals/:id/edit': 'verticalEdit'
+
+  articleEdit: ->
+    require('../apps/edit/client.coffee').init()
+
+  verticalEdit: ->
+    require('../apps/verticals/edit_client.coffee').init()
+
+new Router()
 $ ->
   require('../components/layout/client.coffee').init()
-  if sd.URL.match /// /articles/new|.*/edit ///
-    require('../apps/edit/client.coffee').init()

--- a/client/assets/main.styl
+++ b/client/assets/main.styl
@@ -2,5 +2,8 @@
 @import '../components/layout/stylesheets'
 @import '../components/autocomplete'
 @import '../components/autocomplete_select'
+@import '../components/paginated_list'
+@import '../components/image_upload_form'
 @import '../apps/article_list'
 @import '../apps/edit'
+@import '../apps/verticals'

--- a/client/collections/articles.coffee
+++ b/client/collections/articles.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore'
 Backbone = require 'backbone'
 Article = require '../models/article.coffee'
 sd = require('sharify').data
+moment = require 'moment'
 { ApiCollection } = require './mixins.coffee'
 
 module.exports = class Articles extends Backbone.Collection
@@ -11,3 +12,15 @@ module.exports = class Articles extends Backbone.Collection
   url: "#{sd.API_URL}/articles"
 
   model: Article
+
+  toPaginatedListItems: ->
+    @map (article) ->
+      imgSrc: article.get('thumbnail_image')
+      title: article.get('thumbnail_title')
+      subtitle: (
+        if article.get('published_at')
+          "Published #{moment(article.get('published_at')).fromNow()}"
+        else
+          "Last saved #{moment(article.get('updated_at')).fromNow()}"
+      )
+      href: "/articles/#{article.get('id')}/edit"

--- a/client/collections/verticals.coffee
+++ b/client/collections/verticals.coffee
@@ -1,0 +1,24 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+moment = require 'moment'
+Vertical = require '../models/vertical.coffee'
+sd = require('sharify').data
+{ ApiCollection } = require './mixins.coffee'
+
+module.exports = class Verticals extends Backbone.Collection
+
+  _.extend @prototype, ApiCollection
+
+  url: "#{sd.API_URL}/verticals"
+
+  model: Vertical
+
+  toPaginatedListItems: ->
+    @map (vertical) ->
+      imgSrc: vertical.get('thumbnail_url')
+      title: vertical.get('title')
+      subtitle: (
+        moment(vertical.get('start_at')).format('MMM Do') + ' – ' +
+        moment(vertical.get('end_at')).format('MMM Do')
+      )
+      href: "/verticals/#{vertical.get('id')}/edit"

--- a/client/components/autocomplete/index.styl
+++ b/client/components/autocomplete/index.styl
@@ -28,7 +28,7 @@
 
 .twitter-typeahead input
   padding-left 36px
-  background url("/autocomplete_search.svg") 9px 7px no-repeat
+  background url("/autocomplete_search.svg") 9px 9px no-repeat
   background-size 18px
   &:active, &:focus
     border-color purple-color

--- a/client/components/autocomplete/index.styl
+++ b/client/components/autocomplete/index.styl
@@ -10,6 +10,11 @@
   background white
   margin-top -2px
 
+.tt-suggestion, .autocomplete-empty
+  garamond()
+  text-transform none
+  letter-spacing 0
+
 .tt-suggestion
   padding 10px
   border-bottom 1px solid gray-lighter-color

--- a/client/components/autocomplete_select/README.md
+++ b/client/components/autocomplete_select/README.md
@@ -1,7 +1,6 @@
 # Autocomplete Select
 
-Kinda like a cross between a `<select>` box and the autocomplete component. It has a selected state
-that indicates the chosen value.
+Kinda like a cross between a `<select>` box and the autocomplete component. It has a selected state that indicates the chosen value.
 
 ![](https://s3.amazonaws.com/f.cl.ly/items/222m2M2e2h1e250q3I0E/Image%202015-01-29%20at%204.06.08%20PM.png)
 

--- a/client/components/autocomplete_select/README.md
+++ b/client/components/autocomplete_select/README.md
@@ -6,6 +6,8 @@ Kinda like a cross between a `<select>` box and the autocomplete component. It h
 
 ## Example
 
+Basic usage
+
 ````coffeescript
 select = AutocompleteSelect @$('#input-container')[0],
   url: "#{sd.ARTSY_URL}/api/v1/match/fairs?term=%QUERY"
@@ -15,4 +17,17 @@ select = AutocompleteSelect @$('#input-container')[0],
     article.save fair_id: item.id
   cleared: ->
     article.save fair_id: null
+select.setState loading: false, value: article.get('fair_id')
+````
+
+If you're using a label and server-side serialization
+
+````coffeescript
+select = AutocompleteSelect @$('#input-container')[0],
+  label: 'Fair Id'
+  name: 'fair_id'
+  url: "#{sd.ARTSY_URL}/api/v1/match/fairs?term=%QUERY"
+  filter: (res) -> for r in res
+    { id: r._id, value: r.name }
+select.setState loading: false, value: article.get('fair_id')
 ````

--- a/client/components/autocomplete_select/index.coffee
+++ b/client/components/autocomplete_select/index.coffee
@@ -9,10 +9,10 @@ module.exports = (el, props) ->
 module.exports.AutocompleteSelect = AutocompleteSection = React.createClass
 
   getInitialState: ->
-    loading: true, value: null
+    loading: true, value: null, id: null
 
   clear: ->
-    @setState { value: null }, -> $(@refs.input.getDOMNode()).focus()
+    @setState { value: null }, => $(@refs.input.getDOMNode()).focus()
     @props.cleared?()
 
   componentDidUpdate: ->
@@ -25,20 +25,25 @@ module.exports.AutocompleteSelect = AutocompleteSection = React.createClass
     @autocomplete = new Autocomplete _.extend _.pick(@props, 'url', 'filter'),
       el: $(@refs.input?.getDOMNode())
       selected: (e, item) =>
-        @setState value: item.value
+        @setState value: item.value, id: item.id
         @props.selected? e, item
 
   render: ->
+    hidden = input { type: 'hidden', value: @state.id, name: @props.name }
     if @state.loading
-      label { className: 'bordered-input-loading' },
+      label { className: 'bordered-input-loading' }, @props.label,
         input { className: 'bordered-input' }
+        hidden
     else if @state.value
-      div { className: 'autocomplete-select-selected' }, @state.value,
-        button { className: 'autocomplete-select-remove', onClick: @clear }
+      label {}, @props.label,
+        div { className: 'autocomplete-select-selected' }, @state.value,
+          button { className: 'autocomplete-select-remove', onClick: @clear }
+        hidden
     else
-      label {},
+      label {}, @props.label,
         input {
           ref: 'input'
           className: 'bordered-input'
           placeholder: @props.placeholder
         }
+        hidden

--- a/client/components/autocomplete_select/index.styl
+++ b/client/components/autocomplete_select/index.styl
@@ -1,10 +1,14 @@
 @import '../stylus_lib'
 
 .autocomplete-select-selected
-  padding 10px
+  garamond()
+  text-transform none
+  letter-spacing 0
+  padding 5px 20px 7px 10px
   position relative
   cursor pointer
   color purple-color
+  overflow ellipsis
 
 .autocomplete-select-remove
   background transparent center center no-repeat url("/icons/remove_g.svg")

--- a/client/components/error/index.styl
+++ b/client/components/error/index.styl
@@ -35,6 +35,8 @@ global-reset()
   position relative
   &::before
     content '!'
+    avant-garde()
+    font-smoothing none
     color red-color
     width 33px
     height @width
@@ -45,7 +47,7 @@ global-reset()
     top 0
     left -55px
     text-align center
-    font-size 25px
+    font-size 29px
     font-weight bold
   h1
     avant-garde()

--- a/client/components/error/server.coffee
+++ b/client/components/error/server.coffee
@@ -17,8 +17,7 @@ render = (req, res, locals) ->
 
 errorHandler = (err, req, res, next) ->
   debug err.stack, err.message
-  if err.status in [401, 403]
-    return res.redirect '/logout'
+  return res.redirect '/logout' if err.status is 401
   render req, res, error: err
 
 module.exports = (app) ->

--- a/client/components/image_upload_form/README.md
+++ b/client/components/image_upload_form/README.md
@@ -1,0 +1,18 @@
+# Image Upload Form
+
+A styled image upload form that shows a progress bar and preview. Used to upload thumbnails to articles and various image forms in the vertical admin UI.
+
+![](https://s3.amazonaws.com/f.cl.ly/items/133F1h1b1I3i3Z3W0y0K/Image%202015-05-26%20at%205.34.55%20PM.png)
+
+## Example
+
+````coffeescript
+ImageUploadForm = require '../components/image_upload_form/index.coffee'
+
+new ImageUploadForm
+  el: $('.image-form')
+  remove: =>
+    @vertical.save thumbnail_image: null
+  done: (src) =>
+    @vertical.save thumbnail_image: src
+````

--- a/client/components/image_upload_form/form.jade
+++ b/client/components/image_upload_form/form.jade
@@ -1,0 +1,17 @@
+section.image-upload-form( data-state=(src ? 'loaded': '') )
+  h1
+    | Drag &&nbsp;
+    span.image-upload-form-drop Drop&nbsp;
+    | or&nbsp;
+    span.image-upload-form-click click&nbsp;
+    | to upload
+  h2 Up to 30MB
+  if src
+    .image-upload-form-preview( style="background-image: url(#{resize(src, { width: 800 })})" )
+  else
+    .image-upload-form-preview
+  .image-upload-form-remove ×
+  input.image-upload-form-input( type='file' )
+  input.image-upload-hidden-input( type='hidden' name=name value=src )
+  .image-upload-form-progress-container
+    .image-upload-form-progress

--- a/client/components/image_upload_form/index.coffee
+++ b/client/components/image_upload_form/index.coffee
@@ -6,17 +6,20 @@ formTemplate = -> require('./form.jade') arguments...
 
 module.exports = class ImageUploadForm extends Backbone.View
 
-  initialize: ({ @upload, @done, @src, @name }) ->
+  initialize: (@options) ->
     @render()
 
   render: ->
-    @$el.html formTemplate src: @src, name: @name
+    @$el.html formTemplate src: @options.src, name: @options.name
 
   events:
     'change .image-upload-form-input': 'upload'
-    'click .image-upload-form-remove': 'remove'
+    'click .image-upload-form-remove': 'onRemove'
+    'dragenter': 'toggleDragover'
+    'dragleave': 'toggleDragover'
 
   upload: (e) ->
+    @$('.image-upload-form').removeClass 'is-dragover'
     gemup e.target.files[0],
       key: sd.GEMINI_KEY
       progress: (percent) =>
@@ -26,16 +29,20 @@ module.exports = class ImageUploadForm extends Backbone.View
         @$el.attr 'data-state', 'uploading'
         @$('.image-upload-form-preview').css 'background-image': src
       done: (src) =>
-        img = new Image()
+        img = new Image
         img.src = src
         img.onload = =>
           @$('.image-upload-form').attr 'data-state', 'loaded'
           @$('.image-upload-form-preview').css 'background-image': "url(#{src})"
         @$('.image-upload-hidden-input').val src
-        @done?()
+        @options.done?()
 
-  remove: (e) ->
+  onRemove: (e) ->
     e.preventDefault()
+    return unless confirm 'Are you sure you want to remove this image?'
     @$('.image-upload-form').attr 'data-state', ''
     @$('.image-upload-form-preview').css 'background-image': ''
-    @remove?()
+    @options.remove?()
+
+  toggleDragover: ->
+    @$('.image-upload-form').toggleClass 'is-dragover'

--- a/client/components/image_upload_form/index.coffee
+++ b/client/components/image_upload_form/index.coffee
@@ -1,0 +1,41 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+gemup = require 'gemup'
+sd = require('sharify').data
+formTemplate = -> require('./form.jade') arguments...
+
+module.exports = class ImageUploadForm extends Backbone.View
+
+  initialize: ({ @upload, @done, @src, @name }) ->
+    @render()
+
+  render: ->
+    @$el.html formTemplate src: @src, name: @name
+
+  events:
+    'change .image-upload-form-input': 'upload'
+    'click .image-upload-form-remove': 'remove'
+
+  upload: (e) ->
+    gemup e.target.files[0],
+      key: sd.GEMINI_KEY
+      progress: (percent) =>
+        @$('.image-upload-form').attr 'data-state', 'uploading'
+        @$('.image-upload-form-progress').css width: "#{percent * 100}%"
+      add: (src) =>
+        @$el.attr 'data-state', 'uploading'
+        @$('.image-upload-form-preview').css 'background-image': src
+      done: (src) =>
+        img = new Image()
+        img.src = src
+        img.onload = =>
+          @$('.image-upload-form').attr 'data-state', 'loaded'
+          @$('.image-upload-form-preview').css 'background-image': "url(#{src})"
+        @$('.image-upload-hidden-input').val src
+        @done?()
+
+  remove: (e) ->
+    e.preventDefault()
+    @$('.image-upload-form').attr 'data-state', ''
+    @$('.image-upload-form-preview').css 'background-image': ''
+    @remove?()

--- a/client/components/image_upload_form/index.coffee
+++ b/client/components/image_upload_form/index.coffee
@@ -35,7 +35,7 @@ module.exports = class ImageUploadForm extends Backbone.View
           @$('.image-upload-form').attr 'data-state', 'loaded'
           @$('.image-upload-form-preview').css 'background-image': "url(#{src})"
         @$('.image-upload-hidden-input').val src
-        @options.done?()
+        @options.done? src
 
   onRemove: (e) ->
     e.preventDefault()

--- a/client/components/image_upload_form/index.styl
+++ b/client/components/image_upload_form/index.styl
@@ -1,0 +1,80 @@
+@import '../stylus_lib'
+
+form-height = 150px
+
+fill-form()
+  fill-container()
+  top -2px
+  left -2px
+  width calc(100% + 4px)
+  height @width
+
+.image-upload-form
+  border 2px dashed gray-lighter-color
+  padding 10px
+  text-align center
+  position relative
+  height form-height
+  &[data-state=uploading]
+    .image-upload-form-preview, .image-upload-form-progress-container
+      display block
+  &[data-state=loaded]
+    .image-upload-form-preview, .image-upload-form-remove
+      display block
+  h1, h2
+    avant-garde(s-headline)
+    color gray-dark-color
+  h1
+    margin-top (form-height / 2 - 30px)
+  h2
+    margin-top 3px
+    color gray-color
+
+.image-upload-form-input
+  fill-form()
+  z-index 2
+  opacity 0
+  cursor pointer
+
+.image-upload-form-preview
+  fill-form()
+  background gray-lighter-color
+  z-index 1
+  display none
+
+.image-upload-form-remove
+  top -2px
+  right -2px
+  width 25px
+  height @width
+  line-height 20px
+  position absolute
+  z-index 3
+  background black
+  color white
+  font-size 27px
+  font-weight bold
+  text-align center
+  padding 1px 0 0 2px
+  display none
+  transition background-color 0.3s ease-in-out
+  cursor pointer
+  &:hover
+    background-color red-color
+
+.image-upload-form-progress-container
+  width 70%
+  margin auto
+  height 5px
+  top 50%
+  left calc(50% - 35%)
+  margin-top -(@height / 2)
+  background white
+  position absolute
+  z-index 1
+  display none
+
+.image-upload-form-progress
+  fill-container()
+  min-width 3px
+  background purple-color

--- a/client/components/image_upload_form/index.styl
+++ b/client/components/image_upload_form/index.styl
@@ -54,19 +54,19 @@ fill-form()
   display none
 
 .image-upload-form-remove
+  font-family Helvetica, Arial, sans-serif !important
   top -2px
   right -2px
-  width 25px
+  width 30px
   height @width
   line-height 20px
   position absolute
   z-index 3
   background black
   color white
-  font-size 27px
-  font-weight bold
+  font-size 26px
   text-align center
-  padding 1px 0 0 2px
+  padding 2px
   display none
   transition background-color 0.3s ease-in-out
   cursor pointer

--- a/client/components/image_upload_form/index.styl
+++ b/client/components/image_upload_form/index.styl
@@ -15,15 +15,26 @@ fill-form()
   text-align center
   position relative
   height form-height
+  &:hover
+    h1, h1, span
+      color gray-color
+    .image-upload-form-click
+      color purple-color
   &[data-state=uploading]
     .image-upload-form-preview, .image-upload-form-progress-container
       display block
   &[data-state=loaded]
     .image-upload-form-preview, .image-upload-form-remove
       display block
-  h1, h2
+  &.is-dragover
+    h1, h1, span
+      color gray-color
+    .image-upload-form-drop
+      color purple-color
+  h1, h2, span
     avant-garde(s-headline)
     color gray-dark-color
+    transition color 0.3s ease-in-out 0s
   h1
     margin-top (form-height / 2 - 30px)
   h2

--- a/client/components/image_upload_form/index.styl
+++ b/client/components/image_upload_form/index.styl
@@ -15,6 +15,7 @@ fill-form()
   text-align center
   position relative
   height form-height
+  transition border-color 0.3s ease-in-out
   &:hover
     h1, h1, span
       color gray-color
@@ -27,6 +28,7 @@ fill-form()
     .image-upload-form-preview, .image-upload-form-remove
       display block
   &.is-dragover
+    border-color purple-color
     h1, h1, span
       color gray-color
     .image-upload-form-drop

--- a/client/components/image_upload_form/index.styl
+++ b/client/components/image_upload_form/index.styl
@@ -76,7 +76,7 @@ fill-form()
 .image-upload-form-progress-container
   width 70%
   margin auto
-  height 5px
+  height 4px
   top 50%
   left calc(50% - 35%)
   margin-top -(@height / 2)
@@ -89,3 +89,4 @@ fill-form()
   fill-container()
   min-width 3px
   background purple-color
+  transition width 0.2s ease-out

--- a/client/components/image_upload_form/test/index.coffee
+++ b/client/components/image_upload_form/test/index.coffee
@@ -1,0 +1,39 @@
+_ = require 'underscore'
+benv = require 'benv'
+sinon = require 'sinon'
+Backbone = require 'backbone'
+fixtures = require '../../../../test/helpers/fixtures'
+{ resolve } = require 'path'
+
+describe 'ImageUploadForm', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose $: require('jquery')
+      Backbone.$ = $
+      ImageUploadForm = benv.requireWithJadeify(
+        resolve(__dirname, '../index')
+        ['formTemplate']
+      )
+      ImageUploadForm.__set__ 'gemup', @gemup = sinon.stub()
+      global.confirm ?= -> true
+      @view = new ImageUploadForm
+        el: $('body')
+        remove: @remove = sinon.stub()
+      done()
+
+  afterEach ->
+    benv.teardown()
+
+  describe '#upload', ->
+
+    it 'uploads to gemini', ->
+      @view.upload target: files: ['foo']
+      @gemup.args[0][0].should.equal 'foo'
+
+  describe '#onRemove', ->
+
+    it 'removes the state and callsback', ->
+      @view.onRemove preventDefault: ->
+      @view.$('.image-upload-form').attr('data-state').should.equal ''
+      @remove.called.should.be.ok

--- a/client/components/layout/stylesheets/admin_form.styl
+++ b/client/components/layout/stylesheets/admin_form.styl
@@ -11,13 +11,16 @@ gutter-size = 30px
   width 100%
   margin-bottom 20px
   display block
-  &:last-of-type
-    margin-bottom 0
-  input, textarea, .image-upload-form
+  input, textarea, .image-upload-form, .autocomplete-select-selected
     garamond(body)
     display block
     width 100%
     margin-top 5px
+
+.admin-form-left > label:last-of-type
+.admin-form-center > label:last-of-type
+.admin-form-right > label:last-of-type
+  margin-bottom 0
 
 .admin-form-left, .admin-form-right, .admin-form-center
   width 280px

--- a/client/components/layout/stylesheets/admin_form.styl
+++ b/client/components/layout/stylesheets/admin_form.styl
@@ -1,0 +1,38 @@
+//
+// A responsive 3 column grid that has labels on the left and form elements
+// on the right 2 columns. Used in the admin section of articles, in vertical
+// edit UI, and useful for generic form element containers.
+//
+
+gutter-size = 30px
+
+.admin-form-container label
+  avant-garde(s-headline)
+  width 100%
+  margin-bottom 20px
+  display block
+  &:last-of-type
+    margin-bottom 0
+  input, textarea, .image-upload-form
+    garamond(body)
+    display block
+    width 100%
+    margin-top 5px
+
+.admin-form-left, .admin-form-right, .admin-form-center
+  width 280px
+  margin-right gutter-size
+  display inline-block
+  vertical-align top
+
+.admin-form-left
+  garamond(headline)
+
+.admin-form-right
+  margin-right 0
+
+.admin-form-section
+  border-bottom 1px solid gray-lighter-color
+  padding gutter-size 0
+  &:last-of-type
+    border-bottom 0

--- a/client/components/layout/stylesheets/form_elements.styl
+++ b/client/components/layout/stylesheets/form_elements.styl
@@ -15,6 +15,7 @@
   cursor pointer
   margin 0
   vertical-align top
+  text-align center
   &:hover, &:active
     color purple-color
   &:disabled, &.is-disabled, &[data-disabled=true]
@@ -30,7 +31,11 @@
       border-color purple-color
   &.avant-garde-button-black
     background black
+    border-color black
     color white
+    &:hover, &:active, &:focus
+      background purple-color
+      border-color purple-color
   &.avant-garde-button-external-link
     position relative
     padding-right 30px

--- a/client/components/layout/stylesheets/index.styl
+++ b/client/components/layout/stylesheets/index.styl
@@ -2,6 +2,7 @@
 @import './sidebar'
 @import './form_elements'
 @import './simple_modal'
+@import './admin_form'
 
 global-reset()
 
@@ -33,8 +34,8 @@ em
   border-bottom 1px solid gray-lighter-color
 
 .max-width-container
-  max-width 700px + (35px * 2)
-  padding 0 35px
+  max-width overflow-width + 60px
+  padding 0 30px
   margin auto
 
 #layout-hamburger
@@ -66,7 +67,7 @@ em
     line-height 63px !important
     font-size 15px !important
 
-// TODO: Move to artsy-ezel-components
+// Responsive pagination styling. TODO: Move to artsy-ezel-components
 @media (max-width: 600px)
   .bordered-pagination
     position relative

--- a/client/components/layout/stylesheets/index.styl
+++ b/client/components/layout/stylesheets/index.styl
@@ -30,7 +30,7 @@ em
 .page-header
   avant-garde()
   font-size default-avant-garde-font-size
-  padding 25px 0
+  padding 20px 0
   border-bottom 1px solid gray-lighter-color
 
 .max-width-container

--- a/client/components/layout/stylesheets/sidebar.styl
+++ b/client/components/layout/stylesheets/sidebar.styl
@@ -16,8 +16,7 @@ triangle-size = 12px
   a:not(#layout-sidebar-home), #layout-sidebar-profile
     display block
     margin-top 40px
-    avant-garde()
-    font-size 10px
+    avant-garde(s-headline)
     color gray-dark-color
     transition color 0.3s
     text-decoration none
@@ -70,7 +69,7 @@ triangle-size = 12px
     opacity 0.8
   #layout-sidebar-profile-menu
     position absolute
-    width 220px
+    width 232px
     background black
     left sidebar-width
     border-left 20px solid white

--- a/client/components/layout/templates/sidebar.jade
+++ b/client/components/layout/templates/sidebar.jade
@@ -19,6 +19,11 @@
       include ../public/icons/layout_published.svg
       br
       | Published
+    a( href='/verticals'
+       class=(sd.URL == '/verticals' ? 'is-active' : '') )
+      include ../public/icons/layout_published.svg
+      br
+      | Verticals
     #layout-sidebar-profile
       img( src=user.get('profile_icon_url') )
       br

--- a/client/components/paginated_list/README.md
+++ b/client/components/paginated_list/README.md
@@ -1,0 +1,13 @@
+# Paginated List
+
+A simple paginated list where the list items have a thumbnail, title, and subtitle. Re-used between the articles and verticals list view.
+
+## Example
+
+Include the mixin and indicate arguments (currentPage, totalPages, items, paginationParams). `items` is an array of hashes that look like `{ imgSrc: '', title: '', subtitle: '', href: '' }`.
+
+````jade
+include ../components/paginated_list/index
+
++paginated-list(2, 10, articles.map(...), '?published=' + published + '&')
+````

--- a/client/components/paginated_list/index.jade
+++ b/client/components/paginated_list/index.jade
@@ -1,0 +1,17 @@
+include ../../../node_modules/artsy-ezel-components/pagination/paginator
+
+mixin paginated-list(currentPage, totalPages, items, paginationParams)
+  for item in items
+    section.paginated-list-item
+      a( href=item.href )
+        if item.imgSrc
+          .paginated-list-img( style="background-image: url(#{item.imgSrc})" )
+        else
+          .paginated-list-missing-img Missing Thumbnail
+        .paginated-list-text-container
+          if item.title
+            h1= item.title
+          else
+            h1.paginated-list-missing-title Missing Title
+          h2= item.subtitle
+  +paginate(currentPage, totalPages, paginationParams)

--- a/client/components/paginated_list/index.styl
+++ b/client/components/paginated_list/index.styl
@@ -1,0 +1,49 @@
+@import '../stylus_lib'
+
+thumbnail-height = 90px
+thumbnail-width = 145px
+
+.paginated-list-item
+  clearfix()
+  border-bottom 1px solid gray-lighter-color
+  padding 20px 0
+  cursor pointer
+  transition opacity 0.2s ease-in-out
+  &:hover
+    opacity 0.7
+  &:last-of-type
+    border-bottom 0
+  .paginated-list-img, .paginated-list-missing-img
+    width thumbnail-width
+    margin-right 20px
+    vertical-align middle
+    height thumbnail-height
+    display inline-block
+  .paginated-list-img, .paginated-list-text-container
+    display inline-block
+    vertical-align middle
+  h1
+    garamond(l-body)
+    margin-bottom 5px
+  h2
+    avant-garde(s-headline)
+
+.paginated-list-text-container
+  width "calc(100% - %s)" % (thumbnail-width + 20px)
+  h1, h2
+    overflow ellipsis
+
+.paginated-list-img
+  background center center gray-lighter-color
+  background-size cover
+
+.paginated-list-missing-img
+  avant-garde(s-headline)
+  text-align center
+  color gray-dark-color
+  position relative
+  padding (thumbnail-height / 2) - 15px
+  background gray-lighter-color
+
+.paginated-list-missing-title
+  color gray-dark-color

--- a/client/lib/setup/index.coffee
+++ b/client/lib/setup/index.coffee
@@ -51,6 +51,7 @@ module.exports = (app) ->
   app.use ua
 
   # Mount apps
+  app.use require '../../apps/verticals'
   app.use require '../../apps/article_list'
   app.use require '../../apps/edit'
   app.use require '../../apps/impersonate'

--- a/client/lib/view_helpers.coffee
+++ b/client/lib/view_helpers.coffee
@@ -7,4 +7,5 @@ sd = require('sharify').data
 
 @moment = require 'moment'
 @_ = require 'underscore'
+@_s = require 'underscore.string'
 { @crop, @resize, @fill } = require('embedly-view-helpers')(sd.EMBEDLY_KEY)

--- a/client/models/vertical.coffee
+++ b/client/models/vertical.coffee
@@ -1,0 +1,7 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+sd = require('sharify').data
+
+module.exports = class Vertical extends Backbone.Model
+
+  urlRoot: "#{sd.API_URL}/verticals"

--- a/client/models/vertical.coffee
+++ b/client/models/vertical.coffee
@@ -1,7 +1,7 @@
-_ = require 'underscore'
 Backbone = require 'backbone'
 sd = require('sharify').data
 
 module.exports = class Vertical extends Backbone.Model
 
   urlRoot: "#{sd.API_URL}/verticals"
+    

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -161,7 +161,7 @@
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -373,7 +373,7 @@
                     "delayed-stream": {
                       "version": "0.0.5",
                       "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
@@ -383,13 +383,13 @@
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
-                  "version": "1.7.0",
+                  "version": "1.7.1",
                   "from": "har-validator@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
                   "dependencies": {
                     "bluebird": {
                       "version": "2.9.26",
-                      "from": "bluebird@>=2.9.25 <3.0.0",
+                      "from": "bluebird@>=2.9.26 <3.0.0",
                       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
                     },
                     "chalk": {
@@ -457,7 +457,7 @@
                     },
                     "is-my-json-valid": {
                       "version": "2.12.0",
-                      "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                       "dependencies": {
                         "generate-function": {
@@ -661,7 +661,7 @@
             },
             "mime-types": {
               "version": "2.0.12",
-              "from": "mime-types@>=2.0.3 <2.1.0",
+              "from": "mime-types@>=2.0.11 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
@@ -1413,7 +1413,7 @@
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.40 <0.2.0",
+                      "from": "source-map@>=0.1.7 <0.2.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
@@ -1623,7 +1623,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -1824,7 +1824,6 @@
     "browserify-dev-middleware": {
       "version": "0.1.1",
       "from": "browserify-dev-middleware@*",
-      "resolved": "https://registry.npmjs.org/browserify-dev-middleware/-/browserify-dev-middleware-0.1.1.tgz",
       "dependencies": {
         "watchify": {
           "version": "3.2.1",
@@ -3128,14 +3127,14 @@
                   "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
                 },
                 "xmlbuilder": {
-                  "version": "2.6.2",
+                  "version": "2.6.4",
                   "from": "xmlbuilder@>=2.4.6",
-                  "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
+                  "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "3.5.0",
-                      "from": "lodash@>=3.5.0 <3.6.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
+                      "version": "3.9.3",
+                      "from": "lodash@>=3.5.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                     }
                   }
                 }
@@ -3174,7 +3173,7 @@
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.3.4 <2.0.0",
+          "from": "mime@1.3.4",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         }
       }
@@ -3409,7 +3408,7 @@
       "dependencies": {
         "through": {
           "version": "2.3.7",
-          "from": "through@>=2.3.6 <3.0.0",
+          "from": "through@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         },
         "esprima": {
@@ -3527,7 +3526,7 @@
         "escape-html": {
           "version": "1.0.1",
           "from": "escape-html@1.0.1",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+          "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
           "version": "1.6.0",
@@ -3802,7 +3801,7 @@
           "dependencies": {
             "acorn-globals": {
               "version": "1.0.4",
-              "from": "acorn-globals@>=1.0.0 <2.0.0",
+              "from": "acorn-globals@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
               "dependencies": {
                 "acorn": {
@@ -3990,7 +3989,7 @@
             },
             "acorn-globals": {
               "version": "1.0.4",
-              "from": "acorn-globals@>=1.0.0 <2.0.0",
+              "from": "acorn-globals@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz"
             }
           }
@@ -4004,7 +4003,7 @@
       "dependencies": {
         "through": {
           "version": "2.3.7",
-          "from": "through@>=2.3.6 <3.0.0",
+          "from": "through@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         }
       }
@@ -4577,7 +4576,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4715,7 +4714,7 @@
                 "delayed-stream": {
                   "version": "0.0.5",
                   "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
@@ -4725,13 +4724,13 @@
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
-              "version": "1.7.0",
+              "version": "1.7.1",
               "from": "har-validator@>=1.4.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "2.9.26",
-                  "from": "bluebird@>=2.9.25 <3.0.0",
+                  "from": "bluebird@>=2.9.26 <3.0.0",
                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
                 },
                 "chalk": {
@@ -4799,7 +4798,7 @@
                 },
                 "is-my-json-valid": {
                   "version": "2.12.0",
-                  "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                   "dependencies": {
                     "generate-function": {
@@ -5343,7 +5342,7 @@
                   "dependencies": {
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@>=1.0.2 <1.1.0",
+                      "from": "esprima@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     },
                     "estraverse": {
@@ -5559,14 +5558,14 @@
                   "dependencies": {
                     "through": {
                       "version": "2.3.7",
-                      "from": "through@>=2.3.4 <2.4.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "readable-stream@>=1.0.27-1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -6077,7 +6076,7 @@
                 "delayed-stream": {
                   "version": "0.0.5",
                   "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
@@ -6175,7 +6174,7 @@
         },
         "through": {
           "version": "2.3.7",
-          "from": "through@>=2.3.6 <3.0.0",
+          "from": "through@>=2.3.4 <2.4.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         },
         "uglify-js": {
@@ -6300,9 +6299,9 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.9",
+          "version": "0.4.10",
           "from": "iconv-lite@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.9.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.10.tgz"
         },
         "jsdom": {
           "version": "3.1.2",
@@ -6699,7 +6698,7 @@
                 "delayed-stream": {
                   "version": "0.0.5",
                   "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
@@ -6709,9 +6708,9 @@
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
-              "version": "1.7.0",
+              "version": "1.7.1",
               "from": "har-validator@>=1.4.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.0.0",
@@ -6752,7 +6751,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@>=1.1.0 <2.0.0",
+                          "from": "ansi-regex@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         }
                       }
@@ -6778,7 +6777,7 @@
                 },
                 "is-my-json-valid": {
                   "version": "2.12.0",
-                  "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                   "dependencies": {
                     "generate-function": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -35,9 +35,9 @@
       "resolved": "git://github.com/artsy/artsy-ezel-components.git#aa2ca5d817eeb9b5b9c64dc4545c6dd58fea8d62"
     },
     "async": {
-      "version": "0.9.2",
+      "version": "1.0.0",
       "from": "async@*",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
     },
     "backbone": {
       "version": "1.2.0",
@@ -116,9 +116,9 @@
               "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
             },
             "cssstyle": {
-              "version": "0.2.26",
+              "version": "0.2.27",
               "from": "cssstyle@>=0.2.21 <0.3.0",
-              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.26.tgz"
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.27.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
@@ -161,7 +161,7 @@
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -255,7 +255,14 @@
                 "form-data": {
                   "version": "0.2.0",
                   "from": "form-data@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    }
+                  }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
@@ -290,9 +297,9 @@
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
-                  "version": "1.1.0",
+                  "version": "1.2.0",
                   "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
@@ -327,14 +334,14 @@
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
-                      "version": "2.13.0",
+                      "version": "2.14.0",
                       "from": "hoek@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
-                      "version": "2.7.1",
+                      "version": "2.7.2",
                       "from": "boom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
@@ -366,7 +373,7 @@
                     "delayed-stream": {
                       "version": "0.0.5",
                       "from": "delayed-stream@0.0.5",
-                      "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
@@ -381,9 +388,9 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.9.25",
+                      "version": "2.9.26",
                       "from": "bluebird@>=2.9.25 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
                     },
                     "chalk": {
                       "version": "1.0.0",
@@ -502,9 +509,9 @@
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.1.0",
+                  "version": "1.2.1",
                   "from": "acorn@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                 }
               }
             },
@@ -631,14 +638,14 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "raw-body": {
-          "version": "2.0.1",
+          "version": "2.0.2",
           "from": "raw-body@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz",
           "dependencies": {
             "bytes": {
-              "version": "2.0.1",
-              "from": "bytes@2.0.1",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.0.1.tgz"
+              "version": "2.1.0",
+              "from": "bytes@2.1.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
             }
           }
         },
@@ -654,7 +661,7 @@
             },
             "mime-types": {
               "version": "2.0.12",
-              "from": "mime-types@>=2.0.11 <2.1.0",
+              "from": "mime-types@>=2.0.3 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
@@ -853,29 +860,29 @@
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
           "dependencies": {
             "browserify-aes": {
-              "version": "1.0.0",
+              "version": "1.0.1",
               "from": "browserify-aes@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
             },
             "browserify-sign": {
-              "version": "3.0.1",
+              "version": "3.0.2",
               "from": "browserify-sign@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.0.5",
+                  "from": "bn.js@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "2.0.0",
+                  "version": "2.0.1",
                   "from": "browserify-rsa@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "elliptic": {
-                  "version": "1.0.1",
-                  "from": "elliptic@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                  "version": "3.0.3",
+                  "from": "elliptic@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
@@ -883,57 +890,47 @@
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
-                      "version": "1.0.2",
+                      "version": "1.0.3",
                       "from": "hash.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                     }
                   }
                 },
                 "parse-asn1": {
-                  "version": "3.0.0",
+                  "version": "3.0.1",
                   "from": "parse-asn1@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.6",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz",
+                      "version": "2.0.3",
+                      "from": "asn1.js@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
                           "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                        },
-                        "bn.js": {
-                          "version": "2.0.5",
-                          "from": "bn.js@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                         }
                       }
-                    },
-                    "pbkdf2-compat": {
-                      "version": "3.0.2",
-                      "from": "pbkdf2-compat@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                     }
                   }
                 }
               }
             },
             "create-ecdh": {
-              "version": "2.0.0",
+              "version": "2.0.1",
               "from": "create-ecdh@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.0.5",
+                  "from": "bn.js@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                 },
                 "elliptic": {
-                  "version": "1.0.1",
-                  "from": "elliptic@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                  "version": "3.0.3",
+                  "from": "elliptic@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
@@ -941,9 +938,9 @@
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
-                      "version": "1.0.2",
+                      "version": "1.0.3",
                       "from": "hash.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                     }
                   }
                 }
@@ -972,19 +969,19 @@
               "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
-              "version": "3.0.1",
+              "version": "3.0.2",
               "from": "diffie-hellman@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.0.5",
+                  "from": "bn.js@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                 },
                 "miller-rabin": {
-                  "version": "1.1.5",
-                  "from": "miller-rabin@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                  "version": "2.0.1",
+                  "from": "miller-rabin@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
@@ -1001,46 +998,36 @@
               "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
             },
             "public-encrypt": {
-              "version": "2.0.0",
+              "version": "2.0.1",
               "from": "public-encrypt@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.0.5",
+                  "from": "bn.js@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "2.0.0",
+                  "version": "2.0.1",
                   "from": "browserify-rsa@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "parse-asn1": {
-                  "version": "3.0.0",
+                  "version": "3.0.1",
                   "from": "parse-asn1@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.6",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz",
+                      "version": "2.0.3",
+                      "from": "asn1.js@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
                           "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                        },
-                        "bn.js": {
-                          "version": "2.0.5",
-                          "from": "bn.js@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                         }
                       }
-                    },
-                    "pbkdf2-compat": {
-                      "version": "3.0.2",
-                      "from": "pbkdf2-compat@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                     }
                   }
                 }
@@ -1064,14 +1051,14 @@
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
-          "version": "1.3.8",
+          "version": "1.3.9",
           "from": "deps-sort@>=1.3.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.3",
+              "version": "1.0.4",
               "from": "JSONStream@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "1.0.0",
@@ -1084,11 +1071,6 @@
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
                 }
               }
-            },
-            "through2": {
-              "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
             }
           }
         },
@@ -1199,19 +1181,24 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
-          "version": "6.4.3",
+          "version": "6.5.0",
           "from": "insert-module-globals@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.0.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.3",
+              "version": "1.0.4",
               "from": "JSONStream@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "1.0.0",
                   "from": "jsonparse@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                },
+                "through": {
+                  "version": "2.3.7",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
                 }
               }
             },
@@ -1269,23 +1256,18 @@
                   "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                   "dependencies": {
                     "acorn": {
-                      "version": "1.1.0",
+                      "version": "1.2.1",
                       "from": "acorn@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                     }
                   }
                 }
               }
             },
             "process": {
-              "version": "0.11.0",
+              "version": "0.11.1",
               "from": "process@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.0.tgz"
-            },
-            "through": {
-              "version": "2.3.7",
-              "from": "through@>=2.3.4 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
             },
             "xtend": {
               "version": "4.0.0",
@@ -1336,14 +1318,14 @@
           }
         },
         "module-deps": {
-          "version": "3.7.13",
+          "version": "3.8.0",
           "from": "module-deps@>=3.5.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.13.tgz",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.0.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.3",
+              "version": "1.0.4",
               "from": "JSONStream@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "1.0.0",
@@ -1363,19 +1345,14 @@
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "detective": {
-              "version": "4.0.2",
+              "version": "4.1.0",
               "from": "detective@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.0.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.1.0",
+                  "version": "1.2.1",
                   "from": "acorn@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
-                },
-                "defined": {
-                  "version": "0.0.0",
-                  "from": "defined@0.0.0",
-                  "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                 },
                 "escodegen": {
                   "version": "1.6.1",
@@ -1462,6 +1439,18 @@
                 }
               }
             },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
+            },
             "resolve": {
               "version": "1.1.6",
               "from": "resolve@>=1.1.3 <2.0.0",
@@ -1477,29 +1466,22 @@
                   "from": "through2@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        }
+                      }
+                    },
                     "xtend": {
                       "version": "3.0.0",
                       "from": "xtend@>=3.0.0 <3.1.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "through2": {
-              "version": "0.4.2",
-              "from": "through2@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-              "dependencies": {
-                "xtend": {
-                  "version": "2.1.2",
-                  "from": "xtend@>=2.1.1 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                  "dependencies": {
-                    "object-keys": {
-                      "version": "0.4.0",
-                      "from": "object-keys@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
                 }
@@ -1551,7 +1533,7 @@
         },
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
+          "from": "readable-stream@>=1.0.27-1 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "dependencies": {
             "core-util-is": {
@@ -1623,14 +1605,14 @@
           }
         },
         "syntax-error": {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "from": "syntax-error@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
           "dependencies": {
             "acorn": {
-              "version": "1.1.0",
+              "version": "1.2.1",
               "from": "acorn@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
             }
           }
         },
@@ -1641,7 +1623,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -1664,9 +1646,9 @@
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
           "dependencies": {
             "process": {
-              "version": "0.11.0",
+              "version": "0.11.1",
               "from": "process@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.0.tgz"
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
             }
           }
         },
@@ -1840,9 +1822,9 @@
       }
     },
     "browserify-dev-middleware": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "from": "browserify-dev-middleware@*",
-      "resolved": "https://registry.npmjs.org/browserify-dev-middleware/-/browserify-dev-middleware-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-dev-middleware/-/browserify-dev-middleware-0.1.1.tgz",
       "dependencies": {
         "watchify": {
           "version": "3.2.1",
@@ -1855,9 +1837,9 @@
               "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.1.tgz",
               "dependencies": {
                 "JSONStream": {
-                  "version": "1.0.3",
+                  "version": "1.0.4",
                   "from": "JSONStream@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "1.0.0",
@@ -1877,9 +1859,9 @@
                   "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
                 },
                 "browser-pack": {
-                  "version": "5.0.0",
+                  "version": "5.0.1",
                   "from": "browser-pack@>=5.0.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
                   "dependencies": {
                     "combine-source-map": {
                       "version": "0.6.1",
@@ -2006,29 +1988,29 @@
                   "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
                   "dependencies": {
                     "browserify-aes": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "browserify-aes@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
                     },
                     "browserify-sign": {
-                      "version": "3.0.1",
+                      "version": "3.0.2",
                       "from": "browserify-sign@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "1.3.0",
-                          "from": "bn.js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                          "version": "2.0.5",
+                          "from": "bn.js@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                         },
                         "browserify-rsa": {
-                          "version": "2.0.0",
+                          "version": "2.0.1",
                           "from": "browserify-rsa@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                         },
                         "elliptic": {
-                          "version": "1.0.1",
-                          "from": "elliptic@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                          "version": "3.0.3",
+                          "from": "elliptic@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
@@ -2036,57 +2018,47 @@
                               "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                             },
                             "hash.js": {
-                              "version": "1.0.2",
+                              "version": "1.0.3",
                               "from": "hash.js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                             }
                           }
                         },
                         "parse-asn1": {
-                          "version": "3.0.0",
+                          "version": "3.0.1",
                           "from": "parse-asn1@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "1.0.6",
-                              "from": "asn1.js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz",
+                              "version": "2.0.3",
+                              "from": "asn1.js@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.3.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
                                   "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                                },
-                                "bn.js": {
-                                  "version": "2.0.5",
-                                  "from": "bn.js@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                                 }
                               }
-                            },
-                            "pbkdf2-compat": {
-                              "version": "3.0.2",
-                              "from": "pbkdf2-compat@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                             }
                           }
                         }
                       }
                     },
                     "create-ecdh": {
-                      "version": "2.0.0",
+                      "version": "2.0.1",
                       "from": "create-ecdh@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "1.3.0",
-                          "from": "bn.js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                          "version": "2.0.5",
+                          "from": "bn.js@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                         },
                         "elliptic": {
-                          "version": "1.0.1",
-                          "from": "elliptic@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                          "version": "3.0.3",
+                          "from": "elliptic@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
@@ -2094,9 +2066,9 @@
                               "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                             },
                             "hash.js": {
-                              "version": "1.0.2",
+                              "version": "1.0.3",
                               "from": "hash.js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                             }
                           }
                         }
@@ -2125,19 +2097,19 @@
                       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
                     },
                     "diffie-hellman": {
-                      "version": "3.0.1",
+                      "version": "3.0.2",
                       "from": "diffie-hellman@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "1.3.0",
-                          "from": "bn.js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                          "version": "2.0.5",
+                          "from": "bn.js@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                         },
                         "miller-rabin": {
-                          "version": "1.1.5",
-                          "from": "miller-rabin@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                          "version": "2.0.1",
+                          "from": "miller-rabin@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
@@ -2154,46 +2126,36 @@
                       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
                     },
                     "public-encrypt": {
-                      "version": "2.0.0",
+                      "version": "2.0.1",
                       "from": "public-encrypt@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "1.3.0",
-                          "from": "bn.js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                          "version": "2.0.5",
+                          "from": "bn.js@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                         },
                         "browserify-rsa": {
-                          "version": "2.0.0",
+                          "version": "2.0.1",
                           "from": "browserify-rsa@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                         },
                         "parse-asn1": {
-                          "version": "3.0.0",
+                          "version": "3.0.1",
                           "from": "parse-asn1@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "1.0.6",
-                              "from": "asn1.js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz",
+                              "version": "2.0.3",
+                              "from": "asn1.js@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.3.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
                                   "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                                },
-                                "bn.js": {
-                                  "version": "2.0.5",
-                                  "from": "bn.js@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                                 }
                               }
-                            },
-                            "pbkdf2-compat": {
-                              "version": "3.0.2",
-                              "from": "pbkdf2-compat@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                             }
                           }
                         }
@@ -2212,35 +2174,9 @@
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
                 },
                 "deps-sort": {
-                  "version": "1.3.8",
+                  "version": "1.3.9",
                   "from": "deps-sort@>=1.3.7 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.8.tgz",
-                  "dependencies": {
-                    "through2": {
-                      "version": "0.5.1",
-                      "from": "through2@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.17 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "3.0.0",
-                          "from": "xtend@>=3.0.0 <3.1.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz"
                 },
                 "domain-browser": {
                   "version": "1.1.4",
@@ -2345,9 +2281,9 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "insert-module-globals": {
-                  "version": "6.4.3",
+                  "version": "6.5.0",
                   "from": "insert-module-globals@>=6.4.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.0.tgz",
                   "dependencies": {
                     "combine-source-map": {
                       "version": "0.3.0",
@@ -2403,18 +2339,13 @@
                           "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                           "dependencies": {
                             "acorn": {
-                              "version": "1.1.0",
+                              "version": "1.2.1",
                               "from": "acorn@>=1.0.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                             }
                           }
                         }
                       }
-                    },
-                    "through": {
-                      "version": "2.3.7",
-                      "from": "through@>=2.3.4 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
                     }
                   }
                 },
@@ -2448,24 +2379,19 @@
                   }
                 },
                 "module-deps": {
-                  "version": "3.7.13",
+                  "version": "3.8.0",
                   "from": "module-deps@>=3.7.11 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.13.tgz",
+                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.0.tgz",
                   "dependencies": {
                     "detective": {
-                      "version": "4.0.2",
+                      "version": "4.1.0",
                       "from": "detective@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.0.tgz",
                       "dependencies": {
                         "acorn": {
-                          "version": "1.1.0",
+                          "version": "1.2.1",
                           "from": "acorn@>=1.0.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
-                        },
-                        "defined": {
-                          "version": "0.0.0",
-                          "from": "defined@0.0.0",
-                          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                         },
                         "escodegen": {
                           "version": "1.6.1",
@@ -2570,37 +2496,6 @@
                           }
                         }
                       }
-                    },
-                    "through2": {
-                      "version": "0.4.2",
-                      "from": "through2@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.17 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "2.1.2",
-                          "from": "xtend@>=2.1.1 <2.2.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                          "dependencies": {
-                            "object-keys": {
-                              "version": "0.4.0",
-                              "from": "object-keys@>=0.4.0 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-                            }
-                          }
-                        }
-                      }
                     }
                   }
                 },
@@ -2627,9 +2522,9 @@
                   "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
                 },
                 "process": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "process@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/process/-/process-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
                 },
                 "punycode": {
                   "version": "1.3.2",
@@ -2722,14 +2617,14 @@
                   }
                 },
                 "syntax-error": {
-                  "version": "1.1.3",
+                  "version": "1.1.4",
                   "from": "syntax-error@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
                   "dependencies": {
                     "acorn": {
-                      "version": "1.1.0",
+                      "version": "1.2.1",
                       "from": "acorn@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                     }
                   }
                 },
@@ -2907,9 +2802,9 @@
                               "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                             },
                             "is-dotfile": {
-                              "version": "1.0.0",
+                              "version": "1.0.1",
                               "from": "is-dotfile@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                             },
                             "is-extglob": {
                               "version": "1.0.0",
@@ -2962,9 +2857,9 @@
                   "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
                 },
                 "is-binary-path": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "is-binary-path@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "dependencies": {
                     "binary-extensions": {
                       "version": "1.3.1",
@@ -3135,6 +3030,11 @@
       "from": "bucket-assets@*",
       "resolved": "https://registry.npmjs.org/bucket-assets/-/bucket-assets-0.2.8.tgz",
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
         "commander": {
           "version": "2.8.1",
           "from": "commander@>=2.8.1 <3.0.0",
@@ -3148,9 +3048,9 @@
           }
         },
         "glob": {
-          "version": "5.0.6",
+          "version": "5.0.10",
           "from": "glob@>=5.0.5 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -3414,9 +3314,9 @@
           }
         },
         "lodash": {
-          "version": "3.9.1",
+          "version": "3.9.3",
           "from": "lodash@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.1.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         }
       }
     },
@@ -3627,7 +3527,7 @@
         "escape-html": {
           "version": "1.0.1",
           "from": "escape-html@1.0.1",
-          "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
           "version": "1.6.0",
@@ -3850,14 +3750,45 @@
       }
     },
     "jade": {
-      "version": "1.9.2",
+      "version": "1.10.0",
       "from": "jade@*",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-1.10.0.tgz",
       "dependencies": {
         "character-parser": {
           "version": "1.2.1",
           "from": "character-parser@1.2.1",
           "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
+        },
+        "clean-css": {
+          "version": "3.2.10",
+          "from": "clean-css@>=3.1.9 <4.0.0",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.2.10.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.8.1",
+              "from": "commander@>=2.8.0 <2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.2",
+              "from": "source-map@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
         },
         "commander": {
           "version": "2.6.0",
@@ -3875,9 +3806,33 @@
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.1.0",
+                  "version": "1.2.1",
                   "from": "acorn@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "jstransformer": {
+          "version": "0.0.2",
+          "from": "jstransformer@0.0.2",
+          "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
+          "dependencies": {
+            "is-promise": {
+              "version": "2.0.0",
+              "from": "is-promise@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.0.0.tgz"
+            },
+            "promise": {
+              "version": "6.1.0",
+              "from": "promise@>=6.0.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "1.0.0",
+                  "from": "asap@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
                 }
               }
             }
@@ -3962,6 +3917,62 @@
             }
           }
         },
+        "uglify-js": {
+          "version": "2.4.23",
+          "from": "uglify-js@>=2.4.19 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "source-map@0.1.34",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "from": "yargs@>=3.5.4 <3.6.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.1.0",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                },
+                "decamelize": {
+                  "version": "1.0.0",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
         "void-elements": {
           "version": "2.0.1",
           "from": "void-elements@>=2.0.1 <2.1.0",
@@ -3973,9 +3984,9 @@
           "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
           "dependencies": {
             "acorn": {
-              "version": "1.1.0",
+              "version": "1.2.1",
               "from": "acorn@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
             },
             "acorn-globals": {
               "version": "1.0.4",
@@ -3999,14 +4010,14 @@
       }
     },
     "joi": {
-      "version": "6.4.1",
+      "version": "6.4.2",
       "from": "joi@*",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.4.2.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.13.0",
+          "version": "2.14.0",
           "from": "hoek@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
@@ -4220,7 +4231,7 @@
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.26 <1.1.0",
+              "from": "readable-stream@>=1.0.27-1 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -4279,14 +4290,14 @@
       }
     },
     "newrelic": {
-      "version": "1.19.1",
+      "version": "1.19.2",
       "from": "newrelic@*",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.19.2.tgz",
       "dependencies": {
         "json-stringify-safe": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "from": "json-stringify-safe@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "https-proxy-agent": {
           "version": "0.3.5",
@@ -4566,7 +4577,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4586,7 +4597,14 @@
             "form-data": {
               "version": "0.2.0",
               "from": "form-data@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                }
+              }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
@@ -4621,9 +4639,9 @@
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
-              "version": "1.1.0",
+              "version": "1.2.0",
               "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
@@ -4658,14 +4676,14 @@
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.13.0",
+                  "version": "2.14.0",
                   "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                 },
                 "boom": {
-                  "version": "2.7.1",
+                  "version": "2.7.2",
                   "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
@@ -4697,7 +4715,7 @@
                 "delayed-stream": {
                   "version": "0.0.5",
                   "from": "delayed-stream@0.0.5",
-                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
@@ -4712,9 +4730,9 @@
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
               "dependencies": {
                 "bluebird": {
-                  "version": "2.9.25",
+                  "version": "2.9.26",
                   "from": "bluebird@>=2.9.25 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
                 },
                 "chalk": {
                   "version": "1.0.0",
@@ -4738,7 +4756,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         },
                         "get-stdin": {
@@ -4755,7 +4773,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         }
                       }
@@ -4820,9 +4838,9 @@
       }
     },
     "passport": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "from": "passport@*",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.2.2.tgz",
       "dependencies": {
         "passport-strategy": {
           "version": "1.0.0",
@@ -5424,9 +5442,9 @@
                       "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                       "dependencies": {
                         "acorn": {
-                          "version": "1.1.0",
+                          "version": "1.2.1",
                           "from": "acorn@>=1.0.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                         }
                       }
                     }
@@ -5548,7 +5566,7 @@
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -5652,14 +5670,14 @@
               }
             },
             "syntax-error": {
-              "version": "1.1.3",
+              "version": "1.1.4",
               "from": "syntax-error@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.1.0",
+                  "version": "1.2.1",
                   "from": "acorn@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                 }
               }
             },
@@ -6046,6 +6064,11 @@
           "from": "form-data@0.2.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
             "combined-stream": {
               "version": "0.0.7",
               "from": "combined-stream@>=0.0.4 <0.1.0",
@@ -6054,7 +6077,7 @@
                 "delayed-stream": {
                   "version": "0.0.5",
                   "from": "delayed-stream@0.0.5",
-                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
@@ -6241,9 +6264,9 @@
           }
         },
         "bluebird": {
-          "version": "2.9.25",
-          "from": "bluebird@>=2.9.25 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+          "version": "2.9.26",
+          "from": "bluebird@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
         },
         "eventsource": {
           "version": "0.1.6",
@@ -6266,9 +6289,9 @@
                       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
                     },
                     "requires-port": {
-                      "version": "0.0.0",
+                      "version": "0.0.1",
                       "from": "requires-port@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz"
                     }
                   }
                 }
@@ -6277,9 +6300,9 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.8",
+          "version": "0.4.9",
           "from": "iconv-lite@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.9.tgz"
         },
         "jsdom": {
           "version": "3.1.2",
@@ -6314,9 +6337,9 @@
               "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
             },
             "cssstyle": {
-              "version": "0.2.26",
+              "version": "0.2.27",
               "from": "cssstyle@>=0.2.21 <0.3.0",
-              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.26.tgz"
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.27.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
@@ -6417,9 +6440,9 @@
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.1.0",
+                  "version": "1.2.1",
                   "from": "acorn@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.1.tgz"
                 }
               }
             },
@@ -6563,7 +6586,14 @@
             "form-data": {
               "version": "0.2.0",
               "from": "form-data@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                }
+              }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
@@ -6630,14 +6660,14 @@
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.13.0",
+                  "version": "2.14.0",
                   "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                 },
                 "boom": {
-                  "version": "2.7.1",
+                  "version": "2.7.2",
                   "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
@@ -6669,7 +6699,7 @@
                 "delayed-stream": {
                   "version": "0.0.5",
                   "from": "delayed-stream@0.0.5",
-                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
@@ -6722,7 +6752,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         }
                       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,7 +5,7 @@
     "antigravity": {
       "version": "0.1.1",
       "from": "git://github.com/artsy/antigravity.git",
-      "resolved": "git://github.com/artsy/antigravity.git#b294932d3a98ae2ac6663835221ee13afb53bdd9"
+      "resolved": "git://github.com/artsy/antigravity.git#e3baa5a8aba2063c816b5ba63c27d10e950711cc"
     },
     "artsy-backbone-mixins": {
       "version": "0.0.20",
@@ -18,31 +18,31 @@
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.3.tgz"
         },
         "q": {
-          "version": "1.3.0",
+          "version": "1.4.1",
           "from": "q@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "qs": {
-          "version": "2.4.1",
+          "version": "2.4.2",
           "from": "qs@>=2.4.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         }
       }
     },
     "artsy-ezel-components": {
       "version": "0.0.2",
       "from": "git://github.com/artsy/artsy-ezel-components.git",
-      "resolved": "git://github.com/artsy/artsy-ezel-components.git#a9e81d625c3e9b4a84217289d48972961e9016f5"
+      "resolved": "git://github.com/artsy/artsy-ezel-components.git#aa2ca5d817eeb9b5b9c64dc4545c6dd58fea8d62"
     },
     "async": {
-      "version": "0.9.0",
+      "version": "0.9.2",
       "from": "async@*",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
     },
     "backbone": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "from": "backbone@*",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.0.tgz"
     },
     "backbone-super-sync": {
       "version": "0.0.22",
@@ -50,26 +50,26 @@
       "resolved": "https://registry.npmjs.org/backbone-super-sync/-/backbone-super-sync-0.0.22.tgz",
       "dependencies": {
         "q": {
-          "version": "1.3.0",
+          "version": "1.4.1",
           "from": "q@*",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         }
       }
     },
     "bcrypt": {
-      "version": "0.8.2",
+      "version": "0.8.3",
       "from": "bcrypt@*",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.3.tgz",
       "dependencies": {
         "bindings": {
-          "version": "1.2.0",
-          "from": "bindings@1.2.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.0.tgz"
+          "version": "1.2.1",
+          "from": "bindings@1.2.1",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "nan": {
-          "version": "1.7.0",
-          "from": "nan@1.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
+          "version": "1.8.4",
+          "from": "nan@1.8.4",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
         }
       }
     },
@@ -94,9 +94,9 @@
               "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
             },
             "contextify": {
-              "version": "0.1.13",
+              "version": "0.1.14",
               "from": "contextify@>=0.1.9 <0.2.0",
-              "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
@@ -104,9 +104,9 @@
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
-                  "version": "1.5.3",
-                  "from": "nan@>=1.5.0 <1.6.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+                  "version": "1.8.4",
+                  "from": "nan@>=1.8.4 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
             },
@@ -116,9 +116,9 @@
               "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
             },
             "cssstyle": {
-              "version": "0.2.24",
+              "version": "0.2.26",
               "from": "cssstyle@>=0.2.21 <0.3.0",
-              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.24.tgz"
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.26.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
@@ -258,19 +258,19 @@
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.0",
+                  "version": "5.0.1",
                   "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.0.10",
+                  "version": "2.0.12",
                   "from": "mime-types@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.8.0",
-                      "from": "mime-db@>=1.8.0 <1.9.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                      "version": "1.10.0",
+                      "from": "mime-db@>=1.10.0 <1.11.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                     }
                   }
                 },
@@ -280,9 +280,9 @@
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
-                  "version": "2.4.1",
+                  "version": "2.4.2",
                   "from": "qs@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
@@ -449,9 +449,9 @@
                       }
                     },
                     "is-my-json-valid": {
-                      "version": "2.10.1",
+                      "version": "2.12.0",
                       "from": "is-my-json-valid@>=2.10.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
@@ -459,9 +459,9 @@
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
-                          "version": "1.1.1",
+                          "version": "1.2.0",
                           "from": "generate-object-property@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
@@ -502,9 +502,9 @@
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.0.3",
+                  "version": "1.1.0",
                   "from": "acorn@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                 }
               }
             },
@@ -539,9 +539,9 @@
                   "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "dependencies": {
                     "prelude-ls": {
-                      "version": "1.1.1",
+                      "version": "1.1.2",
                       "from": "prelude-ls@>=1.1.1 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                     },
                     "deep-is": {
                       "version": "0.1.3",
@@ -549,9 +549,9 @@
                       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                     },
                     "wordwrap": {
-                      "version": "0.0.2",
+                      "version": "0.0.3",
                       "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "type-check": {
                       "version": "0.3.1",
@@ -589,9 +589,9 @@
       }
     },
     "body-parser": {
-      "version": "1.12.3",
+      "version": "1.12.4",
       "from": "body-parser@*",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.3.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
       "dependencies": {
         "bytes": {
           "version": "1.0.0",
@@ -615,7 +615,7 @@
         },
         "on-finished": {
           "version": "2.2.1",
-          "from": "on-finished@>=2.2.0 <2.3.0",
+          "from": "on-finished@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "dependencies": {
             "ee-first": {
@@ -626,19 +626,26 @@
           }
         },
         "qs": {
-          "version": "2.4.1",
-          "from": "qs@2.4.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+          "version": "2.4.2",
+          "from": "qs@2.4.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "raw-body": {
-          "version": "1.3.4",
-          "from": "raw-body@1.3.4",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz"
+          "version": "2.0.1",
+          "from": "raw-body@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.1.tgz",
+          "dependencies": {
+            "bytes": {
+              "version": "2.0.1",
+              "from": "bytes@2.0.1",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.0.1.tgz"
+            }
+          }
         },
         "type-is": {
-          "version": "1.6.1",
-          "from": "type-is@>=1.6.1 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
+          "version": "1.6.2",
+          "from": "type-is@>=1.6.2 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -646,14 +653,14 @@
               "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.0.10",
-              "from": "mime-types@>=2.0.10 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "version": "2.0.12",
+              "from": "mime-types@>=2.0.11 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.10.0",
+                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             }
@@ -744,9 +751,9 @@
           }
         },
         "browser-resolve": {
-          "version": "1.8.2",
+          "version": "1.9.0",
           "from": "browser-resolve@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz",
           "dependencies": {
             "resolve": {
               "version": "1.1.6",
@@ -778,9 +785,9 @@
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
             },
             "ieee754": {
-              "version": "1.1.4",
+              "version": "1.1.5",
               "from": "ieee754@>=1.1.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
             },
             "is-array": {
               "version": "1.0.1",
@@ -888,14 +895,19 @@
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.4",
+                      "version": "1.0.6",
                       "from": "asn1.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
                           "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        },
+                        "bn.js": {
+                          "version": "2.0.5",
+                          "from": "bn.js@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                         }
                       }
                     },
@@ -943,14 +955,14 @@
               "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "dependencies": {
                 "ripemd160": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "ripemd160@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                 },
                 "sha.js": {
-                  "version": "2.4.0",
+                  "version": "2.4.1",
                   "from": "sha.js@>=2.3.6 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.0.tgz"
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.1.tgz"
                 }
               }
             },
@@ -1009,14 +1021,19 @@
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.4",
+                      "version": "1.0.6",
                       "from": "asn1.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
                           "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        },
+                        "bn.js": {
+                          "version": "2.0.5",
+                          "from": "bn.js@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                         }
                       }
                     },
@@ -1047,19 +1064,19 @@
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
-          "version": "1.3.6",
+          "version": "1.3.8",
           "from": "deps-sort@>=1.3.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.8.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.10.0",
-              "from": "JSONStream@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+              "version": "1.0.3",
+              "from": "JSONStream@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "jsonparse@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
                   "version": "2.3.7",
@@ -1122,9 +1139,9 @@
               }
             },
             "minimatch": {
-              "version": "2.0.7",
+              "version": "2.0.8",
               "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -1182,19 +1199,19 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
-          "version": "6.4.0",
+          "version": "6.4.3",
           "from": "insert-module-globals@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.4.3.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.10.0",
-              "from": "JSONStream@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+              "version": "1.0.3",
+              "from": "JSONStream@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "jsonparse@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 }
               }
             },
@@ -1252,9 +1269,9 @@
                   "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                   "dependencies": {
                     "acorn": {
-                      "version": "1.0.3",
+                      "version": "1.1.0",
                       "from": "acorn@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                     }
                   }
                 }
@@ -1319,19 +1336,19 @@
           }
         },
         "module-deps": {
-          "version": "3.7.8",
+          "version": "3.7.13",
           "from": "module-deps@>=3.5.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.8.tgz",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.13.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.10.0",
-              "from": "JSONStream@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+              "version": "1.0.3",
+              "from": "JSONStream@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "jsonparse@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
                   "version": "2.3.7",
@@ -1346,14 +1363,14 @@
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "detective": {
-              "version": "4.0.1",
+              "version": "4.0.2",
               "from": "detective@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.2.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.0.3",
+                  "version": "1.1.0",
                   "from": "acorn@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                 },
                 "defined": {
                   "version": "0.0.0",
@@ -1386,9 +1403,9 @@
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
-                          "version": "1.1.1",
+                          "version": "1.1.2",
                           "from": "prelude-ls@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
@@ -1396,9 +1413,9 @@
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
-                          "version": "0.0.2",
+                          "version": "0.0.3",
                           "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
@@ -1534,7 +1551,7 @@
         },
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.27-1 <2.0.0",
+          "from": "readable-stream@>=1.0.26 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "dependencies": {
             "core-util-is": {
@@ -1611,9 +1628,9 @@
           "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.3.tgz",
           "dependencies": {
             "acorn": {
-              "version": "1.0.3",
+              "version": "1.1.0",
               "from": "acorn@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
             }
           }
         },
@@ -1642,14 +1659,14 @@
           }
         },
         "timers-browserify": {
-          "version": "1.4.0",
+          "version": "1.4.1",
           "from": "timers-browserify@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
           "dependencies": {
             "process": {
-              "version": "0.10.1",
-              "from": "process@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
+              "version": "0.11.0",
+              "from": "process@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.0.tgz"
             }
           }
         },
@@ -1708,9 +1725,9 @@
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "dependencies": {
                         "wordwrap": {
-                          "version": "0.0.2",
+                          "version": "0.0.3",
                           "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         }
                       }
                     }
@@ -1724,9 +1741,9 @@
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
             },
             "uglify-js": {
-              "version": "2.4.21",
+              "version": "2.4.23",
               "from": "uglify-js@>=2.4.0 <2.5.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.21.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
@@ -1756,9 +1773,9 @@
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.0.2",
+                      "version": "1.1.0",
                       "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "decamelize": {
                       "version": "1.0.0",
@@ -1833,19 +1850,19 @@
           "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.2.1.tgz",
           "dependencies": {
             "browserify": {
-              "version": "10.1.0",
+              "version": "10.2.1",
               "from": "browserify@>=10.0.0 <11.0.0",
-              "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.1.tgz",
               "dependencies": {
                 "JSONStream": {
-                  "version": "0.10.0",
-                  "from": "JSONStream@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+                  "version": "1.0.3",
+                  "from": "JSONStream@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
                   "dependencies": {
                     "jsonparse": {
-                      "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
-                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                      "version": "1.0.0",
+                      "from": "jsonparse@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                     },
                     "through": {
                       "version": "2.3.7",
@@ -1860,43 +1877,34 @@
                   "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
                 },
                 "browser-pack": {
-                  "version": "4.0.2",
-                  "from": "browser-pack@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.2.tgz",
+                  "version": "5.0.0",
+                  "from": "browser-pack@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.0.tgz",
                   "dependencies": {
                     "combine-source-map": {
-                      "version": "0.3.0",
-                      "from": "combine-source-map@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                      "version": "0.6.1",
+                      "from": "combine-source-map@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
                       "dependencies": {
-                        "inline-source-map": {
-                          "version": "0.3.1",
-                          "from": "inline-source-map@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-                          "dependencies": {
-                            "source-map": {
-                              "version": "0.3.0",
-                              "from": "source-map@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-                              "dependencies": {
-                                "amdefine": {
-                                  "version": "0.1.0",
-                                  "from": "amdefine@>=0.0.4",
-                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
                         "convert-source-map": {
-                          "version": "0.3.5",
-                          "from": "convert-source-map@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                          "version": "1.1.1",
+                          "from": "convert-source-map@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                        },
+                        "inline-source-map": {
+                          "version": "0.5.0",
+                          "from": "inline-source-map@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                        },
+                        "lodash.memoize": {
+                          "version": "3.0.4",
+                          "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                         },
                         "source-map": {
-                          "version": "0.1.43",
-                          "from": "source-map@>=0.1.31 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "version": "0.4.2",
+                          "from": "source-map@>=0.4.2 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
@@ -1904,30 +1912,6 @@
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
-                        }
-                      }
-                    },
-                    "through2": {
-                      "version": "0.5.1",
-                      "from": "through2@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.17 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "3.0.0",
-                          "from": "xtend@>=3.0.0 <3.1.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                         }
                       }
                     },
@@ -1939,9 +1923,9 @@
                   }
                 },
                 "browser-resolve": {
-                  "version": "1.8.2",
+                  "version": "1.9.0",
                   "from": "browser-resolve@>=1.7.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
+                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz"
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
@@ -1956,9 +1940,9 @@
                   }
                 },
                 "buffer": {
-                  "version": "3.2.1",
+                  "version": "3.2.2",
                   "from": "buffer@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.2.2.tgz",
                   "dependencies": {
                     "base64-js": {
                       "version": "0.0.8",
@@ -1966,9 +1950,9 @@
                       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                     },
                     "ieee754": {
-                      "version": "1.1.4",
+                      "version": "1.1.5",
                       "from": "ieee754@>=1.1.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
                     },
                     "is-array": {
                       "version": "1.0.1",
@@ -2064,14 +2048,19 @@
                           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "1.0.4",
+                              "version": "1.0.6",
                               "from": "asn1.js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
                                   "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                },
+                                "bn.js": {
+                                  "version": "2.0.5",
+                                  "from": "bn.js@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                                 }
                               }
                             },
@@ -2119,14 +2108,14 @@
                       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
                       "dependencies": {
                         "ripemd160": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "from": "ripemd160@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                         },
                         "sha.js": {
-                          "version": "2.4.0",
+                          "version": "2.4.1",
                           "from": "sha.js@>=2.3.6 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.0.tgz"
+                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.1.tgz"
                         }
                       }
                     },
@@ -2185,14 +2174,19 @@
                           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "1.0.4",
+                              "version": "1.0.6",
                               "from": "asn1.js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
                                   "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                },
+                                "bn.js": {
+                                  "version": "2.0.5",
+                                  "from": "bn.js@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
                                 }
                               }
                             },
@@ -2218,9 +2212,9 @@
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
                 },
                 "deps-sort": {
-                  "version": "1.3.6",
-                  "from": "deps-sort@>=1.3.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.6.tgz",
+                  "version": "1.3.8",
+                  "from": "deps-sort@>=1.3.7 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.8.tgz",
                   "dependencies": {
                     "through2": {
                       "version": "0.5.1",
@@ -2281,9 +2275,9 @@
                       }
                     },
                     "minimatch": {
-                      "version": "2.0.7",
+                      "version": "2.0.8",
                       "from": "minimatch@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
@@ -2351,9 +2345,9 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "insert-module-globals": {
-                  "version": "6.4.0",
-                  "from": "insert-module-globals@>=6.4.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.4.0.tgz",
+                  "version": "6.4.3",
+                  "from": "insert-module-globals@>=6.4.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.4.3.tgz",
                   "dependencies": {
                     "combine-source-map": {
                       "version": "0.3.0",
@@ -2409,9 +2403,9 @@
                           "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                           "dependencies": {
                             "acorn": {
-                              "version": "1.0.3",
+                              "version": "1.1.0",
                               "from": "acorn@>=1.0.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                             }
                           }
                         }
@@ -2454,19 +2448,19 @@
                   }
                 },
                 "module-deps": {
-                  "version": "3.7.8",
-                  "from": "module-deps@>=3.7.7 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.8.tgz",
+                  "version": "3.7.13",
+                  "from": "module-deps@>=3.7.11 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.13.tgz",
                   "dependencies": {
                     "detective": {
-                      "version": "4.0.1",
+                      "version": "4.0.2",
                       "from": "detective@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.2.tgz",
                       "dependencies": {
                         "acorn": {
-                          "version": "1.0.3",
+                          "version": "1.1.0",
                           "from": "acorn@>=1.0.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                         },
                         "defined": {
                           "version": "0.0.0",
@@ -2499,9 +2493,9 @@
                               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                               "dependencies": {
                                 "prelude-ls": {
-                                  "version": "1.1.1",
+                                  "version": "1.1.2",
                                   "from": "prelude-ls@>=1.1.1 <1.2.0",
-                                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                                 },
                                 "deep-is": {
                                   "version": "0.1.3",
@@ -2509,9 +2503,9 @@
                                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                                 },
                                 "wordwrap": {
-                                  "version": "0.0.2",
+                                  "version": "0.0.3",
                                   "from": "wordwrap@>=0.0.2 <0.1.0",
-                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                                 },
                                 "type-check": {
                                   "version": "0.3.1",
@@ -2676,11 +2670,6 @@
                   "from": "resolve@>=1.1.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
                 },
-                "shallow-copy": {
-                  "version": "0.0.1",
-                  "from": "shallow-copy@0.0.1",
-                  "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
-                },
                 "shasum": {
                   "version": "1.0.1",
                   "from": "shasum@>=1.0.0 <2.0.0",
@@ -2738,9 +2727,9 @@
                   "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.3.tgz",
                   "dependencies": {
                     "acorn": {
-                      "version": "1.0.3",
+                      "version": "1.1.0",
                       "from": "acorn@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                     }
                   }
                 },
@@ -2750,16 +2739,9 @@
                   "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
                 },
                 "timers-browserify": {
-                  "version": "1.4.0",
+                  "version": "1.4.1",
                   "from": "timers-browserify@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
-                  "dependencies": {
-                    "process": {
-                      "version": "0.10.1",
-                      "from": "process@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
                 },
                 "tty-browserify": {
                   "version": "0.0.0",
@@ -2869,9 +2851,9 @@
                               "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                             },
                             "repeat-element": {
-                              "version": "1.1.0",
+                              "version": "1.1.2",
                               "from": "repeat-element@>=1.1.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                             }
                           }
                         },
@@ -2985,9 +2967,9 @@
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
                   "dependencies": {
                     "binary-extensions": {
-                      "version": "1.3.0",
+                      "version": "1.3.1",
                       "from": "binary-extensions@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                     }
                   }
                 },
@@ -3012,14 +2994,14 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.2",
+                          "version": "2.6.4",
                           "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                         },
                         "sigmund": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     },
@@ -3053,14 +3035,14 @@
                   }
                 },
                 "fsevents": {
-                  "version": "0.3.5",
+                  "version": "0.3.6",
                   "from": "fsevents@>=0.3.1 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "1.5.3",
-                      "from": "nan@>=1.5.0 <1.6.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+                      "version": "1.8.4",
+                      "from": "nan@>=1.8.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                     }
                   }
                 }
@@ -3166,9 +3148,9 @@
           }
         },
         "glob": {
-          "version": "5.0.5",
+          "version": "5.0.6",
           "from": "glob@>=5.0.5 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.6.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -3188,9 +3170,9 @@
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
-              "version": "2.0.7",
+              "version": "2.0.8",
               "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -3292,7 +3274,7 @@
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@1.3.4",
+          "from": "mime@>=1.3.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         }
       }
@@ -3308,9 +3290,9 @@
           "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-1.1.0.tgz",
           "dependencies": {
             "convert-source-map": {
-              "version": "1.1.0",
+              "version": "1.1.1",
               "from": "convert-source-map@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
             }
           }
         },
@@ -3432,9 +3414,9 @@
           }
         },
         "lodash": {
-          "version": "3.8.0",
+          "version": "3.9.1",
           "from": "lodash@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.8.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.1.tgz"
         }
       }
     },
@@ -3444,14 +3426,14 @@
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.2.tgz"
     },
     "cookie-parser": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "from": "cookie-parser@*",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
       "dependencies": {
         "cookie": {
-          "version": "0.1.2",
-          "from": "cookie@0.1.2",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+          "version": "0.1.3",
+          "from": "cookie@0.1.3",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
@@ -3474,6 +3456,18 @@
               "version": "1.0.1",
               "from": "keygrip@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.1.3",
+          "from": "debug@>=2.1.0 <2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.0",
+              "from": "ms@0.7.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
             }
           }
         },
@@ -3515,7 +3509,7 @@
       "dependencies": {
         "through": {
           "version": "2.3.7",
-          "from": "through@>=2.0.0 <3.0.0",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         },
         "esprima": {
@@ -3560,14 +3554,14 @@
       }
     },
     "debug": {
-      "version": "2.1.3",
+      "version": "2.2.0",
       "from": "debug@*",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "dependencies": {
         "ms": {
-          "version": "0.7.0",
-          "from": "ms@0.7.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },
@@ -3577,31 +3571,31 @@
       "resolved": "https://registry.npmjs.org/embedly-view-helpers/-/embedly-view-helpers-1.0.0.tgz"
     },
     "express": {
-      "version": "4.12.3",
+      "version": "4.12.4",
       "from": "express@*",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.12.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.12.4.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.2.5",
-          "from": "accepts@>=1.2.5 <1.3.0",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
+          "version": "1.2.7",
+          "from": "accepts@>=1.2.7 <1.3.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.0.10",
-              "from": "mime-types@>=2.0.10 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "version": "2.0.12",
+              "from": "mime-types@>=2.0.11 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.10.0",
+                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             },
             "negotiator": {
-              "version": "0.5.1",
-              "from": "negotiator@0.5.1",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
+              "version": "0.5.3",
+              "from": "negotiator@0.5.3",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
             }
           }
         },
@@ -3627,7 +3621,7 @@
         },
         "depd": {
           "version": "1.0.1",
-          "from": "depd@>=1.0.0 <1.1.0",
+          "from": "depd@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "escape-html": {
@@ -3636,9 +3630,9 @@
           "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
-          "version": "1.5.1",
-          "from": "etag@>=1.5.1 <1.6.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+          "version": "1.6.0",
+          "from": "etag@>=1.6.0 <1.7.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
           "dependencies": {
             "crc": {
               "version": "3.2.1",
@@ -3648,14 +3642,14 @@
           }
         },
         "finalhandler": {
-          "version": "0.3.4",
-          "from": "finalhandler@0.3.4",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz"
+          "version": "0.3.6",
+          "from": "finalhandler@0.3.6",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.6.tgz"
         },
         "fresh": {
           "version": "0.2.4",
           "from": "fresh@0.2.4",
-          "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.0",
@@ -3669,7 +3663,7 @@
         },
         "on-finished": {
           "version": "2.2.1",
-          "from": "on-finished@>=2.2.0 <2.3.0",
+          "from": "on-finished@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "dependencies": {
             "ee-first": {
@@ -3687,12 +3681,12 @@
         "path-to-regexp": {
           "version": "0.1.3",
           "from": "path-to-regexp@0.1.3",
-          "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
         },
         "proxy-addr": {
-          "version": "1.0.7",
-          "from": "proxy-addr@>=1.0.7 <1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.7.tgz",
+          "version": "1.0.8",
+          "from": "proxy-addr@>=1.0.8 <1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
@@ -3700,16 +3694,16 @@
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
-              "version": "0.1.9",
-              "from": "ipaddr.js@0.1.9",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz"
+              "version": "1.0.1",
+              "from": "ipaddr.js@1.0.1",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.1.tgz"
             }
           }
         },
         "qs": {
-          "version": "2.4.1",
-          "from": "qs@2.4.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+          "version": "2.4.2",
+          "from": "qs@2.4.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "range-parser": {
           "version": "1.0.2",
@@ -3717,9 +3711,9 @@
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
         },
         "send": {
-          "version": "0.12.2",
-          "from": "send@0.12.2",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.12.2.tgz",
+          "version": "0.12.3",
+          "from": "send@0.12.3",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.3",
@@ -3732,21 +3726,21 @@
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
-              "version": "0.7.0",
-              "from": "ms@0.7.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "serve-static": {
-          "version": "1.9.2",
-          "from": "serve-static@>=1.9.2 <1.10.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz"
+          "version": "1.9.3",
+          "from": "serve-static@>=1.9.3 <1.10.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz"
         },
         "type-is": {
-          "version": "1.6.1",
-          "from": "type-is@>=1.6.1 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
+          "version": "1.6.2",
+          "from": "type-is@>=1.6.2 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -3754,14 +3748,14 @@
               "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.0.10",
-              "from": "mime-types@>=2.0.10 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "version": "2.0.12",
+              "from": "mime-types@>=2.0.11 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.10.0",
+                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             }
@@ -3834,9 +3828,9 @@
       }
     },
     "html-janitor": {
-      "version": "1.1.0",
+      "version": "2.0.0",
       "from": "html-janitor@*",
-      "resolved": "https://registry.npmjs.org/html-janitor/-/html-janitor-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/html-janitor/-/html-janitor-2.0.0.tgz"
     },
     "imagesloaded": {
       "version": "3.1.8",
@@ -3877,22 +3871,22 @@
           "dependencies": {
             "acorn-globals": {
               "version": "1.0.4",
-              "from": "acorn-globals@>=1.0.3 <2.0.0",
+              "from": "acorn-globals@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.0.3",
+                  "version": "1.1.0",
                   "from": "acorn@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                 }
               }
             }
           }
         },
         "mkdirp": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -3958,9 +3952,9 @@
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "dependencies": {
                     "wordwrap": {
-                      "version": "0.0.2",
+                      "version": "0.0.3",
                       "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     }
                   }
                 }
@@ -3979,13 +3973,13 @@
           "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
           "dependencies": {
             "acorn": {
-              "version": "1.0.3",
+              "version": "1.1.0",
               "from": "acorn@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
             },
             "acorn-globals": {
               "version": "1.0.4",
-              "from": "acorn-globals@>=1.0.3 <2.0.0",
+              "from": "acorn-globals@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz"
             }
           }
@@ -3993,13 +3987,13 @@
       }
     },
     "jadeify": {
-      "version": "4.2.0",
+      "version": "4.3.0",
       "from": "jadeify@*",
-      "resolved": "https://registry.npmjs.org/jadeify/-/jadeify-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/jadeify/-/jadeify-4.3.0.tgz",
       "dependencies": {
         "through": {
           "version": "2.3.7",
-          "from": "through@>=2.0.0 <3.0.0",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         }
       }
@@ -4047,9 +4041,9 @@
       "resolved": "https://registry.npmjs.org/jquery-fillwidth-lite/-/jquery-fillwidth-lite-1.0.3.tgz"
     },
     "mocha": {
-      "version": "2.2.4",
+      "version": "2.2.5",
       "from": "mocha@*",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
@@ -4069,9 +4063,9 @@
           }
         },
         "diff": {
-          "version": "1.0.8",
-          "from": "diff@1.0.8",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
+          "version": "1.4.0",
+          "from": "diff@1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
@@ -4089,14 +4083,14 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.2",
+                  "version": "2.6.4",
                   "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
@@ -4154,9 +4148,9 @@
       }
     },
     "moment": {
-      "version": "2.10.2",
+      "version": "2.10.3",
       "from": "moment@*",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.2.tgz"
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
     },
     "mongojs": {
       "version": "0.18.2",
@@ -4226,7 +4220,7 @@
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@latest",
+              "from": "readable-stream@>=1.0.26 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -4256,23 +4250,23 @@
       }
     },
     "morgan": {
-      "version": "1.5.2",
+      "version": "1.5.3",
       "from": "morgan@*",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.3.tgz",
       "dependencies": {
         "basic-auth": {
-          "version": "1.0.0",
-          "from": "basic-auth@1.0.0",
-          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
+          "version": "1.0.1",
+          "from": "basic-auth@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.1.tgz"
         },
         "depd": {
           "version": "1.0.1",
-          "from": "depd@>=1.0.0 <1.1.0",
+          "from": "depd@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "on-finished": {
           "version": "2.2.1",
-          "from": "on-finished@>=2.2.0 <2.3.0",
+          "from": "on-finished@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "dependencies": {
             "ee-first": {
@@ -4285,9 +4279,9 @@
       }
     },
     "newrelic": {
-      "version": "1.18.5",
+      "version": "1.19.1",
       "from": "newrelic@*",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.18.5.tgz",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.19.1.tgz",
       "dependencies": {
         "json-stringify-safe": {
           "version": "5.0.0",
@@ -4324,9 +4318,9 @@
           }
         },
         "semver": {
-          "version": "4.3.3",
+          "version": "4.3.4",
           "from": "semver@>=4.2.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
         },
         "yakaa": {
           "version": "1.0.1",
@@ -4355,7 +4349,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -4403,14 +4397,14 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.2",
+                      "version": "2.6.4",
                       "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -4484,9 +4478,9 @@
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
-              "version": "2.0.7",
+              "version": "2.0.8",
               "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -4595,19 +4589,19 @@
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
             },
             "json-stringify-safe": {
-              "version": "5.0.0",
+              "version": "5.0.1",
               "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.0.10",
+              "version": "2.0.12",
               "from": "mime-types@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.10.0",
+                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             },
@@ -4617,9 +4611,9 @@
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
-              "version": "2.4.1",
+              "version": "2.4.2",
               "from": "qs@>=2.4.0 <2.5.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
@@ -4719,7 +4713,7 @@
               "dependencies": {
                 "bluebird": {
                   "version": "2.9.25",
-                  "from": "bluebird@>=2.0.0 <3.0.0",
+                  "from": "bluebird@>=2.9.25 <3.0.0",
                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
                 },
                 "chalk": {
@@ -4786,9 +4780,9 @@
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.10.1",
+                  "version": "2.12.0",
                   "from": "is-my-json-valid@>=2.10.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
@@ -4796,9 +4790,9 @@
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
-                      "version": "1.1.1",
+                      "version": "1.2.0",
                       "from": "generate-object-property@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
@@ -5006,9 +5000,9 @@
       "resolved": "https://registry.npmjs.org/sharify/-/sharify-0.1.6.tgz"
     },
     "should": {
-      "version": "6.0.1",
+      "version": "6.0.3",
       "from": "should@*",
-      "resolved": "https://registry.npmjs.org/should/-/should-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/should/-/should-6.0.3.tgz",
       "dependencies": {
         "should-equal": {
           "version": "0.3.1",
@@ -5205,9 +5199,9 @@
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                 },
                 "ieee754": {
-                  "version": "1.1.4",
+                  "version": "1.1.5",
                   "from": "ieee754@>=1.1.1 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
                 }
               }
             },
@@ -5309,7 +5303,7 @@
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "minimist@>=0.0.7 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
@@ -5379,14 +5373,14 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.2",
+                      "version": "2.6.4",
                       "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -5430,9 +5424,9 @@
                       "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                       "dependencies": {
                         "acorn": {
-                          "version": "1.0.3",
+                          "version": "1.1.0",
                           "from": "acorn@>=1.0.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                         }
                       }
                     }
@@ -5652,7 +5646,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "minimist@>=0.0.7 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
@@ -5663,9 +5657,9 @@
               "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.3.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.0.3",
+                  "version": "1.1.0",
                   "from": "acorn@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                 }
               }
             },
@@ -5777,9 +5771,9 @@
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
-                              "version": "0.0.2",
+                              "version": "0.0.3",
                               "from": "wordwrap@>=0.0.2 <0.1.0",
-                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                             }
                           }
                         }
@@ -5793,9 +5787,9 @@
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
                 },
                 "uglify-js": {
-                  "version": "2.4.21",
+                  "version": "2.4.23",
                   "from": "uglify-js@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.21.tgz",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
@@ -5825,9 +5819,9 @@
                       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.0.2",
+                          "version": "1.1.0",
                           "from": "camelcase@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                         },
                         "decamelize": {
                           "version": "1.0.0",
@@ -5975,14 +5969,14 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.2",
+                  "version": "2.6.4",
                   "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             }
@@ -6025,7 +6019,7 @@
         "component-emitter": {
           "version": "1.1.2",
           "from": "component-emitter@1.1.2",
-          "resolved": "http://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
         },
         "methods": {
           "version": "1.0.1",
@@ -6065,14 +6059,14 @@
               }
             },
             "mime-types": {
-              "version": "2.0.10",
+              "version": "2.0.12",
               "from": "mime-types@>=2.0.3 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.10.0",
+                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             }
@@ -6081,7 +6075,7 @@
         "readable-stream": {
           "version": "1.0.27-1",
           "from": "readable-stream@1.0.27-1",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
@@ -6145,26 +6139,26 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.2",
+              "version": "2.6.4",
               "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
-              "version": "1.0.0",
+              "version": "1.0.1",
               "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "through": {
           "version": "2.3.7",
-          "from": "through@>=2.0.0 <3.0.0",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         },
         "uglify-js": {
-          "version": "2.4.21",
+          "version": "2.4.23",
           "from": "uglify-js@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.21.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -6194,9 +6188,9 @@
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
-                  "version": "1.0.2",
+                  "version": "1.1.0",
                   "from": "camelcase@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                 },
                 "decamelize": {
                   "version": "1.0.0",
@@ -6248,7 +6242,7 @@
         },
         "bluebird": {
           "version": "2.9.25",
-          "from": "bluebird@>=2.0.0 <3.0.0",
+          "from": "bluebird@>=2.9.25 <3.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
         },
         "eventsource": {
@@ -6298,9 +6292,9 @@
               "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
             },
             "contextify": {
-              "version": "0.1.13",
+              "version": "0.1.14",
               "from": "contextify@>=0.1.9 <0.2.0",
-              "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
@@ -6308,9 +6302,9 @@
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
-                  "version": "1.5.3",
-                  "from": "nan@>=1.5.0 <1.6.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+                  "version": "1.8.4",
+                  "from": "nan@>=1.8.4 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
             },
@@ -6320,9 +6314,9 @@
               "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
             },
             "cssstyle": {
-              "version": "0.2.24",
+              "version": "0.2.26",
               "from": "cssstyle@>=0.2.21 <0.3.0",
-              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.24.tgz"
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.26.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
@@ -6423,9 +6417,9 @@
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.0.3",
+                  "version": "1.1.0",
                   "from": "acorn@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                 }
               }
             },
@@ -6460,9 +6454,9 @@
                   "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "dependencies": {
                     "prelude-ls": {
-                      "version": "1.1.1",
+                      "version": "1.1.2",
                       "from": "prelude-ls@>=1.1.1 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                     },
                     "deep-is": {
                       "version": "0.1.3",
@@ -6470,9 +6464,9 @@
                       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                     },
                     "wordwrap": {
-                      "version": "0.0.2",
+                      "version": "0.0.3",
                       "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "type-check": {
                       "version": "0.3.1",
@@ -6529,7 +6523,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@latest",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -6572,19 +6566,19 @@
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
             },
             "json-stringify-safe": {
-              "version": "5.0.0",
+              "version": "5.0.1",
               "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.0.10",
+              "version": "2.0.12",
               "from": "mime-types@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.10.0",
+                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             },
@@ -6594,9 +6588,9 @@
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
-              "version": "2.4.1",
+              "version": "2.4.2",
               "from": "qs@>=2.4.0 <2.5.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
@@ -6753,9 +6747,9 @@
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.10.1",
+                  "version": "2.12.0",
                   "from": "is-my-json-valid@>=2.10.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
@@ -6763,9 +6757,9 @@
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
-                      "version": "1.1.1",
+                      "version": "1.2.0",
                       "from": "generate-object-property@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
@@ -6803,9 +6797,9 @@
           }
         },
         "ws": {
-          "version": "0.7.1",
+          "version": "0.7.2",
           "from": "ws@>=0.7.0 <0.8.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
           "dependencies": {
             "options": {
               "version": "0.0.6",
@@ -6818,9 +6812,9 @@
               "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
             },
             "bufferutil": {
-              "version": "1.0.1",
-              "from": "bufferutil@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.0.1.tgz",
+              "version": "1.1.0",
+              "from": "bufferutil@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.1.0.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
@@ -6828,16 +6822,16 @@
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
-                  "version": "1.6.2",
-                  "from": "nan@>=1.6.0 <1.7.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
+                  "version": "1.8.4",
+                  "from": "nan@>=1.8.0 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
             },
             "utf-8-validate": {
-              "version": "1.0.1",
-              "from": "utf-8-validate@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.0.1.tgz",
+              "version": "1.1.0",
+              "from": "utf-8-validate@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.1.0.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
@@ -6845,9 +6839,9 @@
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
-                  "version": "1.6.2",
-                  "from": "nan@>=1.6.0 <1.7.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
+                  "version": "1.8.4",
+                  "from": "nan@>=1.8.0 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
             }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -40,9 +40,9 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
     },
     "backbone": {
-      "version": "1.2.0",
-      "from": "backbone@*",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.0.tgz"
+      "version": "1.1.2",
+      "from": "backbone@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz"
     },
     "backbone-super-sync": {
       "version": "0.0.22",
@@ -100,12 +100,12 @@
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
-                  "from": "bindings@*",
+                  "from": "bindings@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
                   "version": "1.8.4",
-                  "from": "nan@>=1.8.4 <1.9.0",
+                  "from": "nan@>=1.8.0 <1.9.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
@@ -161,7 +161,7 @@
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -1413,7 +1413,7 @@
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "from": "source-map@>=0.1.40 <0.2.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
@@ -1533,7 +1533,7 @@
         },
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.27-1 <2.0.0",
+          "from": "readable-stream@>=1.0.26 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "dependencies": {
             "core-util-is": {
@@ -3173,7 +3173,7 @@
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@1.3.4",
+          "from": "mime@>=1.3.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         }
       }
@@ -3320,9 +3320,9 @@
       }
     },
     "coffee-script": {
-      "version": "1.9.2",
+      "version": "1.9.3",
       "from": "coffee-script@*",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.2.tgz"
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.3.tgz"
     },
     "cookie-parser": {
       "version": "1.3.5",
@@ -4230,7 +4230,7 @@
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.27-1 <2.0.0",
+              "from": "readable-stream@latest",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -5320,7 +5320,7 @@
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
@@ -5342,7 +5342,7 @@
                   "dependencies": {
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@>=1.0.4 <1.1.0",
+                      "from": "esprima@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     },
                     "estraverse": {
@@ -5558,7 +5558,7 @@
                   "dependencies": {
                     "through": {
                       "version": "2.3.7",
-                      "from": "through@>=2.2.7 <3.0.0",
+                      "from": "through@>=2.3.4 <2.4.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
                     }
                   }
@@ -6174,7 +6174,7 @@
         },
         "through": {
           "version": "2.3.7",
-          "from": "through@>=2.3.4 <2.4.0",
+          "from": "through@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         },
         "uglify-js": {
@@ -6545,7 +6545,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "readable-stream@latest",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "artsy-backbone-mixins": "git://github.com/artsy/artsy-backbone-mixins.git",
     "artsy-ezel-components": "git://github.com/artsy/artsy-ezel-components.git",
     "async": "*",
-    "backbone": "*",
+    "backbone": "1.1.x",
     "backbone-super-sync": "*",
     "body-parser": "*",
     "bucket-assets": "*",


### PR DESCRIPTION
This adds the vertical admin UI in Writer so editorial can CRUD Verticals. There's a lot of little refactors going on here:

* Extracted list view + pagination re-used b/t articles and verticals into a component
* Extracted the image upload form (re-used for vertical and article thumbnails) into a component
* Pulls in new modules including [typography helpers from artsy-ezel-components](https://github.com/artsy/artsy-ezel-components/pull/7)
* Allows searching articles via the `q` query param
* Adds an "admin_forms" set of stylesheets that will help style generic forms like these vertical forms (soon to refactor the article admin panel)

![cap](https://cloud.githubusercontent.com/assets/555859/7843440/aaaf75fa-0477-11e5-89a4-06363de295fa.gif)
