### PR TITLE
@craigspaeth Simplify autosave, remove image set button, fix captions, new layout widths

### DIFF
--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -140,6 +140,7 @@ denormalizedArtworkData = (artwork) ->
   images = artwork.get('images')
   defaultImage = new AdditionalImage(_.findWhere(images, is_default: true) or _.first images)
   denormalizedArtwork =
+    type: 'artwork'
     id: artwork.get('_id')
     slug: artwork.get('id')
     date: artwork.get('date')

--- a/client/apps/edit/components/hero_section/index.styl
+++ b/client/apps/edit/components/hero_section/index.styl
@@ -12,13 +12,16 @@
   .edit-section-container[data-type=video], .edit-section-container[data-type=image]
     min-height 400px
     width 1100px
-    margin-left -280px
     .esv-controls-container
       height 243px
     .esv-nav, .esv-background-color
       display none
   .esi-placeholder
     line-height 480px
+  .edit-section-container[data-type=image]
+    left calc(50% - 410px)
+  .edit-section-container[data-type=video]
+    left calc(50% - 550px)
 
 #edit-hero-section
   .edit-section-tool-menu

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -119,11 +119,8 @@ module.exports = class EditLayout extends Backbone.View
     @article.save @serialize()
 
   addRemoveReset: =>
-    if @article.get('published')
-      @changedAPublishedArticle = true
-      $('#edit-save').addClass 'attention'
-    else
-      @article.save()
+    @changedSection = true
+    $('#edit-save').addClass 'attention'
 
   highlightMissingFields: =>
     @openTab 1

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -37,7 +37,7 @@ module.exports = class EditLayout extends Backbone.View
     window.onbeforeunload = =>
       if $.active > 0
         "Your article is not finished saving."
-      else if @changedAPublishedArticle is true and not @finished
+      else if @changedSection is true and not @finished
         "You have unsaved changes, do you wish to continue?"
       else
         null
@@ -150,7 +150,7 @@ module.exports = class EditLayout extends Backbone.View
 
   onKeyup: =>
     if @article.get('published')
-      @changedAPublishedArticle = true
+      @changedSection = true
       $('#edit-save').addClass 'attention'
     else
       @article.save @serialize()

--- a/client/apps/edit/components/layout/test/index.coffee
+++ b/client/apps/edit/components/layout/test/index.coffee
@@ -47,12 +47,12 @@ describe 'EditLayout', ->
     it 'does not autosave on debounce keyup when editing a published article', ->
       @view.article.set { published: true }
       $('#edit-title textarea').trigger 'keyup'
-      @view.changedAPublishedArticle.should.equal true
+      @view.changedSection.should.equal true
 
     it 'does not autosave on section changes when editing a published article', ->
       @view.article.set { published: true }
       @view.article.sections.trigger 'add'
-      @view.changedAPublishedArticle.should.equal true
+      @view.changedSection.should.equal true
 
   describe '#serialize', ->
 
@@ -128,7 +128,7 @@ describe 'EditLayout', ->
 
     it 'stops you if theres a published article that is not yet saved', ->
       $.active = 0
-      @view.changedAPublishedArticle = true
+      @view.changedSection = true
       @view.finished = false
       @view.setupOnBeforeUnload()
       window.onbeforeunload().should.containEql 'do you wish to continue'

--- a/client/apps/edit/components/section_container/index.styl
+++ b/client/apps/edit/components/section_container/index.styl
@@ -61,3 +61,7 @@
 
 .edit-section-remove.is-hidden
   display none
+
+.edit-section-container[data-layout=column_width]
+  width 620px
+  margin auto

--- a/client/apps/edit/components/section_embed/index.styl
+++ b/client/apps/edit/components/section_embed/index.styl
@@ -76,11 +76,10 @@
 // Varying layouts
 //
 .edit-section-container[data-layout=column_width]
-  width 540px
   nav .ese-column-width
     opacity 1
   .embed-container
-    width 500px
+    width 540px
 
 .edit-section-container[data-layout=overflow]
   width 1100px
@@ -92,7 +91,7 @@
 
 .edit-section-container[data-layout=overflow_fillwidth][data-type=embed]
   width 1100px
-  left -280px
+  left -240px
   input
     width 519px
   iframe

--- a/client/apps/edit/components/section_image_set/index.coffee
+++ b/client/apps/edit/components/section_image_set/index.coffee
@@ -82,7 +82,6 @@ module.exports = React.createClass
   removeItem: (item) -> =>
     newImages = _.without @state.images, item
     @setState images: newImages
-    @forceUpdate()
 
   addArtworkFromUrl: (e) ->
     e.preventDefault()
@@ -195,6 +194,7 @@ module.exports = React.createClass
                       className: 'edit-section-remove button-reset esis-img-remove'
                       dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
                       onClick: @removeItem(item)
+                      key: 2
                     }
                   ]
             )

--- a/client/apps/edit/components/section_image_set/index.coffee
+++ b/client/apps/edit/components/section_image_set/index.coffee
@@ -82,6 +82,7 @@ module.exports = React.createClass
   removeItem: (item) -> =>
     newImages = _.without @state.images, item
     @setState images: newImages
+    @forceUpdate()
 
   addArtworkFromUrl: (e) ->
     e.preventDefault()
@@ -194,7 +195,6 @@ module.exports = React.createClass
                       className: 'edit-section-remove button-reset esis-img-remove'
                       dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
                       onClick: @removeItem(item)
-                      key: 2
                     }
                   ]
             )

--- a/client/apps/edit/components/section_image_set/index.styl
+++ b/client/apps/edit/components/section_image_set/index.styl
@@ -267,15 +267,15 @@ wide-input-width = 640px
       left 5px
 
 .edit-section-container[data-editing=false][data-type=image_set]
-  .esis-preview-container
+  .esis-preview-container, .edit-section-remove
     display block
-  .edit-section-controls, .esis-controls-container, .esis-images-list, .edit-section-remove, .esis-caption-container, .esis-nav, .esis-caption
+  .edit-section-controls, .esis-controls-container, .esis-images-list, .esis-caption-container, .esis-nav, .esis-caption
     display none
 
 .edit-section-container[data-editing=true][data-type=image_set]
-  .edit-section-controls, .esis-controls-container, .esis-images-list, .edit-section-remove, .esis-caption-container
+  .edit-section-controls, .esis-controls-container, .esis-images-list, .esis-caption-container
     display block
   .esis-nav, .esis-caption
     display inline-block
-  .esis-preview-container
+  .esis-preview-container, .edit-section-remove
     display none

--- a/client/apps/edit/components/section_image_set/index.styl
+++ b/client/apps/edit/components/section_image_set/index.styl
@@ -269,13 +269,13 @@ wide-input-width = 640px
 .edit-section-container[data-editing=false][data-type=image_set]
   .esis-preview-container, .edit-section-remove
     display block
-  .edit-section-controls, .esis-controls-container, .esis-images-list, .esis-caption-container, .esis-nav, .esis-caption
+  .edit-section-controls, .esis-controls-container, .esis-images-list, .esis-caption-container, .esis-nav, .esis-caption, .esis-img-remove
     display none
 
 .edit-section-container[data-editing=true][data-type=image_set]
-  .edit-section-controls, .esis-controls-container, .esis-images-list, .esis-caption-container
+  .esis-preview-container, .edit-section-remove
+    display none
+  .edit-section-controls, .esis-controls-container, .esis-images-list, .esis-caption-container, .esis-img-remove
     display block
   .esis-nav, .esis-caption
     display inline-block
-  .esis-preview-container, .edit-section-remove
-    display none

--- a/client/apps/edit/components/section_image_set/input.coffee
+++ b/client/apps/edit/components/section_image_set/input.coffee
@@ -16,6 +16,7 @@ module.exports = React.createClass
   getInitialState: ->
     caption: @props.caption or ''
     images: @props.images
+    url: @props.url
 
   componentDidMount: ->
     @attachScribe()
@@ -41,7 +42,7 @@ module.exports = React.createClass
     return unless @refs.editable
     toggleScribePlaceholder @refs.editable.getDOMNode()
     url = $(@refs.editable.getDOMNode()).data('id')
-    newImages = _.clone @state.images
+    newImages = _.clone @props.images
     image = _.find(newImages, url: url)
     image.caption = $(@refs.editable.getDOMNode()).html()
 
@@ -52,17 +53,17 @@ module.exports = React.createClass
         ref: 'editable'
         onKeyUp: @onEditableKeyup
         'data-id': @props.url
-        dangerouslySetInnerHTML: __html: @state.caption
+        dangerouslySetInnerHTML: __html: @props.caption
       }
       nav { ref: 'toolbar', className: 'edit-scribe-nav esis-nav' },
         button {
           'data-command-name': 'italic'
           dangerouslySetInnerHTML: __html: '&nbsp;'
-          disabled: if @state.caption then false else true
+          disabled: if @props.caption then false else true
         }
         button {
           'data-command-name': 'linkPrompt'
           dangerouslySetInnerHTML:
             __html: "&nbsp;" + $(icons()).filter('.link').html()
-          disabled: if @state.caption then false else true
+          disabled: if @props.caption then false else true
         }

--- a/client/apps/edit/components/section_video/index.styl
+++ b/client/apps/edit/components/section_video/index.styl
@@ -118,7 +118,7 @@ wide-input-width = 640px
 
 .edit-section-container[data-layout=overflow_fillwidth][data-type=video]
   width 1100px
-  left -280px
+  left -240px
   min-height 400px
   .edit-section-video
     width calc(100vw - 110px)


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/719 https://github.com/artsy/positron/issues/718

I'd like to remove autosave from add/remove/reset on sections. Anytime we create a new section, it temporarily saves an empty section to the DB. Then when we click off, it removes it again and saves. The number of writes to an article during editing ends up being a lot more than I expected. Instead, just warn the user to save if a new section is added and they try to X out. Keyup will still trigger an autosave of the entire article. 
