### PR TITLE
@craigspaeth Adds a descending counter for recommended number of chars in a thumbnail title

### DIFF
--- a/client/apps/edit/components/thumbnail/index.coffee
+++ b/client/apps/edit/components/thumbnail/index.coffee
@@ -12,6 +12,7 @@ module.exports = class EditThumbnail extends Backbone.View
     @article.on 'change:title', _.debounce @prefillThumbnailTitle, 3000
     @checkTitleTextarea()
     @renderThumbnailForm()
+    @updateCharCount()
 
   renderThumbnailForm: =>
     new ImageUploadForm
@@ -29,11 +30,13 @@ module.exports = class EditThumbnail extends Backbone.View
   events:
     'click .edit-use-article-title': 'useArticleTitle'
     'change .edit-title-textarea': 'checkTitleTextarea'
+    'keyup .edit-title-textarea': 'updateCharCount'
 
   useArticleTitle: (e) ->
     e?.preventDefault()
     @$('.edit-use-article-title').next().val(@article.get('title'))
     @$('.edit-use-article-title').hide()
+    @updateCharCount()
     @article.save thumbnail_title: @article.get('title')
 
   checkTitleTextarea: ->
@@ -41,3 +44,11 @@ module.exports = class EditThumbnail extends Backbone.View
       $('.edit-use-article-title').hide()
     else
       $('.edit-use-article-title').show()
+
+  updateCharCount: ->
+    textLength = 97 - $('.edit-title-textarea').val().length
+    if textLength < 0
+      $('.edit-char-count').addClass('edit-char-count-limit')
+    else
+      $('.edit-char-count').removeClass('edit-char-count-limit')
+    $('.edit-char-count').text(textLength)

--- a/client/apps/edit/components/thumbnail/index.jade
+++ b/client/apps/edit/components/thumbnail/index.jade
@@ -13,3 +13,5 @@ section#edit-thumbnail
         textarea.bordered-input.edit-title-textarea(
           placeholder="Type a title that captures your reader's attention"
         )= article.get('thumbnail_title')
+        .edit-char-count-message Remaining Characters:
+          .edit-char-count

--- a/client/apps/edit/components/thumbnail/index.styl
+++ b/client/apps/edit/components/thumbnail/index.styl
@@ -66,6 +66,16 @@ error-placeholder()
     text-decoration none
     &:hover
       border-bottom 2px solid
+  .edit-char-count
+    avant-garde s-headline
+    display inline-block
+    margin-left 5px
+  .edit-char-count-message
+    float right
+    padding-top 10px
+
+.edit-char-count-limit
+  color red-color
 
 .edit-title-textarea
   padding 15px 20px

--- a/client/apps/edit/components/thumbnail/test/index.coffee
+++ b/client/apps/edit/components/thumbnail/test/index.coffee
@@ -50,3 +50,10 @@ describe 'EditThumbnail', ->
       @view.$('.edit-title-textarea').val('foo')
       @view.checkTitleTextarea()
       @view.$('.edit-use-article-title').attr('style').should.containEql 'display: none'
+
+  describe '#updateCharCount', ->
+
+    it 'updates the count when adding text', ->
+      @view.$('.edit-title-textarea').val('Title')
+      @view.updateCharCount()
+      @view.$('.edit-char-count').text().should.containEql '92'


### PR DESCRIPTION
Warns the user when they are nearing over 97 chars which would push them to the undesired four lines seen here (added text to the original title): 
![2015-11-09_2103](https://cloud.githubusercontent.com/assets/2236794/11033300/6f4893f8-8725-11e5-967f-acead96681d9.png)

Happy Title
![2015-11-09_2058](https://cloud.githubusercontent.com/assets/2236794/11033318/8096ca58-8725-11e5-87cf-de90523e1d97.png)

Unhappy Title
![2015-11-09_2059](https://cloud.githubusercontent.com/assets/2236794/11033328/8b48197a-8725-11e5-94bf-1169aee9a036.png)

You can successfully save an article that goes over that limit, it's more of a warning for now.

Closes https://github.com/artsy/force/issues/3629