### PR TITLE
@kanaabe : fix elasticsearch reindex script

### DIFF
--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -173,7 +173,7 @@ getDescription = (article) =>
       tags: article.tags
       body: sections and stripHtmlTags(sections.join(' ')) or ''
     , (error, response) ->
-      console.log(error) if error
+      console.log('ElasticsearchIndexingError: Article ' + article.id + ' : ' + error) if error
   )
 
 @removeFromSearch = (id) ->

--- a/api/lib/elasticsearch.coffee
+++ b/api/lib/elasticsearch.coffee
@@ -1,7 +1,11 @@
 elasticsearch = require('elasticsearch')
 { NODE_ENV, ELASTICSEARCH_URL } = process.env
 
-client = new elasticsearch.Client(host: ELASTICSEARCH_URL)
+client = new elasticsearch.Client
+          host: ELASTICSEARCH_URL
+          maxRetries: 2
+          keepAlive: true
+          maxSockets: 10
 
 module.exports =
   index: 'articles_' + NODE_ENV

--- a/scripts/reindex_articles.coffee
+++ b/scripts/reindex_articles.coffee
@@ -17,6 +17,13 @@ db = mongojs(process.env.MONGOHQ_URL, ['articles'])
 
 db.articles.find({ }).toArray (err, articles) ->
   console.log(err) if err
-  articles.map (a) ->
-    indexForSearch Article.present(a), (opts) ->
-      console.log('indexed ' + a.id or a._id)
+  indexWorker(articles, 0)
+
+indexWorker = (articles, i) ->
+  a = articles[i]
+  console.log('indexing ' + a._id)
+  indexForSearch Article.present(a)
+  setTimeout( =>
+    console.log('indexed ' + a.id or a._id)
+    indexWorker(articles, ++i)
+  , 50)


### PR DESCRIPTION
The elasticsearch reindex script was overloading our elasticsearch servers with parallel indexing requests, which was eventually leading to timeouts and connection failures. 

I've adjusted the config to provide a `maxSockets` which the client can bind to in parallel and a 50ms interval between requests. This fixes the issue and allows us to index all our articles in about 15 minutes.

