### PR TITLE
@craigspaeth Decrease size limit in image uploader

### DIFF
--- a/client/components/image_upload_form/form.jade
+++ b/client/components/image_upload_form/form.jade
@@ -5,7 +5,7 @@ section.image-upload-form( data-state=(src ? 'loaded': '') )
     | or&nbsp;
     span.image-upload-form-click click&nbsp;
     | to upload
-  h2 Up to 30MB
+  h2 Up to 10MB
   .type-error Please choose .png, .jpg, or .gif
   .size-error File is too large
   if src

--- a/client/components/image_upload_form/index.coffee
+++ b/client/components/image_upload_form/index.coffee
@@ -25,7 +25,7 @@ module.exports = class ImageUploadForm extends Backbone.View
     if type not in acceptedTypes
       @$('.image-upload-form').attr 'data-error', 'type'
       return
-    if e.target.files[0]?.size > 30000000
+    if e.target.files[0]?.size > 10000000
       @$('.image-upload-form').attr 'data-error', 'size'
       return
     @$('.image-upload-form').attr 'data-error', null


### PR DESCRIPTION
Last Friday we had a piece that contained a bunch of images that were over 15MB and caused Gemini to choke. This decreases the size limit to 10MB.