### PR TITLE
@dzucconi Changes denormalize artwork criteria

### DIFF
--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -50,6 +50,8 @@ Q = require 'bluebird-q'
           debug err if err
           mergeArticleAndAuthor input, article, accessToken, (err, article, author, publishing) ->
             return callback(err) if err
+            console.log 'Here are the article sections after denormalizing'
+            console.log article.sections
             # Merge fullscreen title with main article title
             article.title = article.hero_section.title if article.hero_section?.type is 'fullscreen'
             if publishing

--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -50,8 +50,6 @@ Q = require 'bluebird-q'
           debug err if err
           mergeArticleAndAuthor input, article, accessToken, (err, article, author, publishing) ->
             return callback(err) if err
-            console.log 'Here are the article sections after denormalizing'
-            console.log article.sections
             # Merge fullscreen title with main article title
             article.title = article.hero_section.title if article.hero_section?.type is 'fullscreen'
             if publishing

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -105,13 +105,13 @@ setEmailFields = (article, author) =>
     cb(null, article)
 
 @generateArtworks = (input, article, cb) ->
-  before = _.flatten _.pluck _.where(article.sections, type: 'artworks'), 'ids'
-  after = _.flatten _.pluck _.where(input.sections, type: 'artworks'), 'ids'
-  intersection = _.intersection(before, after)
-  if input.sections and input.sections.length > 0
+  if input.sections?.length > 0
     article.sections = input.sections
   return cb null, article unless input.sections
-  return cb(null, article) if intersection.length is before.length and intersection.length is after.length
+  emptyArtworks = _.filter input.sections, (section) ->
+    section.type is 'artworks' and section.artworks.length is 0
+  if emptyArtworks.length is 0
+    return cb(null, article)
   # Try to fetch and denormalize the artworks from Gravity asynchonously
   artworkIds = _.pluck (_.where input.sections, type: 'artworks' ), 'ids'
   Q.allSettled( for artworkId in _.flatten artworkIds

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -167,6 +167,7 @@ describe 'Save', ->
             type: 'artworks'
             layout: 'overflow'
             ids: ['564be09ab202a319e90000e2']
+            artworks: []
           }
         ]
       }, {}, (err, article) =>
@@ -186,6 +187,7 @@ describe 'Save', ->
             type: 'artworks'
             layout: 'overflow'
             ids: ['123', '564be09ab202a319e90000e2']
+            artworks: []
           }
         ]
       }, {}, (err, article) =>
@@ -205,6 +207,7 @@ describe 'Save', ->
             type: 'artworks'
             layout: 'overflow'
             ids: ['123']
+            artworks: []
           }
         ]
       }, {}, (err, article) =>


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/741

Sooo instead of denormalizing when there are artworks added/removed based on the `id`, i would like to denormalize if we detect an artwork that hasn't been denormalized. That is, an artwork array that is empty since newly added artworks default to `[]`. 

Mainly, this supports a flow of autosave events where the client might not have the denormalized artworks before a user tries to save again. Let me know if you want me to explain anything further.