### PR TITLE
@kanaabe => Add channel to header

### DIFF
--- a/client/apps/articles_list/client/client.coffee
+++ b/client/apps/articles_list/client/client.coffee
@@ -59,6 +59,7 @@ module.exports.ArticlesListView = ArticlesListView = React.createClass
   showArticlesList: ->
     if @props.articles?.length
       div { className: 'articles-list__container' },
+        div { className: 'articles-list__title'}, "Latest Articles"
         FilterSearch {
           url: sd.API_URL + "/articles?published=#{@state.published}&channel_id=#{sd.CURRENT_CHANNEL.id}&q=%QUERY"
           placeholder: 'Search Articles...'
@@ -84,10 +85,12 @@ module.exports.ArticlesListView = ArticlesListView = React.createClass
               className: "#{if @state.published is false then 'is-active' else ''} drafts"
               onClick: => @setPublished false
               }, "Drafts"
+          div {className: 'channel-name'}, "#{@props.channel.name}"
       @showArticlesList()
 
 module.exports.init = ->
   props =
     articles: sd.ARTICLES
     published: sd.HAS_PUBLISHED
+    channel: sd.CURRENT_CHANNEL
   React.render React.createElement(ArticlesListView, props), document.getElementById('articles-list')

--- a/client/apps/articles_list/index.styl
+++ b/client/apps/articles_list/index.styl
@@ -6,23 +6,29 @@
     right 0
     background-color white
     z-index 10
+    .max-width-container
+      display flex
+      justify-content space-between
+      align-items center
   &__container
-    margin-top 75px
+    margin-top 105px
+    position relative
+  &__title
+    garamond headline
+    padding 20px 0
   .filter-search__header-container
-    position fixed
-    top 8px
-    right calc((100vw \- 1070px) \/ 2)
-    max-width 960px
-    padding 0 30px
+    position absolute
+    top 20px
+    right 0
     border none
-    z-index 20
 
 #articles-list-loading
   position relative
   margin-top 75px
   .loading-spinner
     display none
-
+.article-list__results
+  border-top 3px solid gray-lighter-color
 .article-list__empty
   text-align center
   margin-top 150px

--- a/client/apps/articles_list/test/client/client.coffee
+++ b/client/apps/articles_list/test/client/client.coffee
@@ -29,6 +29,7 @@ describe 'ArticlesListView', ->
           articles: [_.extend fixtures().articles, id: '456']
           published: true
           offset: 0
+          channel: {name: 'Artsy Editorial'}
         }
       ), (@$el = $ "<div></div>")[0], => setTimeout =>
         sinon.stub @component, 'setState'
@@ -40,6 +41,7 @@ describe 'ArticlesListView', ->
   it 'renders the nav', ->
     $(@component.getDOMNode()).html().should.containEql 'Published'
     $(@component.getDOMNode()).html().should.containEql 'Drafts'
+    $(@component.getDOMNode()).html().should.containEql 'Artsy Editorial'
 
   it 'articles get passed along to list component', ->
     @component.state.articles.length.should.equal 1

--- a/client/apps/queue/client/client.coffee
+++ b/client/apps/queue/client/client.coffee
@@ -95,6 +95,7 @@ module.exports.QueueView = QueueView = React.createClass
               className: "#{if @state.feed is 'weekly_email' then 'is-active' else ''} weekly-email"
               onClick: => @setFeed 'weekly_email'
               }, "Weekly Email"
+          div {className: 'channel-name'}, "#{@props.channel.name}"
       div {},
         div { className: 'queue-scheduled max-width-container'},
           ArticleList {
@@ -124,4 +125,5 @@ module.exports.init = ->
   props =
     scheduledArticles: sd.SCHEDULED_ARTICLES
     feed: 'scheduled'
+    channel: sd.CURRENT_CHANNEL
   React.render React.createElement(QueueView, props), document.getElementById('queue-root')

--- a/client/apps/queue/index.styl
+++ b/client/apps/queue/index.styl
@@ -9,7 +9,11 @@
       display none
     .queue-queued, .queue-filter-search
       display block
-
+  .page-header
+    .max-width-container
+      display flex
+      justify-content space-between
+      align-items center
 .queue-queued
   margin 60px auto 120px auto
   .queued-articles

--- a/client/apps/queue/test/client/client.coffee
+++ b/client/apps/queue/test/client/client.coffee
@@ -36,6 +36,7 @@ describe 'QueuedView', ->
         {
           scheduledArticles: [_.extend fixtures().articles, id: '456']
           feed: 'scheduled'
+          channel: {name: 'Artsy Editorial'}
         }
       ), (@$el = $ "<div></div>")[0], => setTimeout =>
         sinon.stub @component, 'saveSelected'
@@ -49,6 +50,7 @@ describe 'QueuedView', ->
     $(@component.getDOMNode()).html().should.containEql 'Scheduled'
     $(@component.getDOMNode()).html().should.containEql 'Daily Email'
     $(@component.getDOMNode()).html().should.containEql 'Weekly Email'
+    $(@component.getDOMNode()).html().should.containEql 'Artsy Editorial'
 
   it 'scheduledArticles gets passed along to components', ->
     @component.state.scheduledArticles.length.should.equal 1

--- a/client/components/filter_search/index.styl
+++ b/client/components/filter_search/index.styl
@@ -6,5 +6,8 @@
     justify-content space-between
   &__input
     width 350px
+    padding-left 36px
+    background url("/autocomplete_search.svg") 9px 9px no-repeat
+    background-size 20px
   &__header-text
     garamond('headline')

--- a/client/components/layout/stylesheets/index.styl
+++ b/client/components/layout/stylesheets/index.styl
@@ -37,7 +37,11 @@ em
     right 0
     background-color white
     z-index 100
-
+  .channel-name
+    garamond l-body
+    text-transform none
+    letter-spacing 0
+    line-height 1em
   .nav-tabs
     a
       padding-right 20px


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/906

- Adds channel name to header in articles list and queue
- Articles list has a title
- Filter search input has background image

![screen shot 2017-01-30 at 11 16 53 am](https://cloud.githubusercontent.com/assets/1497424/22433123/46ef1f3c-e6e5-11e6-9d91-c6f6f5a2cb78.png)
