### PR TITLE
@kanabe: Crash on 'no primary server available'

### DIFF
--- a/api/lib/middleware.coffee
+++ b/api/lib/middleware.coffee
@@ -30,5 +30,6 @@ debug = require('debug') 'api'
   # Until then, we know restarting the app fixes this issue. See Slack thread
   # https://artsy.slack.com/archives/web/p1458490282000103
   if err.name is 'MongoError' and
-  msg.match(/connection to host (.*) was destroyed/)
+     msg is 'no primary server available' or
+     msg.match(/connection to host (.*) was destroyed/)
     process.exit(1)


### PR DESCRIPTION
Looks like we were guarding against `connection to host ... destroyed` but not `no primary server available`. This should restart the server if we get into the weird catastrophic state where we lose connection to Mongo that we saw today and some several months ago.

Of course the real fix should be put in [here](https://github.com/christkv/mongodb-core) or [here](https://github.com/mafintosh/mongojs)