### PR TITLE
@craigspaeth Revist tagging

### DIFF
--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -259,9 +259,7 @@ typecastIds = (article) ->
     super_article: if article.super_article?.related_articles then _.extend article.super_article, related_articles: article.super_article.related_articles.map(ObjectId) else {}
 
 @sendArticleToSailthru = (article, cb) =>
-  images = {}
-  tags = []
-  tags = tags.concat ['article']
+  tags = ['article']
   tags = tags.concat ['artsy-editorial'] if article.author_id is ARTSY_EDITORIAL_ID
   tags = tags.concat ['magazine'] if article.featured is true
   tags = tags.concat article.keywords

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -651,10 +651,11 @@ describe 'Article', ->
         fair_id: '5530e72f7261696238050000'
         partner_ids: ['4f5228a1de92d1000100076e']
         tags: ['cool', 'art']
+        contributing_authors: [{name: 'kana'}]
         published: true
       }, 'foo', (err, article) ->
         return done err if err
-        article.keywords.join(',').should.equal 'Pablo Picasso,Pablo Picasso,Armory Show 2013,Gagosian Gallery,cool,art'
+        article.keywords.join(',').should.equal 'cool,art,Pablo Picasso,Pablo Picasso,Armory Show 2013,Gagosian Gallery,kana'
         done()
 
     it 'saves Super Articles', (done) ->

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -50,6 +50,21 @@ describe 'Save', ->
         @sailthru.apiPost.args[0][1].tags.should.containEql 'magazine'
         done()
 
+    it 'concats the keywords at the end', (done) ->
+      Save.sendArticleToSailthru {
+        author_id: '5086df098523e60002000018'
+        published: true
+        featured: true
+        keywords: ['sofa', 'midcentury', 'knoll']
+      }, (err, article) =>
+        @sailthru.apiPost.calledOnce.should.be.true()
+        @sailthru.apiPost.args[0][1].tags[0].should.equal 'article'
+        @sailthru.apiPost.args[0][1].tags[1].should.equal 'magazine'
+        @sailthru.apiPost.args[0][1].tags[2].should.equal 'sofa'
+        @sailthru.apiPost.args[0][1].tags[3].should.equal 'midcentury'
+        @sailthru.apiPost.args[0][1].tags[4].should.equal 'knoll'
+        done()
+
     it 'uses email_metadata vars if provided', (done) ->
       Save.sendArticleToSailthru {
         author_id: '5086df098523e60002000018'


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/732

- Adds contributing authors to the end of the keywords array
- Reverse order of tags -- manually added ones should appear in front
