### PR TITLE
@craigspaeth Default non-italic captions + bug fixes

### DIFF
--- a/client/apps/edit/components/section_image/index.coffee
+++ b/client/apps/edit/components/section_image/index.coffee
@@ -90,12 +90,14 @@ module.exports = React.createClass
               'data-command-name': 'italic'
               dangerouslySetInnerHTML: __html: '&nbsp;'
               disabled: if @state.caption then false else true
+              onClick: @onEditableKeyup
             }
             button {
               'data-command-name': 'linkPrompt'
               dangerouslySetInnerHTML:
                 __html: "&nbsp;" + $(icons()).filter('.link').html()
               disabled: if @state.caption then false else true
+              onClick: @onEditableKeyup
             }
           div {
             className: 'esi-caption bordered-input'

--- a/client/apps/edit/components/section_image/index.coffee
+++ b/client/apps/edit/components/section_image/index.coffee
@@ -57,7 +57,7 @@ module.exports = React.createClass
     @scribe = new Scribe @refs.editable.getDOMNode()
     @scribe.use scribePluginSanitizer {
       tags:
-        p: true
+        p: false
         i: true
         a: { href: true, target: '_blank' }
     }

--- a/client/apps/edit/components/section_image/index.coffee
+++ b/client/apps/edit/components/section_image/index.coffee
@@ -57,7 +57,6 @@ module.exports = React.createClass
     @scribe = new Scribe @refs.editable.getDOMNode()
     @scribe.use scribePluginSanitizer {
       tags:
-        p: false
         i: true
         a: { href: true, target: '_blank' }
     }

--- a/client/apps/edit/components/section_image/index.styl
+++ b/client/apps/edit/components/section_image/index.styl
@@ -75,6 +75,5 @@
 .esi-inline-caption
   color gray-darker-color
   margin-top 10px
-  font-style italic
   a
     color gray-darker-color

--- a/client/apps/edit/components/section_image_set/input.coffee
+++ b/client/apps/edit/components/section_image_set/input.coffee
@@ -30,10 +30,8 @@ module.exports = React.createClass
     @scribe = new Scribe @refs.editable.getDOMNode()
     @scribe.use scribePluginSanitizer {
       tags:
-        p: false
         i: true
         a: { href: true, target: '_blank' }
-        br: false
     }
     @scribe.use scribePluginToolbar @refs.toolbar.getDOMNode()
     @scribe.use scribePluginLinkTooltip()

--- a/client/apps/edit/components/section_image_set/input.coffee
+++ b/client/apps/edit/components/section_image_set/input.coffee
@@ -30,16 +30,16 @@ module.exports = React.createClass
     @scribe = new Scribe @refs.editable.getDOMNode()
     @scribe.use scribePluginSanitizer {
       tags:
-        p: true
+        p: false
         i: true
         a: { href: true, target: '_blank' }
+        br: false
     }
     @scribe.use scribePluginToolbar @refs.toolbar.getDOMNode()
     @scribe.use scribePluginLinkTooltip()
     toggleScribePlaceholder @refs.editable.getDOMNode()
 
   onEditableKeyup: ->
-    return unless @refs.editable
     toggleScribePlaceholder @refs.editable.getDOMNode()
     url = $(@refs.editable.getDOMNode()).data('id')
     newImages = _.clone @props.images

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -157,6 +157,11 @@
       "from": "assert-plus@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
     },
+    "ast-types": {
+      "version": "0.8.16",
+      "from": "ast-types@0.8.16",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
+    },
     "astw": {
       "version": "2.0.0",
       "from": "astw@>=2.0.0 <3.0.0",
@@ -202,9 +207,9 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.29.tgz"
     },
     "backbone": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "from": "backbone@>=1.2.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz"
     },
     "backbone-super-sync": {
       "version": "1.1.1",
@@ -232,9 +237,9 @@
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
     },
     "bcrypt": {
-      "version": "0.8.5",
+      "version": "0.8.6",
       "from": "bcrypt@>=0.8.5 <0.9.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.5.tgz"
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.6.tgz"
     },
     "benv": {
       "version": "3.0.0",
@@ -259,9 +264,9 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
     },
     "bl": {
-      "version": "1.0.3",
-      "from": "bl@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+      "version": "1.1.2",
+      "from": "bl@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -276,9 +281,9 @@
       }
     },
     "bluebird": {
-      "version": "3.3.4",
+      "version": "3.3.5",
       "from": "bluebird@>=3.3.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.5.tgz"
     },
     "bluebird-q": {
       "version": "1.0.3",
@@ -293,9 +298,9 @@
       }
     },
     "bn.js": {
-      "version": "4.11.1",
+      "version": "4.11.3",
       "from": "bn.js@>=4.1.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.1.tgz"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz"
     },
     "body-parser": {
       "version": "1.15.0",
@@ -325,9 +330,9 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
     },
     "braces": {
-      "version": "1.8.3",
+      "version": "1.8.4",
       "from": "braces@>=1.8.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz"
     },
     "broadway": {
       "version": "0.3.6",
@@ -365,6 +370,16 @@
           "version": "1.0.0",
           "from": "defined@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
         }
       }
     },
@@ -399,14 +414,26 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         },
         "readable-stream": {
-          "version": "2.0.6",
+          "version": "2.1.0",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
           "dependencies": {
             "isarray": {
               "version": "1.0.0",
               "from": "isarray@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.14",
+              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
             }
           }
         }
@@ -448,9 +475,9 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "bson": {
-      "version": "0.4.22",
-      "from": "bson@>=0.4.21 <0.5.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.22.tgz"
+      "version": "0.4.23",
+      "from": "bson@>=0.4.23 <0.5.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
     },
     "bucket-assets": {
       "version": "0.2.12",
@@ -564,9 +591,9 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
     },
     "clean-css": {
-      "version": "3.4.10",
+      "version": "3.4.12",
       "from": "clean-css@>=3.1.9 <4.0.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
@@ -640,9 +667,9 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
     },
     "component-emitter": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "from": "component-emitter@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
@@ -655,9 +682,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.1.9 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
@@ -787,9 +814,9 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz"
     },
     "cssfilter": {
-      "version": "0.0.6",
-      "from": "cssfilter@0.0.6",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.6.tgz"
+      "version": "0.0.7",
+      "from": "cssfilter@0.0.7",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.7.tgz"
     },
     "cssify": {
       "version": "0.7.0",
@@ -812,9 +839,9 @@
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
     },
     "dashdash": {
-      "version": "1.13.0",
-      "from": "dashdash@>=1.10.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+      "version": "1.13.1",
+      "from": "dashdash@>=1.12.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -905,7 +932,19 @@
     "deps-sort": {
       "version": "1.3.9",
       "from": "deps-sort@>=1.3.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz"
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
+        }
+      }
     },
     "des.js": {
       "version": "1.0.0",
@@ -987,9 +1026,9 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.1.9 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
@@ -1000,7 +1039,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
@@ -1043,11 +1082,6 @@
       "from": "escodegen@>=1.6.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
       "dependencies": {
-        "esprima": {
-          "version": "2.7.2",
-          "from": "esprima@>=2.7.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-        },
         "source-map": {
           "version": "0.2.0",
           "from": "source-map@>=0.2.0 <0.3.0",
@@ -1055,10 +1089,15 @@
         }
       }
     },
-    "esprima-fb": {
-      "version": "13001.1001.0-dev-harmony-fb",
-      "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+    "esmangle-evaluator": {
+      "version": "1.0.0",
+      "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
+    },
+    "esprima": {
+      "version": "2.7.2",
+      "from": "esprima@>=2.7.1 <2.8.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
     },
     "estraverse": {
       "version": "1.9.3",
@@ -1113,9 +1152,9 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
     },
     "expand-brackets": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "from": "expand-brackets@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
     },
     "expand-range": {
       "version": "1.8.1",
@@ -1183,6 +1222,18 @@
       "version": "1.0.1",
       "from": "ezel-assets@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ezel-assets/-/ezel-assets-1.0.1.tgz"
+    },
+    "falafel": {
+      "version": "1.2.0",
+      "from": "falafel@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "1.2.2",
+          "from": "acorn@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+        }
+      }
     },
     "fast-csv": {
       "version": "0.6.0",
@@ -1677,11 +1728,6 @@
           "from": "ms@0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
-        "nan": {
-          "version": "2.2.1",
-          "from": "nan@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
-        },
         "node-pre-gyp": {
           "version": "0.6.25",
           "from": "node-pre-gyp@0.6.25",
@@ -1947,6 +1993,18 @@
       "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
+    "getpass": {
+      "version": "0.1.5",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.5.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
     "glob": {
       "version": "5.0.15",
       "from": "glob@>=5.0.5 <6.0.0",
@@ -2018,7 +2076,7 @@
     },
     "hawk": {
       "version": "3.1.3",
-      "from": "hawk@>=3.1.0 <3.2.0",
+      "from": "hawk@>=3.1.3 <3.2.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "hoek": {
@@ -2052,9 +2110,9 @@
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
@@ -2123,6 +2181,11 @@
       "from": "ini@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
+    "inline-process-browser": {
+      "version": "2.0.1",
+      "from": "inline-process-browser@>=2.0.1 <2.1.0",
+      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz"
+    },
     "inline-source-map": {
       "version": "0.5.0",
       "from": "inline-source-map@>=0.5.0 <0.6.0",
@@ -2131,7 +2194,19 @@
     "insert-module-globals": {
       "version": "6.6.3",
       "from": "insert-module-globals@>=6.4.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz"
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
+        }
+      }
     },
     "ipaddr.js": {
       "version": "1.0.5",
@@ -2155,7 +2230,7 @@
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-extendable": {
@@ -2188,6 +2263,11 @@
       "from": "is-number@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+    },
     "is-primitive": {
       "version": "2.0.0",
       "from": "is-primitive@>=2.0.0 <3.0.0",
@@ -2219,9 +2299,16 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
     },
     "isobject": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "from": "isobject@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2254,9 +2341,9 @@
       "resolved": "https://registry.npmjs.org/joi-objectid/-/joi-objectid-2.0.0.tgz"
     },
     "jquery": {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "from": "jquery@>=2.1.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.3.tgz"
     },
     "jquery-autosize": {
       "version": "1.18.18",
@@ -2274,9 +2361,9 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jsdom": {
-      "version": "8.2.0",
+      "version": "8.4.1",
       "from": "jsdom@>=4.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.4.1.tgz"
     },
     "json-schema": {
       "version": "0.2.2",
@@ -2323,6 +2410,11 @@
       "from": "jstransform@>=10.0.1 <11.0.0",
       "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
       "dependencies": {
+        "esprima-fb": {
+          "version": "13001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+        },
         "source-map": {
           "version": "0.1.31",
           "from": "source-map@0.1.31",
@@ -2338,7 +2430,14 @@
     "kerberos": {
       "version": "0.0.17",
       "from": "kerberos@0.0.17",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.17.tgz"
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.17.tgz",
+      "dependencies": {
+        "nan": {
+          "version": "2.0.9",
+          "from": "nan@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
+        }
+      }
     },
     "keygrip": {
       "version": "1.0.1",
@@ -2378,9 +2477,9 @@
       "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz"
     },
     "lazy-cache": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "from": "lazy-cache@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
     },
     "levn": {
       "version": "0.3.0",
@@ -2393,9 +2492,9 @@
       "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz"
     },
     "lodash": {
-      "version": "4.7.0",
+      "version": "4.11.1",
       "from": "lodash@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.7.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.1.tgz"
     },
     "lodash-amd": {
       "version": "3.5.0",
@@ -2408,9 +2507,9 @@
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
     },
     "lodash._baseclone": {
-      "version": "4.5.3",
+      "version": "4.5.6",
       "from": "lodash._baseclone@>=4.5.0 <4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.3.tgz"
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.6.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -2473,14 +2572,14 @@
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "log4js": {
-      "version": "0.6.33",
+      "version": "0.6.35",
       "from": "log4js@*",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.33.tgz",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.35.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
+          "version": "1.0.34",
           "from": "readable-stream@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
@@ -2525,9 +2624,9 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "micromatch": {
-      "version": "2.3.7",
+      "version": "2.3.8",
       "from": "micromatch@>=2.1.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz"
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz"
     },
     "miller-rabin": {
       "version": "4.0.0",
@@ -2634,21 +2733,26 @@
           "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.1.13 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
         }
       }
     },
     "moment": {
-      "version": "2.12.0",
+      "version": "2.13.0",
       "from": "moment@>=2.10.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
     },
     "mongodb-core": {
-      "version": "1.3.13",
+      "version": "1.3.18",
       "from": "mongodb-core@>=1.2.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.13.tgz"
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz"
     },
     "mongojs": {
       "version": "1.4.1",
@@ -2661,9 +2765,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.0.6",
+          "version": "2.1.0",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz"
         }
       }
     },
@@ -2683,9 +2787,9 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
     },
     "nan": {
-      "version": "2.0.5",
-      "from": "nan@2.0.5",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
+      "version": "2.2.1",
+      "from": "nan@2.2.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
     },
     "natural": {
       "version": "0.4.0",
@@ -2720,9 +2824,9 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
     },
     "newrelic": {
-      "version": "1.26.1",
+      "version": "1.26.2",
       "from": "newrelic@>=1.22.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.26.1.tgz",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.26.2.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.5.1",
@@ -2731,7 +2835,8 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0"
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "readable-stream": {
               "version": "2.0.6",
@@ -2785,6 +2890,7 @@
             "debug": {
               "version": "2.2.0",
               "from": "debug@2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
@@ -2817,7 +2923,8 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0"
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
@@ -2927,7 +3034,7 @@
     },
     "oauth-sign": {
       "version": "0.8.1",
-      "from": "oauth-sign@>=0.8.0 <0.9.0",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
     },
     "object-assign": {
@@ -2942,7 +3049,7 @@
     },
     "object-keys": {
       "version": "1.0.9",
-      "from": "object-keys@>=1.0.4 <2.0.0",
+      "from": "object-keys@>=1.0.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
     },
     "object.omit": {
@@ -3003,9 +3110,9 @@
       "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
       "dependencies": {
         "shell-quote": {
-          "version": "1.5.0",
+          "version": "1.6.0",
           "from": "shell-quote@>=1.4.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.0.tgz"
         }
       }
     },
@@ -3095,9 +3202,9 @@
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pkginfo": {
       "version": "0.3.1",
@@ -3135,6 +3242,11 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
+    },
+    "private": {
+      "version": "0.1.6",
+      "from": "private@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process": {
       "version": "0.11.2",
@@ -3271,9 +3383,9 @@
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.0.31 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
@@ -3288,9 +3400,9 @@
       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.1.13-1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
@@ -3310,9 +3422,21 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         },
         "readable-stream": {
-          "version": "2.0.6",
+          "version": "2.1.0",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz"
+        }
+      }
+    },
+    "recast": {
+      "version": "0.11.5",
+      "from": "recast@>=0.11.4 <0.12.0",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.5",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
         }
       }
     },
@@ -3322,9 +3446,9 @@
       "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
     },
     "regex-cache": {
-      "version": "0.4.2",
+      "version": "0.4.3",
       "from": "regex-cache@>=0.4.2 <0.5.0",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -3337,14 +3461,14 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
     },
     "request": {
-      "version": "2.69.0",
+      "version": "2.72.0",
       "from": "request@>=2.9.100",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
       "dependencies": {
         "qs": {
-          "version": "6.0.2",
-          "from": "qs@>=6.0.2 <6.1.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+          "version": "6.1.0",
+          "from": "qs@>=6.1.0 <6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
         }
       }
     },
@@ -3455,19 +3579,18 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
     },
     "scribe-editor": {
-      "version": "2.2.2",
+      "version": "2.3.0",
       "from": "scribe-editor@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/scribe-editor/-/scribe-editor-2.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/scribe-editor/-/scribe-editor-2.3.0.tgz"
     },
     "scribe-plugin-enhanced-link-tooltip": {
-      "version": "0.0.8",
+      "version": "0.0.9",
       "from": "git://github.com/artsy/scribe-plugin-enhanced-link-tooltip.git",
-      "resolved": "git://github.com/artsy/scribe-plugin-enhanced-link-tooltip.git#ff96e6c2e37eee3c36912f64a3e492cda0bd69ad"
+      "resolved": "git://github.com/artsy/scribe-plugin-enhanced-link-tooltip.git#a963ed37bbf0901e79bd8b9739d727725f8351d6"
     },
     "scribe-plugin-follow-link-tooltip": {
-      "version": "1.0.1",
-      "from": "scribe-plugin-follow-link-tooltip@1.0.1",
-      "resolved": "https://registry.npmjs.org/scribe-plugin-follow-link-tooltip/-/scribe-plugin-follow-link-tooltip-1.0.1.tgz"
+      "version": "1.0.3",
+      "from": "scribe-plugin-follow-link-tooltip@>=1.0.0 <2.0.0"
     },
     "scribe-plugin-heading-command": {
       "version": "0.1.0",
@@ -3475,9 +3598,8 @@
       "resolved": "https://registry.npmjs.org/scribe-plugin-heading-command/-/scribe-plugin-heading-command-0.1.0.tgz"
     },
     "scribe-plugin-jump-link": {
-      "version": "1.0.0",
-      "from": "scribe-plugin-jump-link@1.0.0",
-      "resolved": "https://registry.npmjs.org/scribe-plugin-jump-link/-/scribe-plugin-jump-link-1.0.0.tgz"
+      "version": "1.0.1",
+      "from": "scribe-plugin-jump-link@>=1.0.0 <2.0.0"
     },
     "scribe-plugin-keyboard-shortcuts": {
       "version": "0.1.1",
@@ -3604,9 +3726,16 @@
       "resolved": "https://registry.npmjs.org/sqwish/-/sqwish-0.2.2.tgz"
     },
     "sshpk": {
-      "version": "1.7.4",
+      "version": "1.8.2",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.2.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
     },
     "stack-trace": {
       "version": "0.0.9",
@@ -3629,9 +3758,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.0.6",
+          "version": "2.1.0",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz"
         }
       }
     },
@@ -3641,9 +3770,9 @@
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
+          "version": "1.0.34",
           "from": "readable-stream@>=1.0.17 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.5.1",
@@ -3673,9 +3802,14 @@
       "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.1.13-1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
         }
       }
     },
@@ -3803,14 +3937,14 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
-      "version": "1.1.1",
-      "from": "through2@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+      "version": "0.6.5",
+      "from": "through2@>=0.6.5 <0.7.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
-          "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
@@ -3892,9 +4026,9 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
     },
     "tweetnacl": {
-      "version": "0.14.3",
-      "from": "tweetnacl@>=0.13.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+      "version": "0.13.3",
+      "from": "tweetnacl@>=0.13.0 <0.14.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
     "type-check": {
       "version": "0.3.2",
@@ -3932,9 +4066,9 @@
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "source-map": {
-          "version": "0.5.3",
+          "version": "0.5.5",
           "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
         }
       }
     },
@@ -3994,6 +4128,11 @@
       "version": "1.0.0",
       "from": "unpipe@1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+    },
+    "unreachable-branch-transform": {
+      "version": "0.5.1",
+      "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz"
     },
     "url": {
       "version": "0.10.3",
@@ -4085,9 +4224,9 @@
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.0.0.tgz"
         },
         "buffer": {
-          "version": "4.5.1",
+          "version": "4.6.0",
           "from": "buffer@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.6.0.tgz",
           "dependencies": {
             "isarray": {
               "version": "1.0.0",
@@ -4102,14 +4241,26 @@
           "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
         },
         "combine-source-map": {
-          "version": "0.7.1",
+          "version": "0.7.2",
           "from": "combine-source-map@>=0.7.1 <0.8.0",
-          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz"
         },
         "concat-stream": {
           "version": "1.5.1",
           "from": "concat-stream@>=1.5.1 <1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "readable-stream": {
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+            }
+          }
         },
         "constants-browserify": {
           "version": "1.0.0",
@@ -4137,9 +4288,9 @@
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
         },
         "inline-source-map": {
-          "version": "0.6.1",
+          "version": "0.6.2",
           "from": "inline-source-map@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz"
         },
         "insert-module-globals": {
           "version": "7.0.1",
@@ -4162,9 +4313,9 @@
           "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.0.6",
+          "version": "2.1.0",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
           "dependencies": {
             "isarray": {
               "version": "1.0.0",
@@ -4174,14 +4325,14 @@
           }
         },
         "shell-quote": {
-          "version": "1.5.0",
+          "version": "1.6.0",
           "from": "shell-quote@>=1.4.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.0.tgz"
         },
         "source-map": {
-          "version": "0.4.2",
-          "from": "source-map@0.4.2",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz"
+          "version": "0.5.5",
+          "from": "source-map@>=0.5.3 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
         },
         "stream-combiner2": {
           "version": "1.1.1",
@@ -4189,9 +4340,9 @@
           "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
         },
         "stream-http": {
-          "version": "2.2.1",
+          "version": "2.3.0",
           "from": "stream-http@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.3.0.tgz"
         },
         "stream-splicer": {
           "version": "2.0.0",
@@ -4201,7 +4352,19 @@
         "through2": {
           "version": "2.0.1",
           "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "readable-stream": {
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+            }
+          }
         },
         "url": {
           "version": "0.11.0",
@@ -4223,9 +4386,9 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
     },
     "whatwg-url": {
-      "version": "1.0.1",
-      "from": "whatwg-url@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-1.0.1.tgz"
+      "version": "2.0.1",
+      "from": "whatwg-url@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-2.0.1.tgz"
     },
     "window-size": {
       "version": "0.1.0",
@@ -4297,9 +4460,9 @@
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
     },
     "xss": {
-      "version": "0.2.10",
+      "version": "0.2.12",
       "from": "xss@>=0.2.7 <0.3.0",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-0.2.12.tgz",
       "dependencies": {
         "commander": {
           "version": "2.9.0",
@@ -4310,7 +4473,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
+      "from": "xtend@>=4.0.0 <4.1.0-0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yallist": {


### PR DESCRIPTION
Makes non-italic the default for captions
fixes a bug @halleyjohnson noticed with clicking into an input
pulls the latest `scribe-plugin-enhanced-link-tooltip` which fixes a bug with input link toggle
fixes a bug where italics and links weren't being applied to the caption preview in an image section