### PR TITLE
@kanaabe: Exit for "connection was destroyed" in middleware

### DIFF
--- a/api/lib/db.coffee
+++ b/api/lib/db.coffee
@@ -11,9 +11,13 @@ debug = require('debug') 'api'
 
 collections = ['articles', 'users', 'sections', 'artists']
 db = mongojs MONGOHQ_URL, collections
-db.on 'close', ->
-  debug 'Mongo Connection Closed'
+exit = (msg) -> (err) ->
+  debug msg
+  debug msg, err if msg is 'Mongo Error'
   process.exit(1)
+
+db.on 'close', exit('Mongo Connection Closed')
+db.on 'error', exit('Mongo Error')
 
 module.exports = db
 module.exports.collections = collections


### PR DESCRIPTION
My [theory](https://artsy.slack.com/archives/web/p1458494729000129) seems to be correct—which I validated by moving [this line of code](https://github.com/christkv/mongodb-core/blob/1.3/lib/cursor.js#L414) where the error would be thrown to the top of the function. That particular error doesn't get emitted as a `close` or `error` event, so we need to catch it in the middleware where it's being bubbled up. I'll look into a PR for [mongo-core](https://github.com/christkv/mongodb-core) or [mongojs](https://github.com/mafintosh/mongojs) to bubble that up properly, but in the meantime this will ensure our app restarts if it encounters that `connection was destroyed` error.