### PR TITLE
@craigspaeth Adds error checking on image uploader

### DIFF
--- a/client/components/image_upload_form/form.jade
+++ b/client/components/image_upload_form/form.jade
@@ -6,12 +6,14 @@ section.image-upload-form( data-state=(src ? 'loaded': '') )
     span.image-upload-form-click click&nbsp;
     | to upload
   h2 Up to 30MB
+  .type-error Please choose .png, .jpg, or .gif
+  .size-error File is too large
   if src
     .image-upload-form-preview( style="background-image: url(#{resize(src, { width: 800 })})" )
   else
     .image-upload-form-preview
   .image-upload-form-remove ×
-  input.image-upload-form-input( type='file' )
+  input.image-upload-form-input( type='file' accept='.png,.gif,.jpeg')
   input.image-upload-hidden-input( type='hidden' name=name value=src )
   .image-upload-form-progress-container
     .image-upload-form-progress

--- a/client/components/image_upload_form/index.coffee
+++ b/client/components/image_upload_form/index.coffee
@@ -20,6 +20,16 @@ module.exports = class ImageUploadForm extends Backbone.View
 
   upload: (e) ->
     @$('.image-upload-form').removeClass 'is-dragover'
+    type = e.target.files[0]?.type
+    acceptedTypes = ['image/jpg','image/jpeg','image/gif','image/png']
+    if type not in acceptedTypes
+      @$('.image-upload-form').attr 'data-error', 'type'
+      return
+    if e.target.files[0]?.size > 30000000
+      @$('.image-upload-form').attr 'data-error', 'size'
+      return
+    @$('.image-upload-form').attr 'data-error', null
+
     gemup e.target.files[0],
       key: sd.GEMINI_KEY
       progress: (percent) =>

--- a/client/components/image_upload_form/index.styl
+++ b/client/components/image_upload_form/index.styl
@@ -21,6 +21,8 @@ fill-form()
       color gray-color
     .image-upload-form-click
       color purple-color
+    .type-error, .size-error
+      color red-light-color
   &[data-state=uploading]
     .image-upload-form-preview, .image-upload-form-progress-container
       display block
@@ -33,6 +35,8 @@ fill-form()
       color gray-color
     .image-upload-form-drop
       color purple-color
+    .type-error, .size-error
+      color red-light-color
   h1, h2, span
     avant-garde(s-headline)
     color gray-dark-color
@@ -42,6 +46,16 @@ fill-form()
   h2
     margin-top 3px
     color gray-color
+  .type-error, .size-error
+    display none
+    color red-color
+    transition color 0.3s ease-in-out 0s
+  &[data-error=type]
+    .type-error
+      display block
+  &[data-error=size]
+    .size-error
+      display block
 
 .image-upload-form-input
   fill-form()

--- a/client/components/image_upload_form/test/index.coffee
+++ b/client/components/image_upload_form/test/index.coffee
@@ -27,9 +27,17 @@ describe 'ImageUploadForm', ->
 
   describe '#upload', ->
 
+    it 'displays error when image is too large', ->
+      @view.upload target: files: [{size: 40000000, type: 'image/jpg'}]
+      $('.image-upload-form').attr('data-error').should.equal 'size'
+
+    it 'displays error when image type is incorrect', ->
+      @view.upload target: files: [{size: 300000, type: 'image/tiff'}]
+      $('.image-upload-form').attr('data-error').should.equal 'type'
+
     it 'uploads to gemini', ->
-      @view.upload target: files: ['foo']
-      @gemup.args[0][0].should.equal 'foo'
+      @view.upload target: files: [{size: 300000, type: 'image/jpg', src: 'foo'}]
+      @gemup.args[0][0].src.should.equal 'foo'
 
   describe '#onRemove', ->
 


### PR DESCRIPTION
I wasn't able to exactly replicate https://github.com/artsy/positron/issues/401 but I did experience broken thumbnail images when I tried to upload .tif

This PR checks file type and size before trying to upload to Gemini. 

![image_errors](https://cloud.githubusercontent.com/assets/2236794/8199737/68a57d1e-1488-11e5-8fac-dabe9ffceef5.gif)