### PR TITLE
@craigspaeth => Restrict channel settings for team type

### DIFF
--- a/client/apps/settings/client/channels.coffee
+++ b/client/apps/settings/client/channels.coffee
@@ -16,8 +16,8 @@ module.exports.EditChannel = class EditChannel extends Backbone.View
   initialize: ->
     @channel = new Channel sd.CHANNEL
     @setupUserAutocomplete()
-    @setupPinnedArticlesAutocomplete()
-    @setupBackgroundImageForm()
+    @setupPinnedArticlesAutocomplete() if @channel.isTeam()
+    @setupBackgroundImageForm() if @channel.isTeam()
 
   setupUserAutocomplete: ->
     @user_ids = @channel.get 'user_ids' or []

--- a/client/apps/settings/client/channels.coffee
+++ b/client/apps/settings/client/channels.coffee
@@ -14,7 +14,7 @@ module.exports.EditChannel = class EditChannel extends Backbone.View
     'click .js--channel-save-metadata': 'saveMetadata'
 
   initialize: ->
-    @channel = new Channel sd.CHANNEL
+    @channel = sd.CHANNEL
     @setupUserAutocomplete()
     @setupPinnedArticlesAutocomplete() if @channel.isTeam()
     @setupBackgroundImageForm() if @channel.isTeam()

--- a/client/apps/settings/templates/channel_edit.jade
+++ b/client/apps/settings/templates/channel_edit.jade
@@ -13,44 +13,45 @@ block content
       .admin-form-right
         #channel-edit__users
           //- Rendered on the client
-    section.admin-form-section
-      .admin-form-left
-        h1 Pinned Articles
-        h2 Add and reorder up to six articles that appear in the featured section of the landing page.
-      .admin-form-right
-        #channel-edit__pinned-articles
-          //- Rendered on the client
-    section.admin-form-section.channel-edit__metadata
-      .admin-form-left
-        h1 Metadata
-        h2 Upload a background image, add featured links and a tagline to the landing page.
-      .admin-form-right
-        label.channel-edit__image-label
-          span(data-hidden=(channel.get('image_url') ? 'true' : 'false')) Background Image
-          #channel-edit__image
-        label Slug
-          input.bordered-input(type='text' name='slug' value=channel.get('slug'))
-        label Tagline
-          input.bordered-input(type='text' name='tagline' value=channel.get('tagline') maxlength='65')
-        - links = channel.get('links') || []
-        .channel-edit__links
-          .channel-edit__links-item
-            .channel-edit__header Link 1
-            label Text
-              input.bordered-input( value=links[0] ? links[0].text : '' name='links[0][text]' )
-            label URL
-              input.bordered-input( value=links[0] ? links[0].url : '' name='links[0][url]' )
-          .channel-edit__links-item
-            .channel-edit__header Link 2
-            label Text
-              input.bordered-input( value=links[1] ? links[1].text : '' name='links[1][text]' )
-            label URL
-              input.bordered-input( value=links[1] ? links[1].url : '' name='links[1][url]' )
-          .channel-edit__links-item
-            .channel-edit__header Link 3
-            label Text
-              input.bordered-input( value=links[2] ? links[2].text : '' name='links[2][text]' )
-            label URL
-              input.bordered-input( value=links[2] ? links[2].url : '' name='links[2][url]' )
+    if channel.isTeam()
+      section.admin-form-section
+        .admin-form-left
+          h1 Pinned Articles
+          h2 Add and reorder up to six articles that appear in the featured section of the landing page.
+        .admin-form-right
+          #channel-edit__pinned-articles
+            //- Rendered on the client
+      section.admin-form-section.channel-edit__metadata
+        .admin-form-left
+          h1 Metadata
+          h2 Upload a background image, add featured links and a tagline to the landing page.
+        .admin-form-right
+          label.channel-edit__image-label
+            span(data-hidden=(channel.get('image_url') ? 'true' : 'false')) Background Image
+            #channel-edit__image
+          label Slug
+            input.bordered-input(type='text' name='slug' value=channel.get('slug'))
+          label Tagline
+            input.bordered-input(type='text' name='tagline' value=channel.get('tagline') maxlength='65')
+          - links = channel.get('links') || []
+          .channel-edit__links
+            .channel-edit__links-item
+              .channel-edit__header Link 1
+              label Text
+                input.bordered-input( value=links[0] ? links[0].text : '' name='links[0][text]' )
+              label URL
+                input.bordered-input( value=links[0] ? links[0].url : '' name='links[0][url]' )
+            .channel-edit__links-item
+              .channel-edit__header Link 2
+              label Text
+                input.bordered-input( value=links[1] ? links[1].text : '' name='links[1][text]' )
+              label URL
+                input.bordered-input( value=links[1] ? links[1].url : '' name='links[1][url]' )
+            .channel-edit__links-item
+              .channel-edit__header Link 3
+              label Text
+                input.bordered-input( value=links[2] ? links[2].text : '' name='links[2][text]' )
+              label URL
+                input.bordered-input( value=links[2] ? links[2].url : '' name='links[2][url]' )
 
-        button.avant-garde-button.avant-garde-button-black.js--channel-save-metadata Save Changes
+          button.avant-garde-button.avant-garde-button-black.js--channel-save-metadata Save Changes

--- a/client/apps/settings/test/channels.coffee
+++ b/client/apps/settings/test/channels.coffee
@@ -16,15 +16,16 @@ describe 'EditChannel', ->
       benv.expose $: benv.require 'jquery'
       Backbone.$ = $
       sinon.stub Backbone, 'sync'
-      @channel = new Channel fixtures().channels
+      @channel = new Channel _.extend fixtures().channels, type: 'team'
       locals = _.extend(fixtures().locals,
         channel: @channel
       )
-      locals.sd = _.extend locals.sd, { CURRENT_CHANNEL: @channel }
+      locals.sd = _.extend locals.sd, { CHANNEL: @channel }
       tmpl = resolve __dirname, '../templates/channel_edit.jade'
       benv.render tmpl, locals, =>
         { @EditChannel } = mod = rewire '../client/channels.coffee'
         mod.__set__ 'AutocompleteSortableList', sinon.stub()
+        mod.__set__ 'sd', { CHANNEL: @channel }
         @EditChannel::setupUserAutocomplete = sinon.stub()
         @EditChannel::setupPinnedArticlesAutocomplete = sinon.stub()
         @EditChannel::setupBackgroundImageForm = sinon.stub()

--- a/client/models/channel.coffee
+++ b/client/models/channel.coffee
@@ -9,6 +9,9 @@ module.exports = class Channel extends Backbone.Model
 
   urlRoot: "#{sd.API_URL}/channels"
 
+  isTeam: ->
+    @get('type') is 'team'
+
   hasFeature: (feature) ->
     type = @get('type')
     if type is 'editorial'

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -101,7 +101,7 @@ module.exports = ->
     id: '5086df098523e60002000018'
     name: 'Editorial'
     user_ids: [ '5522d03ae8e369060053d953', "4d8cd73191a5c50ce200002a" ]
-    type: 'team'
+    type: 'editorial'
     tagline: 'A bunch of cool stuff at Artsy'
     image_url: 'artsy.net/image.jpg'
     slug: 'editorial'

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -101,7 +101,7 @@ module.exports = ->
     id: '5086df098523e60002000018'
     name: 'Editorial'
     user_ids: [ '5522d03ae8e369060053d953', "4d8cd73191a5c50ce200002a" ]
-    type: 'editorial'
+    type: 'team'
     tagline: 'A bunch of cool stuff at Artsy'
     image_url: 'artsy.net/image.jpg'
     slug: 'editorial'


### PR DESCRIPTION
Whoops one minor thing I missed was to whitelist the metadata + pinned articles for `team` types.