### PR TITLE
@kanaabe : fix visible_to_public criteria

### DIFF
--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -167,7 +167,7 @@ getDescription = (article) =>
       published: article.published
       published_at: article.published_at
       scheduled_publish_at: article.scheduled_publish_at
-      visible_to_public: article.published and sections?.length > 0 and article.channel_id is EDITORIAL_CHANNEL
+      visible_to_public: article.published and sections?.length > 0 and article.channel_id and article.channel_id.toString() is EDITORIAL_CHANNEL
       author: article.author and article.author.name or ''
       featured: article.featured
       tags: article.tags

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -172,6 +172,7 @@ getDescription = (article) =>
       featured: article.featured
       tags: article.tags
       body: sections and stripHtmlTags(sections.join(' ')) or ''
+      image_url: article.thumbnail_image
     , (error, response) ->
       console.log('ElasticsearchIndexingError: Article ' + article.id + ' : ' + error) if error
   )

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -702,6 +702,7 @@ describe 'Article', ->
             q: 'name:foo'
             , (error, response) ->
               response.hits.hits[0]._source.name.should.equal 'foo article'
+              response.hits.hits[0]._source.visible_to_public.should.equal true
               done()
           )
         , 1000)

--- a/scripts/reindex_articles.coffee
+++ b/scripts/reindex_articles.coffee
@@ -26,4 +26,4 @@ indexWorker = (articles, i) ->
   setTimeout( =>
     console.log('indexed ' + a.id or a._id)
     indexWorker(articles, ++i)
-  , 50)
+  , 30)


### PR DESCRIPTION
- Fixes a bug in `visible_to_public` flag indexed in elasticsearch, which was affecting visibility of results. The `channel_id` equality check was failing on an `ObjectId` type issue when models were loaded from the db.
- Adds thumbnail image urls to elasticsearch.

