### PR TITLE
@zamiang Type cast objectid on related_articles

### DIFF
--- a/api/apps/articles/model.coffee
+++ b/api/apps/articles/model.coffee
@@ -341,6 +341,7 @@ typecastIds = (article) ->
     featured_artist_ids: article.featured_artist_ids.map(ObjectId) if article.featured_artist_ids
     featured_artwork_ids: article.featured_artwork_ids.map(ObjectId) if article.featured_artwork_ids
     biography_for_artist_id: ObjectId(article.biography_for_artist_id) if article.biography_for_artist_id
+    super_article: _.extend article.super_article, related_articles: article.super_article.related_articles.map(ObjectId) if article.super_article?.related_articles
 
 sanitizeAndSave = (callback) -> (err, article) ->
   return callback err if err

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -584,6 +584,19 @@ describe 'Article', ->
         article.super_article.related_articles.length.should.equal 1
         done()
 
+    it 'type casts ObjectId over articles', (done) ->
+      Article.save {
+        author_id: '5086df098523e60002000018'
+        super_article: {
+          related_articles: [ '5530e72f7261696238050000' ]
+        }
+        published: true
+      }, 'foo', (err, article) ->
+        return done err if err
+        article.author_id instanceof ObjectId
+        article.super_article.related_articles[0] instanceof ObjectId
+        done()
+
   describe "#destroy", ->
 
     it 'removes an article', (done) ->

--- a/api/apps/articles/test/model.coffee
+++ b/api/apps/articles/test/model.coffee
@@ -593,8 +593,8 @@ describe 'Article', ->
         published: true
       }, 'foo', (err, article) ->
         return done err if err
-        article.author_id instanceof ObjectId
-        article.super_article.related_articles[0] instanceof ObjectId
+        (article.author_id instanceof ObjectId).should.be.true
+        (article.super_article.related_articles[0] instanceof ObjectId).should.be.true
         done()
 
   describe "#destroy", ->


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/607
Totally forgot to do this... -.- 

Anyway this will map the ObjectId over `super_article.related_articles` when saving. 

![2015-12-04_1837](https://cloud.githubusercontent.com/assets/2236794/11604064/0d0e0b38-9ab6-11e5-9083-2d1ae0a7c5dd.png)
