### PR TITLE
@kanaabe: HTML XSS sanitizing at API level

### DIFF
--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -393,6 +393,46 @@ describe 'Article', ->
         (article.fair_id?).should.not.be.ok
         done()
 
+    it 'escapes xss', (done) ->
+      body = '<h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com">Aloha</a></p>'
+      badBody = '<script>alert(foo)</script><h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com">Aloha</a></p>'
+      Article.save {
+        author_id: '5086df098523e60002000018'
+        lead_paragraph: '<p>abcd abcd</p><svg/onload=alert(1)>'
+        sections: [
+          {
+            type: 'text'
+            body: body
+          }
+          {
+            type: 'text'
+            body: badBody
+          }
+        ]
+      }, 'foo', (err, article) ->
+        article.lead_paragraph.should.equal '<p>abcd abcd</p>&lt;svg/onload=alert(1)&gt;'
+        article.sections[0].body.should.equal body
+        article.sections[1].body.should.equal '&lt;script&gt;alert(foo)&lt;/script&gt;' + body
+        done()
+
+    it 'fixes anchors urls', (done) ->
+      Article.save {
+        author_id: '5086df098523e60002000018'
+        sections: [
+          {
+            type: 'text'
+            body: '<a href="foo.com">Foo</a>'
+          }
+          {
+            type: 'text'
+            body: '<a href="www.bar.com">Foo</a>'
+          }
+        ]
+      }, 'foo', (err, article) ->
+        article.sections[0].body.should.equal '<a href="http://foo.com">Foo</a>'
+        article.sections[1].body.should.equal '<a href="http://www.bar.com">Foo</a>'
+        done()
+
   describe "#destroy", ->
 
     it 'removes an article', (done) ->

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -410,7 +410,7 @@ describe 'Article', ->
           }
         ]
       }, 'foo', (err, article) ->
-        article.lead_paragraph.should.equal '<p>abcd abcd</p>&lt;svg/onload=alert(1)&gt;'
+        article.lead_paragraph.should.equal '<p>abcd abcd</p>&lt;svg onload="alert(1)"/&gt;'
         article.sections[0].body.should.equal body
         article.sections[1].body.should.equal '&lt;script&gt;alert(foo)&lt;/script&gt;' + body
         done()

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -180,7 +180,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.8.0 <3.0.0",
+          "from": "bluebird@*",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         }
       }
@@ -740,7 +740,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.8.0 <3.0.0",
+          "from": "bluebird@*",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         }
       }
@@ -939,9 +939,9 @@
           }
         },
         "browser-resolve": {
-          "version": "1.9.1",
+          "version": "1.10.0",
           "from": "browser-resolve@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.10.0.tgz",
           "dependencies": {
             "resolve": {
               "version": "1.1.6",
@@ -2338,9 +2338,9 @@
                   }
                 },
                 "browser-resolve": {
-                  "version": "1.9.1",
+                  "version": "1.10.0",
                   "from": "browser-resolve@>=1.7.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.1.tgz"
+                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.10.0.tgz"
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
@@ -2837,9 +2837,9 @@
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     },
                     "object-keys": {
-                      "version": "1.0.7",
+                      "version": "1.0.8",
                       "from": "object-keys@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz"
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.8.tgz"
                     }
                   }
                 },
@@ -3136,7 +3136,7 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "from": "readable-stream@>=1.0.31 <2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
@@ -4583,7 +4583,7 @@
       "dependencies": {
         "through": {
           "version": "2.3.8",
-          "from": "through@>=2.0.0 <3.0.0",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "esprima": {
@@ -5265,15 +5265,15 @@
       "dependencies": {
         "through": {
           "version": "2.3.8",
-          "from": "through@>=2.0.0 <3.0.0",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         }
       }
     },
     "joi": {
-      "version": "6.9.0",
+      "version": "6.9.1",
       "from": "joi@*",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.9.1.tgz",
       "dependencies": {
         "hoek": {
           "version": "2.16.3",
@@ -5500,14 +5500,14 @@
           "resolved": "https://registry.npmjs.org/each-series/-/each-series-1.0.0.tgz"
         },
         "mongodb-core": {
-          "version": "1.2.17",
+          "version": "1.2.19",
           "from": "mongodb-core@>=1.2.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.19.tgz",
           "dependencies": {
             "bson": {
-              "version": "0.4.16",
-              "from": "bson@>=0.4.13",
-              "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.16.tgz"
+              "version": "0.4.19",
+              "from": "bson@>=0.4.19 <0.5.0",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.19.tgz"
             },
             "kerberos": {
               "version": "0.0.15",
@@ -7194,7 +7194,7 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -7447,7 +7447,7 @@
         },
         "through": {
           "version": "2.3.8",
-          "from": "through@>=2.0.0 <3.0.0",
+          "from": "through@>=2.3.4 <2.4.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "uglify-js": {
@@ -7510,6 +7510,30 @@
       "version": "3.2.2",
       "from": "underscore.string@*",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.2.tgz"
+    },
+    "xss": {
+      "version": "0.2.7",
+      "from": "xss@*",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-0.2.7.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1",
+          "from": "commander@>=2.8.0 <2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "graceful-readlink@>=1.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            }
+          }
+        },
+        "cssfilter": {
+          "version": "0.0.5",
+          "from": "cssfilter@0.0.5",
+          "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.5.tgz"
+        }
+      }
     },
     "zombie": {
       "version": "3.1.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -180,7 +180,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@*",
+          "from": "bluebird@>=2.8.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         }
       }
@@ -740,7 +740,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@*",
+          "from": "bluebird@>=2.8.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         }
       }
@@ -3136,7 +3136,7 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.0.31 <2.0.0",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
@@ -6931,7 +6931,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "superagent": "*",
     "ua-parser": "*",
     "underscore": "*",
-    "underscore.string": "*"
+    "underscore.string": "*",
+    "xss": "*"
   },
   "devDependencies": {
     "antigravity": "git://github.com/artsy/antigravity.git",


### PR DESCRIPTION
This uses [an xss sanitization module](https://github.com/leizongmin/js-xss) to escape bad HTML from articles at the API level and prevent haxorz from trying to put `alert('hi')`s in their articles via the API—saving those users who accidentally wander on to 1337fr33kn00bkiller's Artsy profile. Ideally these "text modules" have really stripped down html anyways, so I actually wish this were in place sooner if nothing else but to further clean up copypasta-ed HTML. I know some have abused the looseness of Scribe's sanitization—so hopefully this doesn't shock ppl and cause any headaches.

What's kinda neat is about this being an :sparkles: isomorphic :sparkles: javascript app is that, if necessary, we could extract this lib into a module that can be used in our [client-side Scribe sanitization plugin](https://github.com/artsy/positron/blob/master/client/apps/edit/lib/sanitizer.coffee) and give immediate feedback—e.g. avoiding someone being surprised the garbage they pasted into Writer didn't stick when they refreshed the page.