### PR TITLE
@kanaabe: Revert scrollbar

### DIFF
--- a/client/components/layout/stylesheets/sidebar.styl
+++ b/client/components/layout/stylesheets/sidebar.styl
@@ -13,12 +13,6 @@ triangle-size = 12px
   text-align center
   padding-top 20px
   z-index 5
-  overflow-y scroll
-  &::-webkit-scrollbar
-    background-color black
-    width 8px
-  &::-webkit-scrollbar-corner
-    display none
   a:not(#layout-sidebar-home), #layout-sidebar-profile
     display block
     margin-top 40px


### PR DESCRIPTION
Unfortunately b/c of the way the hover effect works for the profile icon, adding overflow: scroll to the container is hiding it e.g. how overflow:hidden does [related issue](https://github.com/artsy/positron/issues/579). I think the sidebar is growing enough now that we should actually mimic the CMS sidebar to alleviate the issue for smaller screens.

This just reverts your PR unfortunately for now b/c I couldn't find a better workaround to the menu getting hidden, and I think the ideal solutions looks like below anyways.

![image](https://cloud.githubusercontent.com/assets/555859/11128968/f99e602e-894a-11e5-81a0-4a5613193500.png)
