### PR TITLE
@kanaabe Fix super_article_for query to work in production as well as in tests

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -168,8 +168,8 @@ toQuery = (input, callback) ->
     query.featured_artwork_ids = ObjectId input.artwork_id if input.artwork_id
     query.tags = { $in: input.tags } if input.tags
 
-    # Convert query for super article for article
-    query['super_article.related_articles']= ObjectId(input.super_article_for) if input.super_article_for
+    # Convert query for super article for article (note: related articles is an array of strings, not object ids)
+    query['super_article.related_articles'] = input.super_article_for if input.super_article_for
 
     # Only add the $or array for queries that require it (blank $or array causes problems)
     query.$or ?= [] if input.artist_id or input.all_by_author

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -228,7 +228,7 @@ describe 'Article', ->
           title: 'Super Article'
           is_super_article: true
           super_article:
-            related_articles: [childArticleId]
+            related_articles: [childArticleId.toString()]
         }
       ], =>
         Article.where { super_article_for: childArticleId.toString() }, (err, res) ->


### PR DESCRIPTION
So, the previous solution only actually worked in tests :embarrassed:. I did not realize that `related_articles` is actually an array of strings -- not an array of ObjectIds. So, by using an objectId in the query and the test, I was tricking myself into thinking that this worked. This pull request makes the feature actually work.

Also want to flag in case the ObjectId vs String isn't intentional.