### PR TITLE
@craigspaeth Adds process.exit instead of db.close in s3 script

### DIFF
--- a/scripts/daily_upload_s3.coffee
+++ b/scripts/daily_upload_s3.coffee
@@ -51,6 +51,6 @@ db.articles.find({ published: true })
       'Content-Type': 'text/csv'
     }, (err, result) ->
 
-      # Delete filename and close db
+      # Delete filename and exit
       fs.unlink(dir + filename)
-      db.close()
+      process.exit(1)


### PR DESCRIPTION
Whether or not this is what's causing the closed connections, we should exit the script with `process.exit`