### PR TITLE
@kanaabe => Remove callout edit restrictions

### DIFF
--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -21,6 +21,7 @@ HeroSection = React.createFactory require './components/hero_section/index.coffe
   new EditHeader el: $('#edit-header'), article: article
   new EditDisplay el: $('#edit-display'), article: article
   new EditAdmin el: $('#edit-admin'), article: article, channel: channel
+  debugger
   React.render(
     SectionList(sections: article.sections)
     $('#edit-sections')[0]

--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -21,7 +21,6 @@ HeroSection = React.createFactory require './components/hero_section/index.coffe
   new EditHeader el: $('#edit-header'), article: article
   new EditDisplay el: $('#edit-display'), article: article
   new EditAdmin el: $('#edit-admin'), article: article, channel: channel
-  debugger
   React.render(
     SectionList(sections: article.sections)
     $('#edit-sections')[0]

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -45,6 +45,5 @@ module.exports = React.createClass
               key: section.cid
               onSetEditing: @onSetEditing
             }
-            unless section.get('type') is 'callout'
-              SectionTool { sections: @props.sections, index: i }
+            SectionTool { sections: @props.sections, index: i }
           ]

--- a/client/apps/edit/components/section_tool/index.coffee
+++ b/client/apps/edit/components/section_tool/index.coffee
@@ -22,9 +22,6 @@ module.exports = React.createClass
   toggle: ->
     @setState open: not @state.open
 
-  isAboveTextSection: ->
-    @props.sections.models[@props.index + 1]?.get('type') is 'text'
-
   newSection: (type) -> =>
     switch type
       when 'text'
@@ -181,8 +178,8 @@ module.exports = React.createClass
               }
           if @channel.hasFeature 'callout'
             li {
-              className: "edit-section-tool-callout #{'is-disabled' unless @isAboveTextSection()}"
-              onClick: @newSection('callout') if @isAboveTextSection()
+              className: "edit-section-tool-callout"
+              onClick: @newSection('callout')
             }, 'Callout',
               div {
                 className: 'edit-menu-icon-callout'

--- a/client/apps/edit/components/section_tool/test/index.coffee
+++ b/client/apps/edit/components/section_tool/test/index.coffee
@@ -45,24 +45,6 @@ describe 'SectionTool', ->
     @component.props.sections.last().get('type').should.equal 'text'
     @component.props.sections.last().get('body').should.equal ''
 
-  it 'does not show a callout section if there is not a text section below it', ->
-    r.simulate.click r.find @component, 'edit-section-tool-icon'
-    (r.findAll @component, 'edit-section-tool-callout')[0].props.className.should.containEql 'is-disabled'
-    React.renderToString(@SectionTool(
-        sections: @sections = new Backbone.Collection [
-          { body: 'Foo to the bar', type: 'text' }
-        ]
-        index: 0
-    )).should.containEql 'edit-section-tool-callout is-disabled'
-
-  it 'shows a callout section if there is a text section below it', ->
-    React.renderToString(@SectionTool(
-        sections: @sections = new Backbone.Collection [
-          { body: 'Foo to the bar', type: 'text' }
-        ]
-        index: -1
-    )).should.containEql 'edit-section-tool-callout'
-
 describe 'SectionTool - Hero', ->
 
   beforeEach (done) ->


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/859

Remove restrictions on callouts
- Callouts can be added adjacent to any block
- Callouts have edit tools below them