### PR TITLE
@craigspaeth Check that video URL is properly formatted when saving

### DIFF
--- a/client/apps/edit/components/section_video/index.coffee
+++ b/client/apps/edit/components/section_video/index.coffee
@@ -41,7 +41,9 @@ module.exports = React.createClass
       @props.section.set cover_image_url: @state.coverSrc
 
   onChangeUrl: (e) ->
-    @props.section.set url: $(@refs.input.getDOMNode()).val()
+    url = $(@refs.input.getDOMNode()).val()
+    url = "https://".concat(url) if url.indexOf('http') < 0
+    @props.section.set url: url
     @forceUpdate()
 
   uploadCoverImage: (e) ->

--- a/client/apps/edit/components/section_video/test/index.coffee
+++ b/client/apps/edit/components/section_video/test/index.coffee
@@ -40,7 +40,7 @@ describe 'SectionVideo', ->
   it 'changes the video when submitting', ->
     $(@component.refs.input.getDOMNode()).val 'foobar'
     @component.onChangeUrl preventDefault: ->
-    @component.props.section.get('url').should.equal 'http://foobar'
+    @component.props.section.get('url').should.equal 'https://foobar'
 
   it 'renders the video url', ->
     $(@component.getDOMNode()).html().should.containEql 'dQw4w9WgXcQ'

--- a/client/apps/edit/components/section_video/test/index.coffee
+++ b/client/apps/edit/components/section_video/test/index.coffee
@@ -40,7 +40,7 @@ describe 'SectionVideo', ->
   it 'changes the video when submitting', ->
     $(@component.refs.input.getDOMNode()).val 'foobar'
     @component.onChangeUrl preventDefault: ->
-    @component.props.section.get('url').should.equal 'foobar'
+    @component.props.section.get('url').should.equal 'http://foobar'
 
   it 'renders the video url', ->
     $(@component.getDOMNode()).html().should.containEql 'dQw4w9WgXcQ'


### PR DESCRIPTION
We need to add `http://` to URLs if the user gives us a link like `youtube.com?v=123`. The reason being -- `embed-video` uses `URL.parse.hostname` which apparently is `null` when there is no protocol provided. 

Related issue here: https://github.com/artsy/force/issues/4020#event-501401794