### PR TITLE
@eessex => Remove description from Admin and fix saving

### DIFF
--- a/client/apps/edit/components/admin/index.jade
+++ b/client/apps/edit/components/admin/index.jade
@@ -104,9 +104,6 @@ section#edit-admin.admin-form-container.max-width-container
       #edit-admin-tags
         label Tags
         input.bordered-input.edit-admin-tags-input( placeholder='Enter article keywords' value=article.get('tags') )
-      #edit-admin-description
-        label Description
-        textarea.bordered-input.edit-admin-description-input( placeholder='Enter description')= article.get('description')
       .admin-form-right-col
         #edit-admin-publish-date
           label Publish Date
@@ -121,8 +118,6 @@ section#edit-admin.admin-form-container.max-width-container
           label Exclude from Google News
             .flat-checkbox
               input( type='checkbox' name='exclude_google_news' checked=article.get('exclude_google_news') == 1 value=1 )
-
-
 
   //- Super Article
   if channel.hasFeature('superArticle')

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -98,8 +98,6 @@ module.exports = class EditLayout extends Backbone.View
         footer_blurb: @$("#edit-super-article textarea[name='footer_blurb']").val()
         related_articles: if @article.get('super_article')?.related_articles then @article.get('super_article').related_articles else []
       send_body: @$('[name=send_body]').is(':checked')
-      daily_email: @$('[name=daily_email]').is(':checked')
-      weekly_email: @$('[name=weekly_email]').is(':checked')
       layout: @$('[name=layout]:checked').val()
     }
 


### PR DESCRIPTION
The reason we don't want to keep those fields in `serialize` anymore is that those inputs don't exist on the front-end. Soo they were defaulting to `false` which was actually removing things in the queue. 🙈 