### PR TITLE
@craigspaeth Adds sections to input in scheduler

### DIFF
--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -70,6 +70,7 @@ Q = require 'bluebird-q'
         published: true
         published_at: moment(article.scheduled_publish_at).toDate()
         scheduled_publish_at: null
+        sections: article.sections
       }, 'foo', cb
     , (err, results) ->
       return callback err, [] if err

--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -64,14 +64,11 @@ Q = require 'bluebird-q'
     return callback err, [] if err
     return callback null, [] if articles.length is 0
     async.map articles, (article, cb) =>
-      @save {
-        id: article.id.toString()
-        author_id: article.author_id.toString()
+      article = _.extend article,
         published: true
         published_at: moment(article.scheduled_publish_at).toDate()
         scheduled_publish_at: null
-        sections: article.sections
-      }, 'foo', cb
+      onPublish article, article.author, sanitizeAndSave cb
     , (err, results) ->
       return callback err, [] if err
       return callback null, results

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -107,6 +107,7 @@ setEmailFields = (article, author) =>
   intersection = _.intersection(before, after)
   if input.sections and input.sections.length > 0
     article.sections = input.sections
+  return cb null, article unless input.sections
   return cb(null, article) if intersection.length is before.length and intersection.length is after.length
   # Try to fetch and denormalize the artworks from Gravity asynchonously
   artworkIds = _.pluck (_.where input.sections, type: 'artworks' ), 'ids'
@@ -185,11 +186,8 @@ getPartnerLink = (artwork) ->
 
 # TODO: Create a Joi plugin for this https://github.com/hapijs/joi/issues/577
 sanitize = (article) ->
-  sanitized = _.extend article,
-    title: sanitizeHtml article.title
-    thumbnail_title: sanitizeHtml article.thumbnail_title
-    lead_paragraph: sanitizeHtml article.lead_paragraph
-    sections: for section in article.sections
+  if article.sections
+    sections = for section in article.sections
       section.body = sanitizeHtml section.body if section.type is 'text'
       section.caption = sanitizeHtml section.caption if section.type is 'image'
       section.url = sanitizeLink section.url if section.type is 'video'
@@ -198,6 +196,13 @@ sanitize = (article) ->
           item.caption = sanitizeHtml item.caption if item.type is 'image'
           item.url = sanitizeLink item.url if item.type is 'video'
       section
+  else
+    sections = []
+  sanitized = _.extend article,
+    title: sanitizeHtml article.title
+    thumbnail_title: sanitizeHtml article.thumbnail_title
+    lead_paragraph: sanitizeHtml article.lead_paragraph
+    sections: sections
   if article.hero_section?.caption
     sanitized.hero_section.caption = sanitizeHtml article.hero_section.caption
   sanitized

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -105,7 +105,7 @@ setEmailFields = (article, author) =>
   before = _.flatten _.pluck _.where(article.sections, type: 'artworks'), 'ids'
   after = _.flatten _.pluck _.where(input.sections, type: 'artworks'), 'ids'
   intersection = _.intersection(before, after)
-  article.sections = input.sections
+  article.sections = input.sections if input.sections.length > 0
   return cb(null, article) if intersection.length is before.length and intersection.length is after.length
   # Try to fetch and denormalize the artworks from Gravity asynchonously
   artworkIds = _.pluck (_.where input.sections, type: 'artworks' ), 'ids'
@@ -177,7 +177,7 @@ getPartnerLink = (artwork) ->
     return cb err if err
     publishing = (input.published and not article.published) or (input.scheduled_publish_at and not article.published)
     article = _.extend article, _.omit(input, 'sections'), updated_at: new Date
-    article.sections = [] unless input.sections?.length
+    article.sections = [] unless input.sections.length > 0
     article.author = User.denormalizedForArticle author if author
     cb null, article, author, publishing
 

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -105,7 +105,8 @@ setEmailFields = (article, author) =>
   before = _.flatten _.pluck _.where(article.sections, type: 'artworks'), 'ids'
   after = _.flatten _.pluck _.where(input.sections, type: 'artworks'), 'ids'
   intersection = _.intersection(before, after)
-  article.sections = input.sections if input.sections.length > 0
+  if input.sections and input.sections.length > 0
+    article.sections = input.sections
   return cb(null, article) if intersection.length is before.length and intersection.length is after.length
   # Try to fetch and denormalize the artworks from Gravity asynchonously
   artworkIds = _.pluck (_.where input.sections, type: 'artworks' ), 'ids'
@@ -177,7 +178,8 @@ getPartnerLink = (artwork) ->
     return cb err if err
     publishing = (input.published and not article.published) or (input.scheduled_publish_at and not article.published)
     article = _.extend article, _.omit(input, 'sections'), updated_at: new Date
-    article.sections = [] unless input.sections.length > 0
+    if input.sections and input.sections.length is 0
+      article.sections = []
     article.author = User.denormalizedForArticle author if author
     cb null, article, author, publishing
 

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -90,7 +90,7 @@ fullscreenSection = (->
           type: @string().valid('artwork')
           id: @string()
       ]
-  ]).default([])
+  ]).allow(null)
   primary_featured_artist_ids: @array().items(@objectId()).allow(null)
   featured_artist_ids: @array().items(@objectId()).allow(null)
   featured_artwork_ids: @array().items(@objectId()).allow(null)

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -721,10 +721,23 @@ describe 'Article', ->
         author_id: ObjectId('5086df098523e60002000018')
         published: false
         scheduled_publish_at: moment('2016-01-01').toDate()
+        sections: [
+          {
+            type: 'text'
+            body: 'The start of a new article'
+          }
+          {
+            type: 'image'
+            url: 'https://image.png'
+            caption: 'Trademarked'
+          }
+        ]
       , ->
         Article.publishScheduledArticles (err, results) ->
           results[0].published.should.be.true()
           results[0].published_at.toString().should.equal moment('2016-01-01').toDate().toString()
+          results[0].sections[0].body.should.containEql 'The start of a new article'
+          results[0].sections[1].url.should.containEql 'https://image.png'
           done()
 
   describe "#destroy", ->

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -713,6 +713,38 @@ describe 'Article', ->
         article.sections[2].article.should.equal '53da550a726169083c0a0700'
         done()
 
+    it 'saves an article that does not have sections in input', (done) ->
+      fabricate 'articles',
+        _id: ObjectId('5086df098523e60002000018')
+        id: '5086df098523e60002000018'
+        author_id: ObjectId('5086df098523e60002000018')
+        published: false
+        author: {
+          name: 'Kana Abe'
+        }
+        sections: [
+          {
+            type: 'text'
+            body: 'The start of a new article'
+          }
+          {
+            type: 'image'
+            url: 'https://image.png'
+            caption: 'Trademarked'
+          }
+        ]
+      , ->
+        Article.save {
+          _id: ObjectId('5086df098523e60002000018')
+          id: '5086df098523e60002000018'
+          author_id: '5086df098523e60002000018'
+          published: true
+        }, 'foo', (err, article) ->
+          article.published.should.be.true()
+          article.sections.length.should.equal 2
+          article.sections[0].body.should.containEql 'The start of a new article'
+          done()
+
   describe '#publishScheduledArticles', ->
 
     it 'calls #save on each article that needs to be published', (done) ->
@@ -721,6 +753,9 @@ describe 'Article', ->
         author_id: ObjectId('5086df098523e60002000018')
         published: false
         scheduled_publish_at: moment('2016-01-01').toDate()
+        author: {
+          name: 'Kana Abe'
+        }
         sections: [
           {
             type: 'text'


### PR DESCRIPTION
`input` has some dependencies when it comes to the contents in it (author_id, id) -- but I seemed to have left out `sections`. This was causing scheduled articles to save with no sections! :( 