### PR TITLE
@craigspaeth => Increase channel fetch limit on isOutdated check

### DIFF
--- a/client/models/user.coffee
+++ b/client/models/user.coffee
@@ -43,7 +43,7 @@ module.exports = class User extends Backbone.Model
           .end (err, results) ->
             cb null, user, results?.body
       (user, partners, cb) =>
-        request.get("#{sd.API_URL}/channels?user_id=#{@get('id')}")
+        request.get("#{sd.API_URL}/channels?user_id=#{@get('id')}&limit=50")
           .set('X-Access-Token': @get('access_token'))
           .end (err, results) ->
             cb null, [ user, partners, results?.body?.results ]


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/896

### Problem
Positron checks if someone's channel permissions have changed and logs out a user if the `req.user` is different from a fresh fetch. Since the fresh fetch hits our API instead of the database directly, the results have a limit of 10. If the user is added to more than 10 channels, there will always be a difference and thus causes an infinite login/logout loop.  

### Solution
Increase the `limit` on channel fetches from  the default of 10 to 50.

This also implies an issue with Partners, which I haven't touched yet. The infinite loop won't be an issue here since both the `req.user` and fresh fetch are using Gravity's API with a limit of 10. However that means for non-Admins who have manage many partners, it limits their access to just 10. I didn't want to just arbitrarily add a limit of 50 since I'm not sure how many partners people have access to and if non-Admins even manage more than 10 accounts, so I'll create an issue and think about a cleaner solution later on. 