### PR TITLE
@craigspaeth Channel query, biz logic, save partner + channel on user

### DIFF
--- a/api/apps/channels/model.coffee
+++ b/api/apps/channels/model.coffee
@@ -28,6 +28,7 @@ schema = (->
 querySchema = (->
   limit: @number().max(Number API_MAX).default(Number API_PAGE_SIZE)
   offset: @number()
+  user_id: @objectId()
 ).call Joi
 
 #
@@ -40,7 +41,8 @@ querySchema = (->
 @where = (input, callback) ->
   Joi.validate input, querySchema, (err, input) =>
     return callback err if err
-    query = _.omit input, 'limit', 'offset'
+    query = _.omit input, 'limit', 'offset', 'user_id'
+    query.user_ids = ObjectId input.user_id if input.user_id
     cursor = db.channels
       .find(query)
       .limit(input.limit)

--- a/api/apps/channels/test/model.coffee
+++ b/api/apps/channels/test/model.coffee
@@ -21,6 +21,21 @@ describe 'Channel', ->
         results[0].name.should.equal 'Editorial'
         done()
 
+    it 'finds channels by a user_id', (done) ->
+      Channel.save {
+        name: 'Channel'
+        user_ids: ['5086df098523e60002000015', '5086df098523e60002000014']
+        type: 'editorial'
+      }, (err, channel) ->
+        Channel.where
+          user_id: '5086df098523e60002000015'
+        , (err, res) ->
+          { total, count, results } = res
+          total.should.equal 11
+          count.should.equal 1
+          results[0].name.should.equal 'Channel'
+          done()
+
   describe '#find', ->
 
     it 'finds a channel by an id string', (done) ->

--- a/api/apps/users/test/model.coffee
+++ b/api/apps/users/test/model.coffee
@@ -19,8 +19,9 @@ describe 'User', ->
   beforeEach (done) ->
     empty =>
       User.__set__ 'ARTSY_URL', 'http://localhost:5000/__gravity'
-      @server = app.listen 5000, =>
-        done()
+      fabricate 'channels', {}, (err, @channel) =>
+        @server = app.listen 5000, =>
+          done()
 
   afterEach ->
     @server.close()
@@ -31,6 +32,11 @@ describe 'User', ->
       User.fromAccessToken 'foobar', (err, user) ->
         user.name.should.equal 'Craig Spaeth'
         done()
+
+    it 'gets partner_ids', (done) ->
+        User.fromAccessToken 'foobar', (err, user) ->
+          user.partner_ids[0].should.equal '5086df098523e60002000012'
+          done()
 
   describe '#findOrInsert', ->
 
@@ -46,18 +52,6 @@ describe 'User', ->
         User.findOrInsert user.id, 'foobar', (err, user) ->
           user.name.should.equal 'Craig Spaeth'
           done()
-
-    it 'gets admin social media UIDs', (done) ->
-      User.findOrInsert '4d8cd73191a5c50ce200002a', 'foobar', (err, user) ->
-        user.facebook_uid.should.equal '456'
-        user.twitter_uid.should.equal '321'
-        done()
-
-    it 'does not get user social media UIDs', (done) ->
-      User.findOrInsert '563d08e6275b247014000026', 'foobar', (err, user) ->
-        (user.facebook_uid?).should.be.false()
-        (user.twitter_uid?).should.be.false()
-        done()
 
   describe '#present', ->
 

--- a/client/models/channel.coffee
+++ b/client/models/channel.coffee
@@ -4,3 +4,26 @@ sd = require('sharify').data
 module.exports = class Channel extends Backbone.Model
 
   urlRoot: "#{sd.API_URL}/channels"
+
+  getFeatures: ->
+    switch @get 'type'
+      when 'editorial' then {
+        features: ['header', 'superArticle']
+        sections: ['text', 'artworks', 'images', 'image_set', 'video', 'embed', 'callout', 'toc']
+        associations: ['artworks', 'artists', 'shows', 'fairs', 'partners','auctions']
+      }
+      when 'team' then {
+        features: []
+        sections: ['text', 'artworks', 'images', 'image_set', 'video', 'embed', 'callout']
+        associations: []
+      }
+      when 'support' then {
+        features: []
+        sections: ['text', 'artworks', 'images', 'video', 'callout']
+        associations: ['artworks', 'artists', 'shows', 'fairs', 'partners','auctions']
+      }
+      when 'partner' then {
+        features: []
+        sections: ['text','artworks', 'images','video']
+        associations: []
+      }

--- a/client/test/models/channel.coffee
+++ b/client/test/models/channel.coffee
@@ -1,0 +1,41 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+Channel = require '../../models/channel.coffee'
+sinon = require 'sinon'
+fixtures = require '../../../test/helpers/fixtures'
+
+describe "Channel", ->
+
+  beforeEach ->
+    sinon.stub Backbone, 'sync'
+    @channel = new Channel fixtures().articles
+
+  afterEach ->
+    Backbone.sync.restore()
+
+  describe '#getFeatures', ->
+
+    it 'returns features for editorial type', ->
+      @channel.set
+        name: 'Editorial'
+        type: 'editorial'
+      @channel.getFeatures().features[0].should.equal 'header'
+      @channel.getFeatures().sections[0].should.equal 'text'
+      @channel.getFeatures().sections.length.should.equal 8
+      @channel.getFeatures().associations.length.should.equal 6
+
+    it 'returns features for team type', ->
+      @channel.set
+        name: 'Life At Artsy'
+        type: 'team'
+      @channel.getFeatures().features.length.should.equal 0
+      @channel.getFeatures().sections.length.should.equal 7
+      @channel.getFeatures().associations.length.should.equal 0
+
+    it 'returns features for support type', ->
+      @channel.set
+        name: 'Auctions'
+        type: 'support'
+      @channel.getFeatures().features.length.should.equal 0
+      @channel.getFeatures().sections.length.should.equal 5
+      @channel.getFeatures().associations.length.should.equal 6

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -78,7 +78,6 @@ module.exports = ->
     "id" : "4d8cd73191a5c50ce200002a"
     "name" : "Craig Spaeth"
     "type" : "Admin"
-    "access_to_partner_ids" : [ ]
     "profile_icon_url" : "https://d32dm0rphc51dk.cloudfront.net/CJOHhrln8lwVAubiMIIYYA/square140.png"
     "access_token" : "$2a$10$PJrPMBadu1NPdmnshBgFbeZrE3WtYoIoLoeII0mZDqOnatcOdamke"
   fixtures.sections =
@@ -95,7 +94,7 @@ module.exports = ->
   fixtures.channels =
     id: '5086df098523e60002000018'
     name: 'Editorial'
-    user_ids: []
+    user_ids: [ '5522d03ae8e369060053d953', "4d8cd73191a5c50ce200002a" ]
   fixtures.locals =
     asset: ->
     user: new User fixtures.users


### PR DESCRIPTION
This is the final PR before actually switching over the Writer UI to using Channels-- trying to do as much backend work as possible. Will make notes below! 

- Saves Partner and Channel ids to the user
- Adds some biz logic for channel types
- Query for channels by `user_id`
