### PR TITLE
@kanaabe: Save text more often

### DIFF
--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -41,6 +41,7 @@ module.exports = React.createClass
     not (nextProps.editing and @props.editing)
 
   onClickOff: ->
+    @setBody()
     @props.section.destroy() if $(@props.section.get('body')).text() is ''
 
   setBody: ->

--- a/client/apps/edit/components/section_text/test/index.coffee
+++ b/client/apps/edit/components/section_text/test/index.coffee
@@ -46,6 +46,13 @@ describe 'SectionText', ->
     @component.onClickOff()
     @component.props.section.destroy.called.should.be.ok
 
+  it 'updates the body on click off', ->
+    @component.props.section.destroy = sinon.stub()
+    @component.props.section.set body: ''
+    $(@component.refs.editable.getDOMNode()).html 'Hello'
+    @component.onClickOff()
+    @component.props.section.get('body').should.equal 'Hello'
+
   it 'doesnt update while editing b/c Scribe will jump around all weird', ->
     @component.props.editing = true
     @component.shouldComponentUpdate({ editing: true }).should.not.be.ok


### PR DESCRIPTION
Solves https://github.com/artsy/positron/issues/460 —a Writer user was having trouble saving a link in text. Turns out we're probably just simply not updating the model often enough (was on key up and clicking certain elements—but if you hyperlink something with just clicks it could avoid these events). This updates the model on clicking off of the section—which is a good action to "lock in some changes".