### PR TITLE
@craigspaeth Checks that href exists before trying to sanitize it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ BIN = node_modules/.bin
 s:
 	$(BIN)/coffee index.coffee
 
+# Start the server using forever
+sf:
+	$(BIN)/forever $(BIN)/coffee --nodejs --max_old_space_size=960 index.coffee
+
 # Run all of the project-level tests, followed by app-level tests
 test: assets
 	$(BIN)/mocha $(shell find api/test -name '*.coffee' -not -path 'test/helpers/*')

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ s:
 
 # Start the server using forever
 sf:
-	$(BIN)/forever $(BIN)/coffee --nodejs --max_old_space_size=960 index.coffee
+	$(BIN)/forever $(BIN)/coffee --nodejs index.coffee
 
 # Run all of the project-level tests, followed by app-level tests
 test: assets

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: make s
+web: make sf

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -132,8 +132,9 @@ sanitizeLink = (urlString) ->
 sanitizeHtml = (html) ->
   return xss html unless try $ = cheerio.load html, decodeEntities: false
   $('a').each ->
-    u = sanitizeLink $(this).attr 'href'
-    $(this).attr 'href', u
+    if $(this).attr 'href'
+      u = sanitizeLink $(this).attr 'href'
+      $(this).attr 'href', u
   xss $.html()
 
 typecastIds = (article) ->

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore'
 rewire = require 'rewire'
 { fabricate, empty } = require '../../../../test/helpers/db'
 Save = rewire '../../model/save'
+Article = require '../../model/index'
 express = require 'express'
 gravity = require('antigravity').server
 app = require('express')()
@@ -99,3 +100,22 @@ describe 'Save', ->
         @sailthru.apiPost.args[0][1].vars.html.should.containEql '<html>BODY OF TEXT</html>'
         @sailthru.apiPost.args[0][1].vars.html.should.not.containEql 'This Caption'
         done()
+
+  describe '#sanitizeAndSave', ->
+
+    it 'skips sanitizing links that do not have an href', (done) ->
+      Save.sanitizeAndSave( ->
+        Article.find '5086df098523e60002000011', (err, article) =>
+          article.sections[0].body.should.containEql '<a></a>'
+          done()
+      )(null, {
+        author_id: '5086df098523e60002000018'
+        published: false
+        _id: '5086df098523e60002000011'
+        sections: [
+          {
+            type: 'text'
+            body: '<a>'
+          }
+        ]
+      })

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -322,6 +322,27 @@
       "from": "braces@>=1.8.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
     },
+    "broadway": {
+      "version": "0.3.6",
+      "from": "broadway@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/broadway/-/broadway-0.3.6.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.0 <0.3.0"
+        },
+        "cliff": {
+          "version": "0.1.9",
+          "from": "cliff@0.1.9",
+          "resolved": "https://registry.npmjs.org/cliff/-/cliff-0.1.9.tgz"
+        },
+        "winston": {
+          "version": "0.8.0",
+          "from": "winston@0.8.0",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz"
+        }
+      }
+    },
     "brorand": {
       "version": "1.0.5",
       "from": "brorand@>=1.0.1 <2.0.0",
@@ -463,6 +484,11 @@
       "from": "caching-coffeeify@>=0.5.1 <0.6.0",
       "resolved": "https://registry.npmjs.org/caching-coffeeify/-/caching-coffeeify-0.5.1.tgz"
     },
+    "caller": {
+      "version": "0.0.1",
+      "from": "caller@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/caller/-/caller-0.0.1.tgz"
+    },
     "camelcase": {
       "version": "1.2.1",
       "from": "camelcase@>=1.0.2 <2.0.0",
@@ -522,6 +548,18 @@
         }
       }
     },
+    "cliff": {
+      "version": "0.1.10",
+      "from": "cliff@>=0.1.9 <0.2.0",
+      "resolved": "https://registry.npmjs.org/cliff/-/cliff-0.1.10.tgz",
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+        }
+      }
+    },
     "cliui": {
       "version": "2.1.0",
       "from": "cliui@>=2.1.0 <3.0.0",
@@ -534,6 +572,11 @@
         }
       }
     },
+    "clone": {
+      "version": "1.0.2",
+      "from": "clone@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+    },
     "coffee-script": {
       "version": "1.10.0",
       "from": "coffee-script@>=1.10.0 <2.0.0",
@@ -543,6 +586,11 @@
       "version": "1.2.0",
       "from": "coffeeify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-1.2.0.tgz"
+    },
+    "colors": {
+      "version": "0.6.2",
+      "from": "colors@>=0.6.2 <0.7.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
     },
     "combine-source-map": {
       "version": "0.6.1",
@@ -731,6 +779,11 @@
       "from": "cssstyle@>=0.2.29 <0.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.31.tgz"
     },
+    "cycle": {
+      "version": "1.0.3",
+      "from": "cycle@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+    },
     "dashdash": {
       "version": "1.12.2",
       "from": "dashdash@>=1.10.1 <2.0.0",
@@ -790,6 +843,11 @@
       "from": "declare.js@>=0.0.4 <0.1.0",
       "resolved": "https://registry.npmjs.org/declare.js/-/declare.js-0.0.8.tgz"
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "from": "deep-equal@*",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+    },
     "deep-is": {
       "version": "0.1.3",
       "from": "deep-is@>=0.1.3 <0.2.0",
@@ -846,6 +904,11 @@
       "version": "5.0.2",
       "from": "diffie-hellman@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
+    },
+    "director": {
+      "version": "1.2.7",
+      "from": "director@1.2.7",
+      "resolved": "https://registry.npmjs.org/director/-/director-1.2.7.tgz"
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -978,6 +1041,23 @@
       "from": "etag@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
+    "event-stream": {
+      "version": "0.5.3",
+      "from": "event-stream@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.2.8",
+          "from": "optimist@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz"
+        }
+      }
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "from": "eventemitter2@0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+    },
     "eventie": {
       "version": "1.0.6",
       "from": "eventie@>=1.0.4 <1.1.0",
@@ -1060,6 +1140,11 @@
       "from": "extsprintf@1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
+    "eyes": {
+      "version": "0.1.8",
+      "from": "eyes@>=0.1.8 <0.2.0",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+    },
     "ezel-assets": {
       "version": "1.0.1",
       "from": "ezel-assets@>=1.0.0 <2.0.0",
@@ -1090,6 +1175,18 @@
       "from": "finalhandler@0.4.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
     },
+    "flatiron": {
+      "version": "0.4.3",
+      "from": "flatiron@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/flatiron/-/flatiron-0.4.3.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.6.0",
+          "from": "optimist@0.6.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz"
+        }
+      }
+    },
     "for-in": {
       "version": "0.1.4",
       "from": "for-in@>=0.1.4 <0.2.0",
@@ -1105,10 +1202,34 @@
       "from": "foreach@>=2.0.5 <3.0.0",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
+    "forever": {
+      "version": "0.15.1",
+      "from": "forever@latest",
+      "resolved": "https://registry.npmjs.org/forever/-/forever-0.15.1.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "from": "forever-agent@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+    },
+    "forever-monitor": {
+      "version": "1.6.0",
+      "from": "forever-monitor@>=1.6.0 <1.7.0",
+      "resolved": "https://registry.npmjs.org/forever-monitor/-/forever-monitor-1.6.0.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        }
+      }
     },
     "form-data": {
       "version": "0.2.0",
@@ -1970,6 +2091,11 @@
       "from": "https-browserify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
     },
+    "i": {
+      "version": "0.3.4",
+      "from": "i@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.4.tgz"
+    },
     "iconv-lite": {
       "version": "0.4.13",
       "from": "iconv-lite@0.4.13",
@@ -2009,6 +2135,11 @@
       "version": "2.0.1",
       "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "ini": {
+      "version": "1.3.4",
+      "from": "ini@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inline-source-map": {
       "version": "0.5.0",
@@ -2258,6 +2389,11 @@
       "version": "1.0.2",
       "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz"
+    },
+    "lazy": {
+      "version": "1.0.11",
+      "from": "lazy@>=1.0.11 <1.1.0",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz"
     },
     "lazy-cache": {
       "version": "1.0.3",
@@ -2534,6 +2670,11 @@
       "from": "ms@0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
+    "mute-stream": {
+      "version": "0.0.6",
+      "from": "mute-stream@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
+    },
     "nan": {
       "version": "2.0.5",
       "from": "nan@2.0.5",
@@ -2543,6 +2684,28 @@
       "version": "0.2.1",
       "from": "natural@>=0.0.28",
       "resolved": "https://registry.npmjs.org/natural/-/natural-0.2.1.tgz"
+    },
+    "nconf": {
+      "version": "0.6.9",
+      "from": "nconf@>=0.6.9 <0.7.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.6.9.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.9",
+          "from": "async@0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+        },
+        "optimist": {
+          "version": "0.6.0",
+          "from": "optimist@0.6.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz"
+        }
+      }
+    },
+    "ncp": {
+      "version": "0.4.2",
+      "from": "ncp@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
     },
     "negotiator": {
       "version": "0.5.3",
@@ -2735,6 +2898,11 @@
       "from": "normalize-path@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
+    "nssocket": {
+      "version": "0.5.3",
+      "from": "nssocket@>=0.5.1 <0.6.0",
+      "resolved": "https://registry.npmjs.org/nssocket/-/nssocket-0.5.3.tgz"
+    },
     "nth-check": {
       "version": "1.0.1",
       "from": "nth-check@>=1.0.0 <1.1.0",
@@ -2754,6 +2922,11 @@
       "version": "0.8.1",
       "from": "oauth-sign@>=0.8.0 <0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+    },
+    "object-assign": {
+      "version": "3.0.0",
+      "from": "object-assign@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
     },
     "object-extended": {
       "version": "0.0.7",
@@ -2919,6 +3092,11 @@
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
     },
+    "pkginfo": {
+      "version": "0.3.1",
+      "from": "pkginfo@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+    },
     "pos": {
       "version": "0.1.9",
       "from": "pos@>=0.1.0 <0.2.0",
@@ -2933,6 +3111,23 @@
       "version": "0.2.0",
       "from": "preserve@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+    },
+    "prettyjson": {
+      "version": "1.1.3",
+      "from": "prettyjson@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.1.3.tgz",
+      "dependencies": {
+        "colors": {
+          "version": "1.1.2",
+          "from": "colors@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        }
+      }
     },
     "process": {
       "version": "0.11.2",
@@ -2949,6 +3144,11 @@
       "from": "promise@>=6.0.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz"
     },
+    "prompt": {
+      "version": "0.2.14",
+      "from": "prompt@0.2.14",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz"
+    },
     "prop-by-string": {
       "version": "1.0.1",
       "from": "prop-by-string@>=1.0.1 <2.0.0",
@@ -2958,6 +3158,11 @@
       "version": "1.0.10",
       "from": "proxy-addr@>=1.0.10 <1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
+    },
+    "ps-tree": {
+      "version": "0.0.3",
+      "from": "ps-tree@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz"
     },
     "public-encrypt": {
       "version": "4.0.0",
@@ -3030,6 +3235,11 @@
       "version": "0.12.0",
       "from": "react@0.12.0",
       "resolved": "https://registry.npmjs.org/react/-/react-0.12.0.tgz"
+    },
+    "read": {
+      "version": "1.0.7",
+      "from": "read@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
     },
     "read-only-stream": {
       "version": "1.1.1",
@@ -3181,6 +3391,16 @@
         }
       }
     },
+    "resumer": {
+      "version": "0.0.0",
+      "from": "resumer@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz"
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "from": "revalidator@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
+    },
     "rewire": {
       "version": "2.2.0",
       "from": "rewire@2.2.0",
@@ -3190,6 +3410,18 @@
       "version": "0.1.3",
       "from": "right-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+    },
+    "rimraf": {
+      "version": "2.5.2",
+      "from": "rimraf@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.0.0",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz"
+        }
+      }
     },
     "ripemd160": {
       "version": "1.0.1",
@@ -3302,6 +3534,11 @@
       "version": "0.2.0",
       "from": "should-type@0.2.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz"
+    },
+    "shush": {
+      "version": "1.0.0",
+      "from": "shush@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shush/-/shush-1.0.0.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
@@ -3424,6 +3661,11 @@
       "from": "strip-ansi@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
     },
+    "strip-json-comments": {
+      "version": "0.1.3",
+      "from": "strip-json-comments@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+    },
     "stylus": {
       "version": "0.52.4",
       "from": "stylus@>=0.52.4 <0.53.0",
@@ -3500,6 +3742,23 @@
       "from": "syntax-error@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.5.tgz"
     },
+    "tape": {
+      "version": "2.3.3",
+      "from": "tape@>=2.3.2 <2.4.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
+      "dependencies": {
+        "deep-equal": {
+          "version": "0.1.2",
+          "from": "deep-equal@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz"
+        },
+        "defined": {
+          "version": "0.0.0",
+          "from": "defined@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+        }
+      }
+    },
     "through": {
       "version": "2.3.8",
       "from": "through@>=2.3.4 <2.4.0",
@@ -3526,6 +3785,11 @@
       "version": "1.4.2",
       "from": "timers-browserify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+    },
+    "timespan": {
+      "version": "2.3.0",
+      "from": "timespan@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz"
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -3737,6 +4001,17 @@
       "from": "util-deprecate@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
+    "utile": {
+      "version": "0.2.1",
+      "from": "utile@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0"
+        }
+      }
+    },
     "utils-merge": {
       "version": "1.0.0",
       "from": "utils-merge@1.0.0",
@@ -3912,6 +4187,18 @@
       "version": "0.1.0",
       "from": "window-size@0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+    },
+    "winston": {
+      "version": "0.8.3",
+      "from": "winston@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        }
+      }
     },
     "with": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.13.3",
     "express-force-ssl": "^0.3.0",
     "fast-csv": "^0.6.0",
+    "forever": "^0.15.1",
     "fs": "0.0.2",
     "glossary": "^0.1.1",
     "jade": "^1.11.0",


### PR DESCRIPTION
This caused Positron to crash at 2:36PM today. `url.parse` doesn't fail gracefully so we should check that `$(this).attr 'href'` exists before trying to sanitize it. Weird that a link in the HTML didn't have an `href` field in the first place though. 
