### PR TITLE
@craigspaeth Don't error on shows that 404 in autocomplete search

### DIFF
--- a/api/apps/shows/model.coffee
+++ b/api/apps/shows/model.coffee
@@ -28,6 +28,7 @@ request = require 'superagent'
             return cb null, null if err
             cb null, { id: res.body._id, value: res.body.name }
       , (err, results) ->
+        return callback err if err
         results = _.compact results
         callback null, results
 

--- a/api/apps/shows/model.coffee
+++ b/api/apps/shows/model.coffee
@@ -25,10 +25,10 @@ request = require 'superagent'
           .get("#{ARTSY_URL}/api/v1/show/#{slug}")
           .set('X-Access-Token': accessToken)
           .end (err, res) ->
-            return cb err if err
+            return cb null, null if err
             cb null, { id: res.body._id, value: res.body.name }
       , (err, results) ->
-        return callback err if err
+        results = _.compact results
         callback null, results
 
 @find = (id, accessToken, callback) ->


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/764

Some shows that were 404-ing would prevent other shows from appearing in the search dropdown. Just return null if the show doesn't exist and let the other shows in the async flow go through. 

