### PR TITLE
@craigspaeth Adds channel_id to articles

### DIFF
--- a/api/apps/articles/model/retrieve.coffee
+++ b/api/apps/articles/model/retrieve.coffee
@@ -11,7 +11,7 @@ moment = require 'moment'
     # Separate "find" query from sort/offest/limit
     { limit, offset, sort } = input
     query = _.omit input, 'limit', 'offset', 'sort', 'artist_id', 'artwork_id', 'super_article_for',
-      'fair_ids', 'fair_programming_id', 'fair_artsy_id', 'fair_about_id', 'partner_id', 'auction_id', 'show_id', 'q', 'all_by_author', 'section_id', 'tags', 'has_video', 'fair_id'
+      'fair_ids', 'fair_programming_id', 'fair_artsy_id', 'fair_about_id', 'partner_id', 'auction_id', 'show_id', 'q', 'all_by_author', 'section_id', 'tags', 'has_video', 'fair_id', 'channel_id'
     # Type cast IDs
     # TODO: https://github.com/pebble/joi-objectid/issues/2#issuecomment-75189638
     query.author_id = ObjectId input.author_id if input.author_id
@@ -27,6 +27,7 @@ moment = require 'moment'
     query.biography_for_artist_id = ObjectId input.biography_for_artist_id if input.biography_for_artist_id
     query.featured_artwork_ids = ObjectId input.artwork_id if input.artwork_id
     query.tags = { $in: input.tags } if input.tags
+    query.channel_id = ObjectId input.channel_id if input.channel_id
 
     # Convert query for super article for article
     query['super_article.related_articles']= ObjectId(input.super_article_for) if input.super_article_for

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -260,6 +260,7 @@ typecastIds = (article) ->
     featured_artwork_ids: article.featured_artwork_ids.map(ObjectId) if article.featured_artwork_ids
     biography_for_artist_id: ObjectId(article.biography_for_artist_id) if article.biography_for_artist_id
     super_article: if article.super_article?.related_articles then _.extend article.super_article, related_articles: article.super_article.related_articles.map(ObjectId) else {}
+    channel_id: ObjectId(article.channel_id) if article.channel_id
 
 @sendArticleToSailthru = (article, cb) =>
   tags = ['article']

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -146,6 +146,7 @@ denormalizedArtwork = (->
     related_articles: @array().items(@objectId()).allow(null)
   send_body: @boolean().default(false)
   instant_article: @boolean().default(false)
+  channel_id: @objectId().allow(null)
 ).call Joi
 
 #
@@ -181,4 +182,5 @@ denormalizedArtwork = (->
   layout: @string()
   instant_article: @boolean()
   has_video: @boolean()
+  channel_id: @objectId()
 ).call Joi

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -352,6 +352,23 @@ describe 'Article', ->
           results[0].title.should.equal 'Hello Wurld'
           done()
 
+    it 'can find articles by channel_id', (done) ->
+      fabricate 'articles', [
+        {
+          title: 'Hello Wurld'
+          published: true
+          channel_id: ObjectId '5086df098523e60002000016'
+        }
+      ], ->
+        Article.where {
+          published: true
+          channel_id: '5086df098523e60002000016'
+        }, (err, res) ->
+          { total, count, results } = res
+          count.should.equal 1
+          results[0].title.should.equal 'Hello Wurld'
+          done()
+
   describe '#find', ->
 
     it 'finds an article by an id string', (done) ->
@@ -866,6 +883,15 @@ describe 'Article', ->
       }, 'foo', (err, article) ->
         return done err if err
         article.instant_article.should.be.true()
+        done()
+
+    it 'saves the channel_id', (done) ->
+      Article.save {
+        author_id: '5086df098523e60002000018'
+        channel_id: '5086df098523e60002000015'
+      }, 'foo', (err, article) ->
+        return done err if err
+        article.channel_id.toString().should.equal '5086df098523e60002000015'
         done()
 
   describe '#publishScheduledArticles', ->

--- a/api/apps/channels/model.coffee
+++ b/api/apps/channels/model.coffee
@@ -22,6 +22,7 @@ schema = (->
   id: @objectId()
   name: @string().allow('', null)
   user_ids: @array().items(@objectId()).default([])
+  type: @string().allow('', null)
 ).call Joi
 
 querySchema = (->

--- a/api/apps/channels/test/model.coffee
+++ b/api/apps/channels/test/model.coffee
@@ -35,9 +35,11 @@ describe 'Channel', ->
       Channel.save {
         name: 'Editorial'
         user_ids: ['5086df098523e60002000015', '5086df098523e60002000014']
+        type: 'editorial'
       }, (err, channel) ->
         channel.user_ids[0].toString().should.equal '5086df098523e60002000015'
         channel.user_ids[1].toString().should.equal '5086df098523e60002000014'
+        channel.type.should.equal 'editorial'
         db.channels.count (err, count) ->
           count.should.equal 11
           done()


### PR DESCRIPTION
Instead of having both `channel_ids` and `partner_channel_ids`, I'm thinking it can be consolidated to one `channel_id` since we've established that articles can only be in one channel, whether it be a partner or our own. 

The desired workflow is that we'd copy the article if we want in two channels (benefits analytics, tweak content for channel, extended versions, etc).

The one weird thing is mixing id types, where `channel_id` can be a Channel or Partner. Is that too confusing? I don't mind separating it to `channel_id` and `partner_channel_id` either. 
