### PR TITLE
@craigspaeth Use worker for s3 fulcrum data sync

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: make sf
+worker: coffee scripts/daily_upload_s3.coffee


### PR DESCRIPTION
I'm not sure if this will work, but the problem is that the scheduler is only uploading partial CSVs to s3. Instead of running `coffee scripts/daily_upload_s3.coffee` directly in the scheduler, does it help to delegate to a worker or is this the same thing..? 
