### PR TITLE
@craigspaeth => Remove duplicate articles in Sailthru

### DIFF
--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -102,7 +102,7 @@ Q = require 'bluebird-q'
 #
 @destroy = (id, callback) ->
   @find id, (err, article = {}) =>
-    deleteArticleFromSailthru article, =>
+    deleteArticleFromSailthru _.last(article.slugs), =>
       db.articles.remove { _id: ObjectId(id) }, =>
         removeFromSearch id.toString()
         callback(id)

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -323,7 +323,7 @@ typecastIds = (article) ->
     full: url: crop(imageSrc, { width: 1200, height: 706 } )
     thumb: url: crop(imageSrc, { width: 900, height: 530 } )
   html = if article.send_body then getTextSections(article) else ''
-  @cleanArticlesFromSailthru article.slugs
+  cleanArticlesInSailthru article.slugs
   sailthru.apiPost 'content',
     url: "#{FORCE_URL}/article/#{_.last(article.slugs)}"
     date: article.published_at
@@ -343,7 +343,7 @@ typecastIds = (article) ->
     debug err if err
     cb()
 
-@cleanArticlesFromSailthru = (slugs = []) ->
+cleanArticlesInSailthru = (slugs = []) ->
   if slugs.length > 1
     _.map slugs, (slug, i) =>
       unless i is slugs.length - 1

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -345,7 +345,7 @@ typecastIds = (article) ->
 
 cleanArticlesInSailthru = (slugs = []) =>
   if slugs.length > 1
-    _.map slugs, (slug, i) =>
+    slugs.forEach (slug, i) =>
       unless i is slugs.length - 1
         @deleteArticleFromSailthru slug, ->
 

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -343,7 +343,7 @@ typecastIds = (article) ->
     debug err if err
     cb()
 
-cleanArticlesInSailthru = (slugs = []) ->
+cleanArticlesInSailthru = (slugs = []) =>
   if slugs.length > 1
     _.map slugs, (slug, i) =>
       unless i is slugs.length - 1

--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -39,7 +39,7 @@ artsyXapp = require('artsy-xapp').token or ''
 
 @onUnpublish = (article, cb) =>
   @generateSlugs article, (err, article) =>
-    @deleteArticleFromSailthru article, =>
+    @deleteArticleFromSailthru _.last(article.slugs), =>
       cb null, article
 
 setOnPublishFields = (article) =>
@@ -323,6 +323,7 @@ typecastIds = (article) ->
     full: url: crop(imageSrc, { width: 1200, height: 706 } )
     thumb: url: crop(imageSrc, { width: 900, height: 530 } )
   html = if article.send_body then getTextSections(article) else ''
+  @cleanArticlesFromSailthru article.slugs
   sailthru.apiPost 'content',
     url: "#{FORCE_URL}/article/#{_.last(article.slugs)}"
     date: article.published_at
@@ -342,9 +343,15 @@ typecastIds = (article) ->
     debug err if err
     cb()
 
-@deleteArticleFromSailthru = (article, cb) =>
+@cleanArticlesFromSailthru = (slugs = []) ->
+  if slugs.length > 1
+    _.map slugs, (slug, i) =>
+      unless i is slugs.length - 1
+        @deleteArticleFromSailthru slug, ->
+
+@deleteArticleFromSailthru = (slug, cb) =>
   sailthru.apiDelete 'content',
-    url: "#{FORCE_URL}/article/#{_.last(article.slugs)}"
+    url: "#{FORCE_URL}/article/#{slug}"
   , (err, response) =>
     debug err if err
     cb()

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -110,10 +110,7 @@ describe 'Save', ->
   describe '#deleteArticleFromSailthru', ->
 
     it 'deletes the article from sailthru', (done) ->
-      Save.deleteArticleFromSailthru {
-        slugs: ['artsy-editorial-delete-me']
-        author_id: '5086df098523e60002000018'
-      }, (err, article) =>
+      Save.deleteArticleFromSailthru 'artsy-editorial-delete-me', (err, article) =>
         @sailthru.apiDelete.args[0][1].url.should.containEql 'artsy-editorial-delete-me'
         done()
 

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -107,6 +107,22 @@ describe 'Save', ->
         @sailthru.apiPost.args[0][1].vars.html.should.not.containEql 'This Caption'
         done()
 
+    it 'deletes all previously formed slugs in Sailthru', (done) ->
+     Save.sendArticleToSailthru {
+        author_id: '5086df098523e60002000018'
+        published: true
+        slugs: [
+          'artsy-editorial-slug-one'
+          'artsy-editorial-slug-two'
+          'artsy-editorial-slug-three'
+        ]
+      }, (err, article) =>
+        @sailthru.apiDelete.callCount.should.equal 2
+        @sailthru.apiDelete.args[0][1].url.should.containEql 'slug-one'
+        @sailthru.apiDelete.args[1][1].url.should.containEql 'slug-two'
+        done()
+
+
   describe '#deleteArticleFromSailthru', ->
 
     it 'deletes the article from sailthru', (done) ->


### PR DESCRIPTION
We're having an issue where sometimes multiple articles appear in Sailthru because Sailthru uses the slug as the key. When we send data to Sailthru, we should ensure that old slugs are also removed from Sailthru.