### PR TITLE
@craigspaeth Add Yoast

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -730,9 +730,9 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cors": {
-      "version": "2.7.1",
+      "version": "2.8.0",
       "from": "cors@>=2.7.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.0.tgz"
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -1257,11 +1257,6 @@
       "version": "0.3.0",
       "from": "fresh@0.3.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
-    },
-    "fs": {
-      "version": "0.0.2",
-      "from": "fs@0.0.2",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz"
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2204,6 +2199,11 @@
       "version": "4.6.0",
       "from": "jadeify@>=4.4.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/jadeify/-/jadeify-4.6.0.tgz"
+    },
+    "jed": {
+      "version": "1.1.1",
+      "from": "jed@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jed/-/jed-1.1.1.tgz"
     },
     "jodid25519": {
       "version": "1.0.2",
@@ -4316,6 +4316,11 @@
       "version": "3.10.0",
       "from": "yargs@>=3.10.0 <3.11.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+    },
+    "yoastseo": {
+      "version": "1.2.2",
+      "from": "git+https://github.com/Yoast/YoastSEO.js.git#901902291eac5f2f775134eefea00225b7054c70",
+      "resolved": "git+https://github.com/Yoast/YoastSEO.js.git#901902291eac5f2f775134eefea00225b7054c70"
     },
     "zombie": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "express": "^4.13.3",
     "express-force-ssl": "^0.3.0",
     "forever": "^0.15.1",
-    "fs": "0.0.2",
     "glossary": "^0.1.1",
     "jade": "^1.11.0",
     "joi": "^6.9.0",
@@ -59,7 +58,8 @@
     "ua-parser": "^0.3.5",
     "underscore": "^1.8.3",
     "underscore.string": "^3.2.2",
-    "xss": "^0.2.7"
+    "xss": "^0.2.7",
+    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#901902291eac5f2f775134eefea00225b7054c70"
   },
   "devDependencies": {
     "antigravity": "git://github.com/artsy/antigravity.git",


### PR DESCRIPTION
- Remove fs - as per https://github.com/npm/npm/issues/13743#issue-172772711
- Install earlier version of Yoast

cc @mdole -- once this gets merged, you _should_ be able to `git pull upstream master`, reinstall modules, and run Yoast w.o issues