### PR TITLE
@xtina-starr Gives associations to partner channels

### DIFF
--- a/client/models/channel.coffee
+++ b/client/models/channel.coffee
@@ -77,7 +77,14 @@ module.exports = class Channel extends Backbone.Model
         'auctions'
       ], association
     else if type is 'partner'
-       false
+      _.contains [
+        'artworks'
+        'artists'
+        'shows'
+        'fairs'
+        'partners'
+        'auctions'
+      ], association
 
   fetchChannelOrPartner: (options) ->
     async.parallel [

--- a/client/test/models/channel.coffee
+++ b/client/test/models/channel.coffee
@@ -122,12 +122,12 @@ describe "Channel", ->
       @channel.set
         name: 'Gagosian'
         type: 'partner'
-      @channel.hasAssociation('artworks').should.be.false()
-      @channel.hasAssociation('artists').should.be.false()
-      @channel.hasAssociation('shows').should.be.false()
-      @channel.hasAssociation('fairs').should.be.false()
-      @channel.hasAssociation('partners').should.be.false()
-      @channel.hasAssociation('auctions').should.be.false()
+      @channel.hasAssociation('artworks').should.be.true()
+      @channel.hasAssociation('artists').should.be.true()
+      @channel.hasAssociation('shows').should.be.true()
+      @channel.hasAssociation('fairs').should.be.true()
+      @channel.hasAssociation('partners').should.be.true()
+      @channel.hasAssociation('auctions').should.be.true()
 
   describe '#fetchChannelOrPartner' , ->
 


### PR DESCRIPTION
The `hasAssociation` method gets used in templates to determine if you should be able to edit associations depending on what Channel its in. Since the Admin panel is only available to Artsy Admins and based [this convo](https://artsy.slack.com/archives/publishing-support/p1469040288000092), we should allow Admins to edit all associations. 
