### PR TITLE
@kanaabe: Can explicitly indicate a Vertical as "featured" to call it out in Magazine

### DIFF
--- a/api/apps/verticals/model.coffee
+++ b/api/apps/verticals/model.coffee
@@ -34,6 +34,7 @@ schema = (->
       title: @string().allow('', null)
       url: @string().allow('', null)
   ]).allow(null)
+  featured: @boolean().default(false)
   start_at: @date().allow(null)
   end_at: @date().allow(null)
   slogan: @string().allow('',null)
@@ -43,6 +44,7 @@ querySchema = (->
   q: @string()
   limit: @number()
   offset: @number()
+  featured: @boolean()
 ).call Joi
 
 #

--- a/api/apps/verticals/model.coffee
+++ b/api/apps/verticals/model.coffee
@@ -57,7 +57,7 @@ querySchema = (->
 @where = (input, callback) ->
   Joi.validate input, querySchema, (err, input) =>
     return callback err if err
-    query = {}
+    query = _.omit input, 'q', 'limit', 'offset'
     query.title = { $regex: ///#{input.q}///i } if input.q
     cursor = db.verticals
       .find(query)

--- a/client/apps/verticals/edit.jade
+++ b/client/apps/verticals/edit.jade
@@ -4,17 +4,25 @@ mixin form-elements(items)
   each item in items
     label
       = _s.humanize(item.attr)
-      if item.type == 'input'
-        input.bordered-input( value=vertical.get(item.attr) name=item.attr )
-      else if item.type == 'date'
-        input.bordered-input(
-          value=moment(vertical.get(item.attr)).format('MM/DD/YYYY')
-          name=item.attr
-        )
-      else if item.type == 'textarea'
-        textarea.bordered-input( name=item.attr rows=4 )=vertical.get(item.attr)
-      else if item.type == 'image'
-        .verticals-image-placeholder( data-name=item.attr )
+      case item.type
+        when 'input'
+          input.bordered-input( value=vertical.get(item.attr) name=item.attr )
+        when 'checkbox'
+          .flat-checkbox
+            input(
+              checked=vertical.get(item.attr) name=item.attr type='checkbox'
+            )
+        when 'date'
+          input.bordered-input(
+            value=moment(vertical.get(item.attr)).format('MM/DD/YYYY')
+            name=item.attr
+          )
+        when 'textarea'
+          textarea.bordered-input(
+            name=item.attr rows=4
+          )=vertical.get(item.attr)
+        when 'image'
+          .verticals-image-placeholder( data-name=item.attr )
 
 mixin featured-link(i)
   - link = vertical.get('featured_links')[i]
@@ -47,8 +55,10 @@ block content
       action=(vertical.isNew() ?  "/verticals" : "/verticals/#{vertical.get('id')}")
       method='post'
     )
-      .admin-form-section
-        .admin-form-left Vertical Details
+      section.admin-form-section
+        .admin-form-left
+          h1 Vertical Details
+          h2 General details that apply to all verticals.
         .admin-form-right
           .admin-form-right-col
             +form-elements([
@@ -59,21 +69,12 @@ block content
             ])
           .admin-form-right-col
             +form-elements([
-              { attr: 'start_at', type: 'date' },
-              { attr: 'end_at', type: 'date' },
               { attr: 'thumbnail_url', type: 'image' }
             ])
-      .admin-form-section
-        .admin-form-left Partner
-        .admin-form-right
-          .admin-form-right-col
-            +form-elements([
-              { attr: 'partner_logo_url', type: 'image' },
-              { attr: 'partner_website_url', type: 'input' },
-              { attr: 'slogan', type: 'input' }
-            ])
-      .admin-form-section
-        .admin-form-left Featured Links
+      section.admin-form-section
+        .admin-form-left
+          h1 Featured Links
+          h2 Sticky links that are called out in the vertical's magazine feed and at the top of individual articles.
         .admin-form-right
           +form-elements([{ attr: 'featured_links_header', type: 'input' }])
           .admin-form-right-col
@@ -82,6 +83,28 @@ block content
           .admin-form-right-col
             +featured-link(2)
             +featured-link(3)
+      section.admin-form-section
+        .admin-form-left
+          h1 Featured on Magazine
+          h2 Verticals can be called out on the main magazine page with a banner that runs for a specified time.
+        .admin-form-right
+          .admin-form-right-col
+            +form-elements([
+              { attr: 'featured', type: 'checkbox' },
+              { attr: 'start_at', type: 'date' },
+              { attr: 'end_at', type: 'date' }
+            ])
+      section.admin-form-section
+        .admin-form-left
+          h1 Partner
+          h2 If this vertical is in partnership with someone external (like the Venice Biennale + UBS partnership).
+        .admin-form-right
+          .admin-form-right-col
+            +form-elements([
+              { attr: 'partner_logo_url', type: 'image' },
+              { attr: 'partner_website_url', type: 'input' },
+              { attr: 'slogan', type: 'input' }
+            ])
       button.avant-garde-button.avant-garde-button-black.verticals-save(
         type='submit' href="/verticals/new"
       ) Save Changes

--- a/client/apps/verticals/routes.coffee
+++ b/client/apps/verticals/routes.coffee
@@ -19,6 +19,7 @@ Vertical = require '../../models/vertical'
 @save = (req, res) ->
   data = _.pick req.body, _.identity
   data.featured_links = cleanFeaturedLinks(data.featured_links)
+  data.featured = data.featured?
   new Vertical(id: req.params.id).save data,
     headers: 'X-Access-Token': req.user?.get('access_token')
     error: res.backboneError

--- a/client/apps/verticals/test/routes.coffee
+++ b/client/apps/verticals/test/routes.coffee
@@ -20,12 +20,14 @@ describe 'routes', ->
     it 'saves the serialized form data to the vertical', ->
       @req.body =
         title: 'Foobar'
+        featured: 'on'
         featured_links: [{ title: 'foo' }, { title: 'bar' }, null, '']
       routes.save @req, @res
       Backbone.sync.args[0][1].toJSON().title.should.equal 'Foobar'
       Backbone.sync.args[0][1].toJSON().featured_links.length
         .should.equal 2
       Backbone.sync.args[0][1].toJSON().featured_links[0].title.should.equal 'foo'
+      Backbone.sync.args[0][1].toJSON().featured.should.equal true
 
     it 'does not save featured links which are empty', ->
       @req.body =

--- a/client/components/layout/stylesheets/admin_form.styl
+++ b/client/components/layout/stylesheets/admin_form.styl
@@ -13,8 +13,9 @@ gutter-size = 30px
   display block
   &:last-of-type
     margin-bottom 0
+
 .admin-form-container
-  .bordered-input, .image-upload-form, .autocomplete-select-selected
+  .bordered-input, .image-upload-form, .autocomplete-select-selected, .flat-checkbox
     garamond s-body
     display block
     width 100%
@@ -74,4 +75,7 @@ gutter-size = 30px
   .admin-form-left
     margin-bottom gutter-size
   .admin-form-section
+    padding gutter-size 0
     border-bottom 0
+  .admin-form-right-col + .admin-form-right-col
+    margin-top 20px


### PR DESCRIPTION
Halley mentioned that the Gallery Insights vertical accidentally appeared called out instead of the Venice Biennale. So we need the ability to be able to explicitly only call out certain verticals, hence the checkbox. Also re-arranged some of the admin inputs to be clearer.

![image](https://cloud.githubusercontent.com/assets/555859/8045319/7dc695f4-0e00-11e5-9755-eb7c4537c8d0.png)