### PR TITLE
@craigspaeth Adds AdditionalImages and fixes Artwork denormalization issue

### DIFF
--- a/client/apps/edit/components/section_artworks/index.coffee
+++ b/client/apps/edit/components/section_artworks/index.coffee
@@ -155,7 +155,7 @@ module.exports = React.createClass
           (@props.section.artworks.map (artwork, i) =>
             li { key: i },
               div { className: 'esa-img-container' },
-                img { src: artwork.imageUrl() }
+                img { src: artwork.defaultImage().bestImageUrl(['larger', 'large', 'medium', 'small']) }
               p {},
                 strong {}, artwork.get('artists')?[0]?.name
               p {}, artwork.get('artwork')?.title or artwork.attributes?.title

--- a/client/collections/additional_images.coffee
+++ b/client/collections/additional_images.coffee
@@ -1,0 +1,11 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+AdditionalImage = require '../models/additional_image.coffee'
+
+module.exports = class AdditionalImages extends Backbone.Collection
+  model: AdditionalImage
+
+  comparator: 'position'
+
+  default: ->
+    @findWhere(is_default: true) or @first()

--- a/client/models/additional_image.coffee
+++ b/client/models/additional_image.coffee
@@ -1,0 +1,8 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+{ Image } = require 'artsy-backbone-mixins'
+{ SECURE_IMAGES_URL } = require('sharify').data
+
+module.exports = class AdditionalImage extends Backbone.Model
+
+  _.extend @prototype, Image(SECURE_IMAGES_URL)

--- a/client/models/artwork.coffee
+++ b/client/models/artwork.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore'
 Backbone = require 'backbone'
 sd = require('sharify').data
 { ArtworkHelpers } = require 'artsy-backbone-mixins'
+AdditionalImages = require '../collections/additional_images.coffee'
 
 module.exports = class Artwork extends Backbone.Model
 
@@ -13,3 +14,6 @@ module.exports = class Artwork extends Backbone.Model
     split = @get('artist').name.split ' '
     artistInitials = split[0][0] + '.' + split[1]?[0] + '.'
     artistInitials + ' ' + @get('title') + ', ' + @get('date')
+
+  defaultImage: ->
+    new AdditionalImages(@get('images')).default()

--- a/client/test/collections/additional_images.coffee
+++ b/client/test/collections/additional_images.coffee
@@ -1,0 +1,19 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+AdditionalImages = require '../../collections/additional_images.coffee'
+sinon = require 'sinon'
+{ fabricate } = require 'antigravity'
+
+describe "AdditionalImages", ->
+
+  beforeEach ->
+    sinon.stub Backbone, 'sync'
+    @images = new AdditionalImages fabricate('artwork').images
+
+  afterEach ->
+    Backbone.sync.restore()
+
+  describe '#default', ->
+
+    it 'returns the default image', ->
+      @images.default().get('is_default').should.be.true()

--- a/client/test/models/additional_image.coffee
+++ b/client/test/models/additional_image.coffee
@@ -1,0 +1,15 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+AdditionalImage = require '../../models/additional_image.coffee'
+AdditionalImages = require '../../collections/additional_images.coffee'
+sinon = require 'sinon'
+{ fabricate } = require 'antigravity'
+
+describe "AdditionalImage", ->
+
+  beforeEach ->
+    sinon.stub Backbone, 'sync'
+    @image = new AdditionalImages(fabricate('artwork').images).default()
+
+  afterEach ->
+    Backbone.sync.restore()


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/695, https://github.com/artsy/positron/issues/698

This PR adds a model/collection similar to Force's `AdditionalImages`. The issue is that `ArtworkHelper`'s `imageUrl` function doesn't take an array of images, only a single size or 'larger' default which some artworks don't have. If an artwork doesn't have 'larger', it defaults to the first image, like 'square' or 'four_thirds'. Anyway, we want to access `artsy-backbone-mixin`'s `Image` helper to be able to pass in an array of options instead.

I'm open to other implementations, but this one seemed to make sense to me. The downside is that the API can't use this model/collection so there is some kinda funny extension stuff happening on [save](https://github.com/artsy/positron/compare/master...kanaabe:denorm-issue?expand=1#diff-f0960fb95e1353f30292b72ab800dd1eR139). 

The other issue this PR fixes is the case that an artwork doesn't have an artist.