### PR TITLE
@kanaabe : index a square cropped thumbnail image in search

### DIFF
--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -172,7 +172,7 @@ getDescription = (article) =>
       featured: article.featured
       tags: article.tags
       body: sections and stripHtmlTags(sections.join(' ')) or ''
-      image_url: article.thumbnail_image
+      image_url: crop(article.thumbnail_image, 70, 70)
     , (error, response) ->
       console.log('ElasticsearchIndexingError: Article ' + article.id + ' : ' + error) if error
   )


### PR DESCRIPTION
- This is arguably Force presentation logic but we need to at least index a square aspect ratio image  for search results. While we're at it we may as well use the largest dimension currently used by Force (70x70 on the search results page). 