### PR TITLE
@craigspaeth => Hide hero-section from partners

### DIFF
--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -25,7 +25,8 @@ HeroSection = React.createFactory require './components/hero_section/index.coffe
     SectionList(sections: article.sections)
     $('#edit-sections')[0]
   )
-  React.render(
-    HeroSection(section: article.heroSection, hasSection: article.get('section_ids')?.length > 0)
-    $('#edit-hero-section')[0]
-  )
+  if article.attributes.hero_section != null or channel.hasFeature 'hero'
+    React.render(
+      HeroSection(section: article.heroSection, hasSection: article.get('section_ids')?.length > 0)
+      $('#edit-hero-section')[0]
+    )

--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -25,7 +25,7 @@ HeroSection = React.createFactory require './components/hero_section/index.coffe
     SectionList(sections: article.sections)
     $('#edit-sections')[0]
   )
-  if article.attributes.hero_section != null or channel.hasFeature 'hero'
+  if article.get('hero_section') != null or channel.hasFeature 'hero'
     React.render(
       HeroSection(section: article.heroSection, hasSection: article.get('section_ids')?.length > 0)
       $('#edit-hero-section')[0]

--- a/client/models/channel.coffee
+++ b/client/models/channel.coffee
@@ -28,6 +28,7 @@ module.exports = class Channel extends Backbone.Model
         'toc'
         'follow'
         'layout'
+        'hero'
       ], feature
     else if type is 'team'
       _.contains [
@@ -39,6 +40,7 @@ module.exports = class Channel extends Backbone.Model
         'embed'
         'callout'
         'follow'
+        'hero'
       ], feature
     else if type is 'support'
       _.contains [
@@ -48,6 +50,7 @@ module.exports = class Channel extends Backbone.Model
         'video'
         'callout'
         'follow'
+        'hero'
       ], feature
     else if type is 'partner'
        _.contains [


### PR DESCRIPTION
closes https://github.com/artsy/positron/issues/778
Hides hero section from partners on new articles. 
Lets partners with existing hero-sections continue to view and edit their content. 