### PR TITLE
@jtotoole: Latest modules

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -244,7 +244,7 @@
             },
             "cssstyle": {
               "version": "0.2.30",
-              "from": "cssstyle@>=0.2.29 <0.3.0",
+              "from": "cssstyle@>=0.2.23 <0.3.0",
               "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz"
             },
             "escodegen": {
@@ -393,7 +393,7 @@
             },
             "nwmatcher": {
               "version": "1.3.6",
-              "from": "nwmatcher@>=1.3.6 <2.0.0",
+              "from": "nwmatcher@>=1.3.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.6.tgz"
             },
             "parse5": {
@@ -3258,15 +3258,15 @@
                       "from": "graceful-readlink@>= 1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     },
-                    "har-validator": {
-                      "version": "2.0.2",
-                      "from": "har-validator@~2.0.2",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
-                    },
                     "has-ansi": {
                       "version": "2.0.0",
                       "from": "has-ansi@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    },
+                    "har-validator": {
+                      "version": "2.0.2",
+                      "from": "har-validator@~2.0.2",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
                     },
                     "has-unicode": {
                       "version": "1.0.1",
@@ -3383,25 +3383,20 @@
                       "from": "node-uuid@~1.4.3",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
-                    "oauth-sign": {
-                      "version": "0.8.0",
-                      "from": "oauth-sign@~0.8.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                    },
                     "npmlog": {
                       "version": "1.2.1",
                       "from": "npmlog@~1.2.0",
                       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
                     },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
                     "once": {
                       "version": "1.1.1",
                       "from": "once@~1.1.1",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-                    },
-                    "pinkie": {
-                      "version": "1.0.0",
-                      "from": "pinkie@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
@@ -3413,20 +3408,25 @@
                       "from": "pinkie-promise@^1.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
                     },
+                    "pinkie": {
+                      "version": "1.0.0",
+                      "from": "pinkie@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                    },
                     "qs": {
                       "version": "5.2.0",
                       "from": "qs@~5.2.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                     },
-                    "request": {
-                      "version": "2.65.0",
-                      "from": "request@2.x",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
-                    },
                     "readable-stream": {
                       "version": "1.1.13",
                       "from": "readable-stream@^1.1.13",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+                    },
+                    "request": {
+                      "version": "2.65.0",
+                      "from": "request@2.x",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
                     },
                     "semver": {
                       "version": "5.0.3",
@@ -4390,9 +4390,8 @@
       }
     },
     "ezel-assets": {
-      "version": "0.0.13",
-      "from": "https://registry.npmjs.org/ezel-assets/-/ezel-assets-0.0.13.tgz",
-      "resolved": "https://registry.npmjs.org/ezel-assets/-/ezel-assets-0.0.13.tgz"
+      "version": "1.0.0",
+      "from": "ezel-assets@>=1.0.0 <2.0.0"
     },
     "fast-csv": {
       "version": "0.6.0",
@@ -5032,7 +5031,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -244,7 +244,7 @@
             },
             "cssstyle": {
               "version": "0.2.30",
-              "from": "cssstyle@>=0.2.29 <0.3.0",
+              "from": "cssstyle@>=0.2.23 <0.3.0",
               "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz"
             },
             "escodegen": {
@@ -393,7 +393,7 @@
             },
             "nwmatcher": {
               "version": "1.3.6",
-              "from": "nwmatcher@>=1.3.6 <2.0.0",
+              "from": "nwmatcher@>=1.3.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.6.tgz"
             },
             "parse5": {
@@ -1761,7 +1761,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -2376,7 +2376,7 @@
                       "dependencies": {
                         "cipher-base": {
                           "version": "1.0.2",
-                          "from": "cipher-base@>=1.0.1 <2.0.0",
+                          "from": "cipher-base@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
                         },
                         "ripemd160": {
@@ -3223,15 +3223,15 @@
                       "from": "forever-agent@~0.6.1",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
-                    "form-data": {
-                      "version": "1.0.0-rc3",
-                      "from": "form-data@~1.0.0-rc3",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
-                    },
                     "fstream": {
                       "version": "1.0.8",
                       "from": "fstream@^1.0.2",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@~1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
                     },
                     "gauge": {
                       "version": "1.2.2",
@@ -3448,15 +3448,15 @@
                       "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
-                    "strip-ansi": {
-                      "version": "3.0.0",
-                      "from": "strip-ansi@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-                    },
                     "strip-json-comments": {
                       "version": "0.1.3",
                       "from": "strip-json-comments@0.1.x",
                       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "from": "strip-ansi@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
                     },
                     "supports-color": {
                       "version": "2.0.0",
@@ -4040,7 +4040,7 @@
       "dependencies": {
         "through": {
           "version": "2.3.8",
-          "from": "through@>=2.0.0 <3.0.0",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "esprima": {
@@ -4170,7 +4170,7 @@
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@1.0.0",
+              "from": "unpipe@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
@@ -4285,7 +4285,7 @@
         },
         "type-is": {
           "version": "1.6.9",
-          "from": "type-is@>=1.6.9 <1.7.0",
+          "from": "type-is@>=1.6.6 <1.7.0",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz",
           "dependencies": {
             "media-typer": {
@@ -4391,7 +4391,7 @@
     },
     "ezel-assets": {
       "version": "0.0.13",
-      "from": "ezel-assets@0.0.13",
+      "from": "https://registry.npmjs.org/ezel-assets/-/ezel-assets-0.0.13.tgz",
       "resolved": "https://registry.npmjs.org/ezel-assets/-/ezel-assets-0.0.13.tgz"
     },
     "fast-csv": {
@@ -4783,7 +4783,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -5146,7 +5146,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "isarray": {
@@ -5336,7 +5336,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
@@ -6292,7 +6292,7 @@
                 },
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "duplexer2@>=0.0.2 <0.1.0",
+                  "from": "duplexer2@0.0.2",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
                 },
                 "minimist": {
@@ -6933,7 +6933,7 @@
         },
         "through": {
           "version": "2.3.8",
-          "from": "through@>=2.0.0 <3.0.0",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "uglify-js": {
@@ -6978,7 +6978,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -7019,7 +7019,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -7380,7 +7380,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.2.0 <4.0.0",
+          "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "mime": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -244,7 +244,7 @@
             },
             "cssstyle": {
               "version": "0.2.30",
-              "from": "cssstyle@>=0.2.23 <0.3.0",
+              "from": "cssstyle@>=0.2.29 <0.3.0",
               "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz"
             },
             "escodegen": {
@@ -393,7 +393,7 @@
             },
             "nwmatcher": {
               "version": "1.3.6",
-              "from": "nwmatcher@>=1.3.4 <2.0.0",
+              "from": "nwmatcher@>=1.3.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.6.tgz"
             },
             "parse5": {
@@ -1761,7 +1761,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -2376,7 +2376,7 @@
                       "dependencies": {
                         "cipher-base": {
                           "version": "1.0.2",
-                          "from": "cipher-base@>=1.0.0 <2.0.0",
+                          "from": "cipher-base@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
                         },
                         "ripemd160": {
@@ -3223,15 +3223,15 @@
                       "from": "forever-agent@~0.6.1",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
-                    "fstream": {
-                      "version": "1.0.8",
-                      "from": "fstream@^1.0.2",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-                    },
                     "form-data": {
                       "version": "1.0.0-rc3",
                       "from": "form-data@~1.0.0-rc3",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.8",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                     },
                     "gauge": {
                       "version": "1.2.2",
@@ -3383,30 +3383,30 @@
                       "from": "node-uuid@~1.4.3",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
-                    "npmlog": {
-                      "version": "1.2.1",
-                      "from": "npmlog@~1.2.0",
-                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
-                    },
                     "oauth-sign": {
                       "version": "0.8.0",
                       "from": "oauth-sign@~0.8.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "npmlog": {
+                      "version": "1.2.1",
+                      "from": "npmlog@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
                     },
                     "once": {
                       "version": "1.1.1",
                       "from": "once@~1.1.1",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
                     },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    },
                     "pinkie": {
                       "version": "1.0.0",
                       "from": "pinkie@^1.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "1.0.0",
@@ -3418,15 +3418,15 @@
                       "from": "qs@~5.2.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                     },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "readable-stream@^1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                    },
                     "request": {
                       "version": "2.65.0",
                       "from": "request@2.x",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@^1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
                     },
                     "semver": {
                       "version": "5.0.3",
@@ -3448,15 +3448,15 @@
                       "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
-                    "strip-json-comments": {
-                      "version": "0.1.3",
-                      "from": "strip-json-comments@0.1.x",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                    },
                     "strip-ansi": {
                       "version": "3.0.0",
                       "from": "strip-ansi@^3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "strip-json-comments@0.1.x",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                     },
                     "supports-color": {
                       "version": "2.0.0",
@@ -5032,7 +5032,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -5146,7 +5146,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "isarray": {
@@ -5336,7 +5336,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -208,9 +208,9 @@
       "resolved": "https://registry.npmjs.org/benv/-/benv-3.0.0.tgz",
       "dependencies": {
         "rewire": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "from": "rewire@>=2.3.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.0.tgz"
         },
         "jsdom": {
           "version": "7.0.2",
@@ -218,14 +218,14 @@
           "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.0.2.tgz",
           "dependencies": {
             "abab": {
-              "version": "1.0.0",
+              "version": "1.0.1",
               "from": "abab@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.1.tgz"
             },
             "acorn": {
-              "version": "2.6.2",
+              "version": "2.6.4",
               "from": "acorn@>=2.4.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.2.tgz"
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz"
             },
             "acorn-globals": {
               "version": "1.0.9",
@@ -488,9 +488,9 @@
                   }
                 },
                 "node-uuid": {
-                  "version": "1.4.4",
+                  "version": "1.4.7",
                   "from": "node-uuid@>=1.4.3 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.4.tgz"
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "qs": {
                   "version": "5.2.0",
@@ -702,9 +702,9 @@
               "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz"
             },
             "tough-cookie": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "from": "tough-cookie@>=2.2.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
             },
             "webidl-conversions": {
               "version": "2.0.1",
@@ -932,9 +932,9 @@
           }
         },
         "buffer": {
-          "version": "3.5.1",
+          "version": "3.5.2",
           "from": "buffer@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.2.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
@@ -1825,9 +1825,9 @@
       "resolved": "https://registry.npmjs.org/browserify-dev-middleware/-/browserify-dev-middleware-0.1.2.tgz",
       "dependencies": {
         "watchify": {
-          "version": "3.6.0",
+          "version": "3.6.1",
           "from": "watchify@*",
-          "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.6.1.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
@@ -2157,9 +2157,9 @@
                   }
                 },
                 "buffer": {
-                  "version": "3.5.1",
+                  "version": "3.5.2",
                   "from": "buffer@>=3.4.3 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.2.tgz",
                   "dependencies": {
                     "base64-js": {
                       "version": "0.0.8",
@@ -3138,10 +3138,10 @@
                       "from": "block-stream@*",
                       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                     },
-                    "chalk": {
-                      "version": "1.1.1",
-                      "from": "chalk@^1.1.1",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@^2.8.x",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
                     "brace-expansion": {
                       "version": "1.1.1",
@@ -3153,10 +3153,10 @@
                       "from": "caseless@~0.11.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                     },
-                    "boom": {
-                      "version": "2.10.1",
-                      "from": "boom@^2.8.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@^1.1.1",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
@@ -3178,11 +3178,6 @@
                       "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@~0.7.2",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                    },
                     "cryptiles": {
                       "version": "2.0.5",
                       "from": "cryptiles@2.x.x",
@@ -3192,6 +3187,11 @@
                       "version": "0.5.3",
                       "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                     },
                     "deep-extend": {
                       "version": "0.2.11",
@@ -3218,6 +3218,11 @@
                       "from": "extend@~3.0.0",
                       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                     },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
                     "form-data": {
                       "version": "1.0.0-rc3",
                       "from": "form-data@~1.0.0-rc3",
@@ -3228,11 +3233,6 @@
                       "from": "fstream@^1.0.2",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                     },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@~0.6.1",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                    },
                     "gauge": {
                       "version": "1.2.2",
                       "from": "gauge@~1.2.0",
@@ -3242,6 +3242,16 @@
                       "version": "2.0.0",
                       "from": "generate-function@^2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@4.1",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                     },
                     "graceful-readlink": {
                       "version": "1.0.1",
@@ -3278,20 +3288,10 @@
                       "from": "http-signature@~0.11.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
                     },
-                    "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "graceful-fs@4.1",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                    },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "inherits@*",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "generate-object-property@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
                     },
                     "ini": {
                       "version": "1.3.4",
@@ -3313,30 +3313,30 @@
                       "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@~5.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
                     "isstream": {
                       "version": "0.1.2",
                       "from": "isstream@~0.1.2",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
                       "from": "jsonpointer@2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
-                    "lodash._createpadding": {
-                      "version": "3.6.1",
-                      "from": "lodash._createpadding@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-                    },
                     "lodash._basetostring": {
                       "version": "3.0.1",
                       "from": "lodash._basetostring@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "from": "lodash._createpadding@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
                     },
                     "lodash.pad": {
                       "version": "3.1.1",
@@ -3348,6 +3348,16 @@
                       "from": "lodash.padleft@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
                     },
+                    "lodash.padright": {
+                      "version": "3.1.1",
+                      "from": "lodash.padright@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                    },
+                    "lodash.repeat": {
+                      "version": "3.0.1",
+                      "from": "lodash.repeat@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                    },
                     "mime-db": {
                       "version": "1.19.0",
                       "from": "mime-db@~1.19.0",
@@ -3357,16 +3367,6 @@
                       "version": "2.1.7",
                       "from": "mime-types@~2.1.7",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
-                    },
-                    "lodash.repeat": {
-                      "version": "3.0.1",
-                      "from": "lodash.repeat@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-                    },
-                    "lodash.padright": {
-                      "version": "3.1.1",
-                      "from": "lodash.padright@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
                     },
                     "minimist": {
                       "version": "0.0.8",
@@ -3382,6 +3382,11 @@
                       "version": "1.4.3",
                       "from": "node-uuid@~1.4.3",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                    },
+                    "npmlog": {
+                      "version": "1.2.1",
+                      "from": "npmlog@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
                     },
                     "oauth-sign": {
                       "version": "0.8.0",
@@ -3408,15 +3413,15 @@
                       "from": "pinkie-promise@^1.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
                     },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "readable-stream@^1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                    },
                     "qs": {
                       "version": "5.2.0",
                       "from": "qs@~5.2.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@^1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
                     },
                     "request": {
                       "version": "2.65.0",
@@ -3433,30 +3438,30 @@
                       "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     },
-                    "stringstream": {
-                      "version": "0.0.5",
-                      "from": "stringstream@~0.0.4",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                    },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
                       "from": "strip-ansi@^3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
                     },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "supports-color@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    },
                     "strip-json-comments": {
                       "version": "0.1.3",
                       "from": "strip-json-comments@0.1.x",
                       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     },
                     "tar": {
                       "version": "2.2.1",
@@ -3478,31 +3483,15 @@
                       "from": "uid-number@0.0.3",
                       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
                     },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@^4.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    },
                     "wrappy": {
                       "version": "1.0.1",
                       "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     },
-                    "npmlog": {
-                      "version": "1.2.1",
-                      "from": "npmlog@~1.2.0",
-                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "once": {
-                          "version": "1.3.2",
-                          "from": "once@>=1.3.0 <2.0.0"
-                        }
-                      }
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@^4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     },
                     "fstream-ignore": {
                       "version": "1.0.3",
@@ -3512,6 +3501,17 @@
                         "minimatch": {
                           "version": "3.0.0",
                           "from": "minimatch@>=3.0.0 <4.0.0"
+                        }
+                      }
+                    },
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <2.0.0"
                         }
                       }
                     },
@@ -4040,7 +4040,7 @@
       "dependencies": {
         "through": {
           "version": "2.3.8",
-          "from": "through@>=2.3.4 <2.4.0",
+          "from": "through@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "esprima": {
@@ -4170,7 +4170,7 @@
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@>=1.0.0 <1.1.0",
+              "from": "unpipe@1.0.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
@@ -4285,7 +4285,7 @@
         },
         "type-is": {
           "version": "1.6.9",
-          "from": "type-is@>=1.6.6 <1.7.0",
+          "from": "type-is@>=1.6.9 <1.7.0",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz",
           "dependencies": {
             "media-typer": {
@@ -4550,9 +4550,9 @@
           "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
         },
         "clean-css": {
-          "version": "3.4.7",
+          "version": "3.4.8",
           "from": "clean-css@>=3.1.9 <4.0.0",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.7.tgz",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.8.tgz",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
@@ -4591,9 +4591,9 @@
           "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
           "dependencies": {
             "acorn": {
-              "version": "2.6.2",
+              "version": "2.6.4",
               "from": "acorn@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.2.tgz"
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz"
             }
           }
         },
@@ -4701,9 +4701,9 @@
           }
         },
         "uglify-js": {
-          "version": "2.5.0",
+          "version": "2.6.1",
           "from": "uglify-js@>=2.4.19 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -4721,14 +4721,103 @@
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
-              "version": "3.5.4",
-              "from": "yargs@>=3.5.4 <3.6.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "version": "3.10.0",
+              "from": "yargs@>=3.10.0 <3.11.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
                   "from": "camelcase@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.2",
+                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "0.2.4",
+                          "from": "lazy-cache@>=0.2.4 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
                 },
                 "decamelize": {
                   "version": "1.1.1",
@@ -4739,11 +4828,6 @@
                   "version": "0.1.0",
                   "from": "window-size@0.1.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "wordwrap@0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             }
@@ -4770,9 +4854,9 @@
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "2.6.2",
+                  "version": "2.6.4",
                   "from": "acorn@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.2.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz"
                 }
               }
             }
@@ -4787,7 +4871,7 @@
       "dependencies": {
         "through": {
           "version": "2.3.8",
-          "from": "through@>=2.3.4 <2.4.0",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         }
       }
@@ -4900,26 +4984,14 @@
       }
     },
     "mocha": {
-      "version": "2.3.3",
+      "version": "2.3.4",
       "from": "mocha@>=2.3.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.3.4.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
           "from": "commander@2.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-        },
-        "debug": {
-          "version": "2.0.0",
-          "from": "debug@2.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.6.2",
-              "from": "ms@0.6.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-            }
-          }
         },
         "diff": {
           "version": "1.4.0",
@@ -5022,9 +5094,9 @@
           "resolved": "https://registry.npmjs.org/each-series/-/each-series-1.0.0.tgz"
         },
         "mongodb-core": {
-          "version": "1.2.21",
+          "version": "1.2.22",
           "from": "mongodb-core@>=1.2.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.21.tgz",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.22.tgz",
           "dependencies": {
             "bson": {
               "version": "0.4.19",
@@ -5233,117 +5305,9 @@
       }
     },
     "node-env-file": {
-      "version": "0.1.7",
+      "version": "0.1.8",
       "from": "node-env-file@>=0.1.7 <0.2.0",
-      "resolved": "https://registry.npmjs.org/node-env-file/-/node-env-file-0.1.7.tgz",
-      "dependencies": {
-        "chai": {
-          "version": "3.4.1",
-          "from": "chai@latest",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-3.4.1.tgz",
-          "dependencies": {
-            "assertion-error": {
-              "version": "1.0.1",
-              "from": "assertion-error@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
-            },
-            "deep-eql": {
-              "version": "0.1.3",
-              "from": "deep-eql@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-              "dependencies": {
-                "type-detect": {
-                  "version": "0.1.1",
-                  "from": "type-detect@0.1.1",
-                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-                }
-              }
-            },
-            "type-detect": {
-              "version": "1.0.0",
-              "from": "type-detect@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
-            }
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "from": "glob@>=4.3.5 <5.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.1",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "temp": {
-          "version": "0.8.3",
-          "from": "temp@>=0.8.1 <0.9.0",
-          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-          "dependencies": {
-            "os-tmpdir": {
-              "version": "1.0.1",
-              "from": "os-tmpdir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@>=2.2.6 <2.3.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "https://registry.npmjs.org/node-env-file/-/node-env-file-0.1.8.tgz"
     },
     "node-mandrill": {
       "version": "1.0.1",
@@ -5437,9 +5401,9 @@
               }
             },
             "node-uuid": {
-              "version": "1.4.4",
+              "version": "1.4.7",
               "from": "node-uuid@>=1.4.3 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.4.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "qs": {
               "version": "5.2.0",
@@ -5452,9 +5416,9 @@
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "from": "tough-cookie@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
             },
             "http-signature": {
               "version": "0.11.0",
@@ -5712,9 +5676,9 @@
           "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-0.0.3.tgz"
         },
         "node-uuid": {
-          "version": "1.4.4",
+          "version": "1.4.7",
           "from": "node-uuid@>=1.4.1 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.4.tgz"
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "stack-trace": {
           "version": "0.0.7",
@@ -5777,9 +5741,9 @@
       "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.2.0.tgz"
     },
     "scribe-editor": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "from": "scribe-editor@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/scribe-editor/-/scribe-editor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/scribe-editor/-/scribe-editor-2.1.1.tgz",
       "dependencies": {
         "lodash-amd": {
           "version": "3.5.0",
@@ -6134,7 +6098,7 @@
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
@@ -6328,7 +6292,7 @@
                 },
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
+                  "from": "duplexer2@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
                 },
                 "minimist": {
@@ -6453,7 +6417,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
@@ -6969,13 +6933,13 @@
         },
         "through": {
           "version": "2.3.8",
-          "from": "through@>=2.3.4 <2.4.0",
+          "from": "through@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "uglify-js": {
-          "version": "2.5.0",
+          "version": "2.6.1",
           "from": "uglify-js@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -6993,14 +6957,103 @@
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
-              "version": "3.5.4",
-              "from": "yargs@>=3.5.4 <3.6.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "version": "3.10.0",
+              "from": "yargs@>=3.10.0 <3.11.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
                   "from": "camelcase@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.2",
+                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "0.2.4",
+                          "from": "lazy-cache@>=0.2.4 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
                 },
                 "decamelize": {
                   "version": "1.1.1",
@@ -7011,11 +7064,6 @@
                   "version": "0.1.0",
                   "from": "window-size@0.1.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "wordwrap@0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             }
@@ -7131,9 +7179,9 @@
               "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "2.6.2",
+                  "version": "2.6.4",
                   "from": "acorn@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.2.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz"
                 }
               }
             },
@@ -7332,7 +7380,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "lodash@>=3.2.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "mime": {
@@ -7432,9 +7480,9 @@
               }
             },
             "node-uuid": {
-              "version": "1.4.4",
+              "version": "1.4.7",
               "from": "node-uuid@>=1.4.3 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.4.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "qs": {
               "version": "5.2.0",
@@ -7641,9 +7689,9 @@
           }
         },
         "tough-cookie": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "from": "tough-cookie@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
         },
         "ws": {
           "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "embedly-view-helpers": "^1.0.0",
     "express": "^4.13.3",
     "express-force-ssl": "^0.3.0",
-    "ezel-assets": "https://registry.npmjs.org/ezel-assets/-/ezel-assets-0.0.13.tgz",
     "fast-csv": "^0.6.0",
     "fs": "0.0.2",
     "glossary": "^0.1.1",
@@ -87,6 +86,7 @@
     "sqwish": "^0.2.2",
     "typeahead.js": "0.10.x",
     "uglifyify": "^3.0.1",
+    "ezel-assets": "^1.0.0",
     "zombie": "^4.1.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "embedly-view-helpers": "^1.0.0",
     "express": "^4.13.3",
     "express-force-ssl": "^0.3.0",
+    "ezel-assets": "https://registry.npmjs.org/ezel-assets/-/ezel-assets-0.0.13.tgz",
     "fast-csv": "^0.6.0",
     "fs": "0.0.2",
     "glossary": "^0.1.1",


### PR DESCRIPTION
Bumps ezel-assets too which should fail the build if it fails to compile a JS bundle.