### PR TITLE
@kanaabe => Yoast snippet properly reflects the title Artsy uses for Google

### DIFF
--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -190,7 +190,7 @@ module.exports = class EditLayout extends Backbone.View
     
     yoastView = new YoastView
       contentField: @fullText
-      title: @article.get('title')
+      title: @article.get('thumbnail_title')
       slug: @article.getSlug()
 
   onKeyup: =>

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -188,9 +188,15 @@ module.exports = class EditLayout extends Backbone.View
     @fullText.push('<img></img>') for num in [imageCount..1]
     @fullText = @fullText.join(' ')
     
+    @yoastTitle = ''
+    if @article.get('thumbnail_title')
+      @yoastTitle = @article.get('thumbnail_title')
+    else
+      @yoastTitle = @article.get('title')
+
     yoastView = new YoastView
       contentField: @fullText
-      title: @article.get('thumbnail_title')
+      title: @yoastTitle
       slug: @article.getSlug()
 
   onKeyup: =>

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -187,16 +187,10 @@ module.exports = class EditLayout extends Backbone.View
         imageCount += 1
     @fullText.push('<img></img>') for num in [imageCount..1]
     @fullText = @fullText.join(' ')
-    
-    @yoastTitle = ''
-    if @article.get('thumbnail_title')
-      @yoastTitle = @article.get('thumbnail_title')
-    else
-      @yoastTitle = @article.get('title')
 
     yoastView = new YoastView
       contentField: @fullText
-      title: @yoastTitle
+      title: @article.get('thumbnail_title') or @article.get('title') or ''
       slug: @article.getSlug()
 
   onKeyup: =>


### PR DESCRIPTION
Had initially set the title for yoast's snippet editor (which imitates the appearance of the page on a google SERP) to be the article title; Artsy uses the thumbnail title instead.