### PR TITLE
@jtotoole: Minor design tweaks on publish scheduling

### DIFF
--- a/client/apps/article_list/index.styl
+++ b/client/apps/article_list/index.styl
@@ -104,6 +104,9 @@
   vertical-align middle
   margin 0 23px 0 15px
 
+.article-list-scheduled
+  color green-color
+
 @media (max-width: 414px)
   .article-list-item-left
     width 30%

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -308,7 +308,6 @@ module.exports = class EditAdmin extends Backbone.View
     if @article.get('scheduled_publish_at')
       @article.save scheduled_publish_at: null
     else
-      return unless confirm "Are you sure you want to schedule publication?" # TODO: Implement Artsy branded dialog
       @schedulePublish()
     @renderScheduleState()
 
@@ -327,12 +326,7 @@ module.exports = class EditAdmin extends Backbone.View
       publishTime = moment(@article.get('scheduled_publish_at')).format('HH:mm')
       @$('.edit-admin-input-time').val(publishTime)
       @$('#edit-schedule-button').addClass('edit-button-when-scheduled')
-      @$('#edit-schedule-button').text('Unschedule')
       @$('.edit-admin-input-date, .edit-admin-input-time').attr('readonly', true)
     else
       @$('#edit-schedule-button').removeClass('edit-button-when-scheduled')
-      @$('#edit-schedule-button').text('Schedule')
       @$('.edit-admin-input-date, .edit-admin-input-time').attr('readonly', false)
-
-
-

--- a/client/apps/edit/components/admin/index.jade
+++ b/client/apps/edit/components/admin/index.jade
@@ -95,14 +95,12 @@ section#edit-admin.admin-form-container.max-width-container
         #edit-admin-publish-date
           label Publish Date
           input.bordered-input.edit-admin-input-date
-        br
-        a#edit-schedule-button.avant-garde-button Schedule 
-      .admin-form-right-col
         #edit-admin-schedule-publish-time
           label Publish time
           //- Firefox + Safari don't currently support time input
           input.bordered-input.edit-admin-input-time( type='time', step=6000, placeholder='Publication time' )
-        br
+        a#edit-schedule-button.avant-garde-button
+      .admin-form-right-col
         #edit-admin-google-news
           label Exclude from Google News
           .flat-checkbox

--- a/client/apps/edit/components/admin/index.styl
+++ b/client/apps/edit/components/admin/index.styl
@@ -93,7 +93,18 @@ gutter-size = 30px
 
 .edit-admin-autocomplete-list-item
   margin-top 5px
-  
-.edit-button-when-scheduled
-  color white
-  background-color purple-color
+
+#edit-admin-publish-date, #edit-admin-schedule-publish-time
+  margin-bottom 10px
+
+#edit-schedule-button
+  width 100%
+  &::after
+    content 'Schedule'
+  &.edit-button-when-scheduled
+    &::after
+      content 'Scheduled'
+      color purple-color
+    &:hover::after
+      content 'Unschedule'
+      color red-color

--- a/client/collections/articles.coffee
+++ b/client/collections/articles.coffee
@@ -21,14 +21,9 @@ module.exports = class Articles extends Backbone.Collection
         if article.get('published_at') && article.get('published')
           "Published #{moment(article.get('published_at')).fromNow()}"
         else if article.get('scheduled_publish_at')
-          "Scheduled to be published #{moment(article.get('scheduled_publish_at')).fromNow()}"
+          "<span class='article-list-scheduled'>Scheduled to publish " +
+          "#{moment(article.get('scheduled_publish_at')).fromNow()}</span>"
         else
           "Last saved #{moment(article.get('updated_at')).fromNow()}"
       )
       href: "/articles/#{article.get('id')}/edit"
-      fontColor: (
-        if article.get('scheduled_publish_at')
-          'red'
-        else
-          'black'
-      )

--- a/client/components/paginated_list/index.jade
+++ b/client/components/paginated_list/index.jade
@@ -10,8 +10,8 @@ mixin paginated-list(currentPage, totalPages, items, paginationParams)
           .paginated-list-missing-img Missing Thumbnail
         .paginated-list-text-container
           if item.title
-            h1= item.title
+            h1!= item.title
           else
             h1.paginated-list-missing-title Missing Title
-          h2( style="color: #{item.fontColor}" )= item.subtitle
+          h2!= item.subtitle
   +paginate(currentPage, totalPages, paginationParams)


### PR DESCRIPTION
B/c I'm a pixel pusher I made some small design tweaks to the schedule to publish feature.
1. Changed scheduled to be published to an Artsy green b/c to me red seemed like it was an error that needed to be handled

![image](https://cloud.githubusercontent.com/assets/555859/11193375/6418a2ee-8c74-11e5-853b-af4238ce7bd3.png)
1. Moved forms to same row and adjusted the button state to look more like our follow buttons on the site.

To be scheduled

![image](https://cloud.githubusercontent.com/assets/555859/11193419/8e45e2e8-8c74-11e5-9c2c-41b5ed79279b.png)

Scheduled

![image](https://cloud.githubusercontent.com/assets/555859/11193394/7b9294ac-8c74-11e5-9d5b-e6477f0af74b.png)

Hover

![image](https://cloud.githubusercontent.com/assets/555859/11193402/827f1998-8c74-11e5-96d8-dc035c282ae2.png)
