### PR TITLE
@kanaabe => Articles list can accept url query

### DIFF
--- a/client/apps/articles_list/routes.coffee
+++ b/client/apps/articles_list/routes.coffee
@@ -6,17 +6,20 @@ Transport = require('lokka-transport-http').Transport
 
 @articles_list = (req, res, next) ->
   channel_id = req.user?.get('current_channel').id
-  publishedQuery = query "published: true, channel_id: \"#{channel_id}\""
+
+  if req._parsedUrl.query?.includes 'published=false' then published = false else published = true
+  theQuery = query "published: #{published}, channel_id: \"#{channel_id}\""
+
   headers =
     'X-Access-Token': req.user.get('access_token')
 
   client = new Lokka
     transport: new Transport(API_URL + '/graphql', {headers})
 
-  client.query(publishedQuery)
+  client.query(theQuery)
     .then (result) =>
       if result.articles.length > 0
-        renderArticles res, req, result, true
+        renderArticles res, req, result, published
       else
         unpublishedQuery = query "published: false, channel_id: \"#{channel_id}\""
         client.query(unpublishedQuery)

--- a/client/apps/articles_list/routes.coffee
+++ b/client/apps/articles_list/routes.coffee
@@ -7,7 +7,7 @@ Transport = require('lokka-transport-http').Transport
 @articles_list = (req, res, next) ->
   channel_id = req.user?.get('current_channel').id
 
-  if req._parsedUrl.query?.includes 'published=false' then published = false else published = true
+  if req.query?.published == 'false' then published = false else published = true
   theQuery = query "published: #{published}, channel_id: \"#{channel_id}\""
 
   headers =

--- a/client/apps/articles_list/test/routes.coffee
+++ b/client/apps/articles_list/test/routes.coffee
@@ -27,3 +27,15 @@ describe 'routes', ->
       routes.articles_list @req, @res, @next
       @res.render.args[0][0].should.equal 'index'
       @res.render.args[0][1].current_channel.name.should.equal 'Editorial'
+
+    it 'is aware of url queries', ->
+      routes.articles_list @req, @res, @next
+      @res.locals.sd.HAS_PUBLISHED.should.equal true
+
+      @req.query = { published: 'false' }
+      routes.articles_list @req, @res, @next
+      @res.locals.sd.HAS_PUBLISHED.should.equal false
+
+      @req.query = { published: 'true' }
+      routes.articles_list @req, @res, @next
+      @res.locals.sd.HAS_PUBLISHED.should.equal true


### PR DESCRIPTION
re: @halleyjohnson's request, new articles page is aware of URL queries 

'/articles?published=false' will query unpublished and go to drafts page