### PR TITLE
@craigspaeth Adds Super Article admin - partnerlogo/link/related articles

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -98,6 +98,12 @@ inputSchema = (->
     author: @string().allow('',null)
     credit_line: @string().allow('',null)
     credit_url: @string().allow('',null)
+  is_super_article: @boolean().default(false)
+  super_article: @object().keys
+    partner_link: @string().allow('',null)
+    partner_logo: @string().allow('',null)
+    secondary_partner_logo: @string().allow('',null)
+    related_articles: @array().items(@objectId()).allow(null)
 ).call Joi
 
 querySchema = (->

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -343,7 +343,7 @@ describe 'Article', ->
         article.published_at.should.be.an.instanceOf(Date)
         moment(article.published_at).format('YYYY').should
           .equal moment().format('YYYY')
-        done() 
+        done()
 
     it 'updates published_at when admin changes it', (done) ->
       Article.save {
@@ -504,6 +504,26 @@ describe 'Article', ->
       }, 'foo', (err, article) ->
         return done err if err
         article.keywords.join(',').should.equal 'Pablo Picasso,Pablo Picasso,Armory Show 2013,Gagosian Gallery,cool,art'
+        done()
+
+    it 'saves Super Articles', (done) ->
+      Article.save {
+        author_id: '5086df098523e60002000018'
+        is_super_article: true
+        super_article: {
+          partner_link: 'http://partnerlink.com'
+          partner_logo: 'http://partnerlink.com/logo.jpg'
+          secondary_partner_logo: 'http://secondarypartner.com/logo.png'
+          related_articles: [ '5530e72f7261696238050000' ]
+        }
+        published: true
+      }, 'foo', (err, article) ->
+        return done err if err
+        article.super_article.partner_link.should.equal 'http://partnerlink.com'
+        article.super_article.partner_logo.should.equal 'http://partnerlink.com/logo.jpg'
+        article.super_article.related_articles.length.should.equal 1
+        article.is_super_article.should.equal true
+        article.super_article.secondary_partner_logo.should.equal 'http://secondarypartner.com/logo.png'
         done()
 
   describe "#destroy", ->

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -506,7 +506,6 @@ describe 'Article', ->
         article.keywords.join(',').should.equal 'Pablo Picasso,Pablo Picasso,Armory Show 2013,Gagosian Gallery,cool,art'
         done()
 
-
   describe "#destroy", ->
 
     it 'removes an article', (done) ->

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -275,7 +275,7 @@ module.exports = class EditAdmin extends Backbone.View
 
   setupSuperArticleAutocomplete: ->
     AutocompleteList = require '../../../../components/autocomplete_list/index.coffee'
-    @related_articles = if @article.get('super_articles') then @article.get('super_articles').related_articles else []
+    @related_articles = if @article.get('super_article')?.related_articles then @article.get('super_article').related_articles else []
     list = new AutocompleteList @$('#edit-admin-related-articles')[0],
       name: 'related_articles[]'
       url: "#{sd.API_URL}/articles?published=true&q=%QUERY"
@@ -297,7 +297,7 @@ module.exports = class EditAdmin extends Backbone.View
         request
           .get("#{sd.API_URL}/articles/#{id}")
           .set('X-Access-Token': sd.USER.access_token).end (err, res) =>
-            @articles.push id: res.body._id, value: "#{res.body.title}, #{res.body.author?.name}"
+            @articles.push id: res.body.id, value: "#{res.body.title}, #{res.body.author?.name}"
             cb()
       , =>
         list.setState loading: false, items: @articles

--- a/client/apps/edit/components/admin/index.jade
+++ b/client/apps/edit/components/admin/index.jade
@@ -138,3 +138,30 @@ section#edit-admin.admin-form-container.max-width-container
           input.bordered-input( onClick="this.select();" readonly )
         label.edit-email-large-image-url Small
           input.bordered-input( onClick="this.select();" readonly )
+
+  //- Super Article
+  section.admin-form-section#edit-super-article
+    .admin-form-left
+      h1 Super Article
+      h2 Enable the Super Article functionality for special partnerships and features.
+    .admin-form-right
+      .admin-form-right-col
+        label Enable
+          .flat-checkbox
+            input( type='checkbox' name='is_super_article'
+              checked=article.get('is_super_article') == true value=true )
+        label Partner Link
+          input.bordered-input( name='partner_link' value="#{article.get('super_article') && article.get('super_article').partner_link ? article.get('super_article').partner_link : ''}")
+        label.edit-partner-logo
+          span(
+            data-hidden=article.get('super_article') && article.get('super_article').partner_logo ? 'true' : 'false'
+          ) Partner Logo
+          #edit-partner-logo-upload
+        label.edit-partner-logo
+          span(
+            data-hidden=article.get('super_article') && article.get('super_article').secondary_partner_logo ? 'true' : 'false'
+          ) Secondary Partner Logo
+          #edit-secondary-partner-logo-upload
+      .admin-form-right-col
+        label Related Articles
+        #edit-admin-related-articles

--- a/client/apps/edit/components/admin/test/index.coffee
+++ b/client/apps/edit/components/admin/test/index.coffee
@@ -34,6 +34,8 @@ describe 'EditAdmin', ->
         EditAdmin::setupPublishDate = sinon.stub()
         EditAdmin::renderScheduleState = sinon.stub()
         EditAdmin::setupContributingAuthors = sinon.stub()
+        EditAdmin::setupSuperArticleAutocomplete = sinon.stub()
+        EditAdmin::setupSuperArticleImages = sinon.stub()
         @view = new EditAdmin el: $('#edit-admin'), article: @article
         done()
 

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -76,6 +76,12 @@ module.exports = class EditLayout extends Backbone.View
         credit_line: @$(".edit-email-form input[name='credit_line']").val()
         credit_url: @$(".edit-email-form input[name='credit_url']").val()
         image_url: if @article.get('email_metadata')?.image_url then @article.get('email_metadata').image_url else ''
+      is_super_article: @$('[name=is_super_article]').is(':checked')
+      super_article:
+        partner_link: @$("#edit-super-article input[name='partner_link']")
+        partner_logo: if @article.get('super_article')?.partner_logo then @article.get('super_article').partner_logo else ''
+        secondary_partner_logo: if @article.get('super_article')?.secondary_partner_logo then @article.get('super_article').secondary_partner_logo else ''
+        related_articles: if @article.get('super_article')?.related_articles then @article.get('super_article').related_articles else []
     }
 
   toggleAstericks: =>

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -78,7 +78,7 @@ module.exports = class EditLayout extends Backbone.View
         image_url: if @article.get('email_metadata')?.image_url then @article.get('email_metadata').image_url else ''
       is_super_article: @$('[name=is_super_article]').is(':checked')
       super_article:
-        partner_link: @$("#edit-super-article input[name='partner_link']")
+        partner_link: @$("#edit-super-article input[name='partner_link']").val()
         partner_logo: if @article.get('super_article')?.partner_logo then @article.get('super_article').partner_logo else ''
         secondary_partner_logo: if @article.get('super_article')?.secondary_partner_logo then @article.get('super_article').secondary_partner_logo else ''
         related_articles: if @article.get('super_article')?.related_articles then @article.get('super_article').related_articles else []


### PR DESCRIPTION
#### TODO 
- Still need a way to relate the related articles back to the super article. When a Super Article is saved, we should run some background job that updates the related articles since they will need TOC info and partner logos. These related articles should probably also have some additional marker such as `has_super_article: '5515bea68ab80c060003f630'`. Feel free to comment on what kind of data would be helpful to you!

- When enable is clicked, the content section should turn red if the fullscreen background is not yet added. Will do this when implementing FS-BG
![2015-11-30_1610](https://cloud.githubusercontent.com/assets/2236794/11484601/e73902fa-977c-11e5-87ac-662bf4594b84.png)

#### Below is how the data in this section is saved
```
"super_article": {
   "partner_link": "htphldfgs",
   "partner_logo": "https://artsy-media.png",
   "secondary_partner_logo": "https://artsy-media.png",
   "related_articles": [
      "5515bea68ab80c060003f630",
      "55021d69e877fa0600014e1d"
   ]
},
"is_super_article": false
```

`is_super_article` might not be necessary as a boolean, but I think it will make the front-end easier to deal with. 

#### UI Example
![super_article_admin](https://cloud.githubusercontent.com/assets/2236794/11484320/62cc40e6-977b-11e5-994c-941adf26bf5b.gif)

