### PR TITLE
@kanaabe Fixes issue with Yoast and keywords in the first paragraph (#805)

### DIFF
--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -158,14 +158,26 @@ module.exports = class EditLayout extends Backbone.View
     imageCount = 0
     textIndex = 0
     @fullText = []
-    if $(@article.get('lead_paragraph')).text() isnt ''
+    if $(@article.get('lead_paragraph')).text()
       @fullText.push(' <p> ' + $(@article.get('lead_paragraph')).text() + ' </p> ')
       textIndex += 1
 
     for section in $(@article.get('sections'))
       if section.type is 'text' && textIndex is 0
-        @fullText.push(' <p> ' + $(section.body).find('p').andSelf().filter('p:first').text() + ' </p> ')
-        @fullText.push($(section.body).find('p').andSelf().filter('p:not(:first)').text())
+        @fullText.push(
+          ' <p> ' + 
+          $(section.body)
+          .find('p')
+          .andSelf()
+          .filter('p:first')
+          .text()
+           + ' </p> ')
+        @fullText.push(
+          $(section.body)
+          .find('p')
+          .andSelf()
+          .filter('p:not(:first)')
+          .text())
         textIndex += 1
       else if section.type is 'text'
         @fullText.push($((section.body).replace(/<\/p>/g," </p>")).text())

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -158,12 +158,12 @@ module.exports = class EditLayout extends Backbone.View
     imageCount = 0
     textIndex = 0
     @fullText = []
-    if ($(@article.get('lead_paragraph')).text() != '')
+    if $(@article.get('lead_paragraph')).text() isnt ''
       @fullText.push(' <p> ' + $(@article.get('lead_paragraph')).text() + ' </p> ')
       textIndex += 1
 
     for section in $(@article.get('sections'))
-      if section.type is 'text' && textIndex == 0
+      if section.type is 'text' && textIndex is 0
         @fullText.push(' <p> ' + $(section.body).find('p').andSelf().filter('p:first').text() + ' </p> ')
         @fullText.push($(section.body).find('p').andSelf().filter('p:not(:first)').text())
         textIndex += 1

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -156,18 +156,26 @@ module.exports = class EditLayout extends Backbone.View
 
   checkSeo: =>
     imageCount = 0
+    textIndex = 0
     @fullText = []
-    @fullText.push(" <p> " + $(@article.get("lead_paragraph")).text() + " </p> ")
-    for section in $(@article.get("sections"))
-      if section.type is "text"
+    if ($(@article.get('lead_paragraph')).text() != '')
+      @fullText.push(' <p> ' + $(@article.get('lead_paragraph')).text() + ' </p> ')
+      textIndex += 1
+
+    for section in $(@article.get('sections'))
+      if section.type is 'text' && textIndex == 0
+        @fullText.push(' <p> ' + $(section.body).find('p').andSelf().filter('p:first').text() + ' </p> ')
+        @fullText.push($(section.body).find('p').andSelf().filter('p:not(:first)').text())
+        textIndex += 1
+      else if section.type is 'text'
         @fullText.push($((section.body).replace(/<\/p>/g," </p>")).text())
-      else if section.type is "artworks"
+      else if section.type is 'artworks'
         imageCount += 1
-      else if section.type is "image"
+      else if section.type is 'image'
         imageCount += 1
-    @fullText.push("<img></img>") for num in [imageCount..1]
+    @fullText.push('<img></img>') for num in [imageCount..1]
     @fullText = @fullText.join(' ')
-      
+    
     yoastView = new YoastView
       contentField: @fullText
       title: @article.get('title')


### PR DESCRIPTION
The issue was that Yoast was only checking the Lead Paragraph of the article, not the first text that appeared (if the author chose not to write a Lead Paragraph). This fix causes Yoast to first check if there's a LP and then check the keyword against the first paragraph of the text if there isn't.