### PR TITLE
@kanaabe: Can query articles by organization_id

### DIFF
--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -168,6 +168,24 @@ describe 'Article', ->
             done()
         )
 
+    it 'can find articles by organization', (done) ->
+      fabricate 'users', { name: 'Molly'}, (err, @user) =>
+        fabricate 'organizations', [{
+          _id: id = ObjectId('4dc98d149a96300001003031')
+          author_ids: [@user._id]
+        }], =>
+          fabricate 'articles', [
+            { title: 'Foo', author_id: @user._id }
+            { title: 'Bar', author_id: @user._id }
+            { title: 'Baz' }
+          ], =>
+            Article.where(
+              { organization_id: id.toString() }
+              (err, { results }) ->
+                _.pluck(results, 'title').join('').should.equal 'BarFoo'
+                done()
+            )
+
   describe '#find', ->
 
     it 'finds an article by an id string', (done) ->

--- a/client/components/error/page.jade
+++ b/client/components/error/page.jade
@@ -25,12 +25,13 @@ html(lang="en")
       src="//fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js"
     )
     script( src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js" )
-    script.
-      analytics.identify("#{sd.USER.id}", {
-        email: "#{sd.USER.email}",
-        name: "#{sd.USER.name}"
-      }, { integrations: { Intercom: { user_hash: "#{sd.USER_HASH}" }}});
-      $('.error-modal-report-button').click(function() {
-        $(this).hide();
-        $('#intercom-launcher').click();
-      });
+    if sd.USER
+      script.
+        analytics.identify("#{sd.USER.id}", {
+          email: "#{sd.USER.email}",
+          name: "#{sd.USER.name}"
+        }, { integrations: { Intercom: { user_hash: "#{sd.USER_HASH}" }}});
+        $('.error-modal-report-button').click(function() {
+          $(this).hide();
+          $('#intercom-launcher').click();
+        });

--- a/doc/api.md
+++ b/doc/api.md
@@ -28,6 +28,7 @@ author_id: Query articles by their author
 artist_id: Query articles by an artist they're featured to
 artwork_id: Query articles by an artwork they're featured to
 vertical_id: Query articles by verticals
+organization: Query articles written by authors in an organization
 fair_ids: Query articles by a fair they're featured to
 show_id: Query articles by a show they're featured to
 partner_id: Query articles by the partner profile they're featured on

--- a/doc/api.md
+++ b/doc/api.md
@@ -28,7 +28,7 @@ author_id: Query articles by their author
 artist_id: Query articles by an artist they're featured to
 artwork_id: Query articles by an artwork they're featured to
 vertical_id: Query articles by verticals
-organization: Query articles written by authors in an organization
+organization_id: Query articles written by authors in an organization
 fair_ids: Query articles by a fair they're featured to
 show_id: Query articles by a show they're featured to
 partner_id: Query articles by the partner profile they're featured on


### PR DESCRIPTION
This will make it easier to create an organization page by allowing a `organizaiton_id=` param to the articles API.

Screenshot of Force PR below (coming soon). Keeping it super minimal b/c I think this page deserves a real design pass before I go replicating the user profile page.

![image](https://cloud.githubusercontent.com/assets/555859/9047018/e12f4eba-39fc-11e5-8e6e-ebb8a5ccb6ae.png)
