### PR TITLE
@kanaabe => ISO dates

### DIFF
--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -118,12 +118,18 @@ Q = require 'bluebird-q'
   }
 
 @present = (article) =>
+  if article?.scheduled_publish_at
+    scheduled = moment(article.scheduled_publish_at).toISOString()
+  else
+    scheduled = null
+
   _.extend article,
     id: article?._id?.toString()
     _id: undefined
     slug: _.last article.slugs
     slugs: undefined
     published_at: moment(article?.published_at).toISOString()
+    scheduled_publish_at: scheduled
     updated_at: moment(article?.updated_at).toISOString()
 
 # Converts an input from the db that use ObjectId to String

--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -118,17 +118,14 @@ Q = require 'bluebird-q'
   }
 
 @present = (article) =>
-  if article?.scheduled_publish_at
-    scheduled = moment(article.scheduled_publish_at).toISOString()
-  else
-    scheduled = null
-
+  scheduled = if (date = article?.scheduled_publish_at) then moment(date).toISOString() else null
+  published = if (date = article?.published_at) then moment(date).toISOString() else null
   _.extend article,
     id: article?._id?.toString()
     _id: undefined
     slug: _.last article.slugs
     slugs: undefined
-    published_at: moment(article?.published_at).toISOString()
+    published_at: published
     scheduled_publish_at: scheduled
     updated_at: moment(article?.updated_at).toISOString()
 

--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -71,7 +71,7 @@ Q = require 'bluebird-q'
             sanitizeAndSave(callback)(null, article)
 
 @publishScheduledArticles = (callback) ->
-  db.articles.find { scheduled_publish_at: { $lt: new Date() } } , (err, articles) =>
+  db.articles.find { scheduled_publish_at: { $lt: new Date } } , (err, articles) =>
     return callback err, [] if err
     return callback null, [] if articles.length is 0
     async.map articles, (article, cb) =>
@@ -123,6 +123,8 @@ Q = require 'bluebird-q'
     _id: undefined
     slug: _.last article.slugs
     slugs: undefined
+    published_at: moment(article?.published_at).toISOString()
+    updated_at: moment(article?.updated_at).toISOString()
 
 # Converts an input from the db that use ObjectId to String
 typecastIds = (article) ->

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -1073,6 +1073,12 @@ describe 'Article', ->
       (data._id?).should.not.be.ok
       data.id.should.equal 'foo'
 
+    it 'converts dates to ISO strings', ->
+      data = Article.present _.extend fixtures().articles, published_at: new Date, scheduled_publish_at: new Date
+      moment(data.updated_at).toISOString().should.equal data.updated_at
+      moment(data.published_at).toISOString().should.equal data.published_at
+      moment(data.scheduled_publish_at).toISOString().should.equal data.scheduled_publish_at
+
   describe '#presentCollection', ->
 
     it 'shows a total/count/results hash for arrays of articles', ->


### PR DESCRIPTION
- Formats article date fields in ISO before GraphQL

Ended up pulling all the pre-save conversion out of this, as we do indeed need to send a Date object to the database, rather than ISO string, for sorting to work. 