### PR TITLE
@eessex => Image size support

### DIFF
--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -46,7 +46,6 @@ Q = require 'bluebird-q'
 #
 @save = (input, accessToken, callback) =>
   validate typecastIds(input), (err, input) =>
-    console.log err
     return callback err if err
     @find (input.id or input._id)?.toString(), (err, article = {}) =>
       return callback err if err

--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -46,6 +46,7 @@ Q = require 'bluebird-q'
 #
 @save = (input, accessToken, callback) =>
   validate typecastIds(input), (err, input) =>
+    console.log err
     return callback err if err
     @find (input.id or input._id)?.toString(), (err, article = {}) =>
       return callback err if err

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -58,6 +58,9 @@ denormalizedArtwork = (->
         name: @string().allow('', null)
         slug: @string().allow('', null)
     ).allow(null).default([])
+    artist: @object().keys
+      name: @string().allow('', null)
+      slug: @string().allow('', null)
     width: @number().allow(null)
     height: @number().allow(null)
 ).call Joi

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -57,9 +57,9 @@ denormalizedArtwork = (->
       @object().keys
         name: @string().allow('', null)
         slug: @string().allow('', null)
+    ).allow(null).default([])
     width: @number().allow(null)
     height: @number().allow(null)
-    ).allow(null).default([])
 ).call Joi
 
 @inputSchema = (->

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -14,6 +14,8 @@ imageSection = (->
     url: @string().allow('', null)
     caption: @string().allow('', null)
     layout: @string().allow('overflow_fillwidth', 'column_width', null)
+    width: @number().allow(null)
+    height: @number().allow(null)
 ).call Joi
 
 videoSection = (->
@@ -55,6 +57,8 @@ denormalizedArtwork = (->
       @object().keys
         name: @string().allow('', null)
         slug: @string().allow('', null)
+    width: @number().allow(null)
+    height: @number().allow(null)
     ).allow(null).default([])
 ).call Joi
 

--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -21,6 +21,7 @@ HeroSection = React.createFactory require './components/hero_section/index.coffe
   new EditHeader el: $('#edit-header'), article: article
   new EditDisplay el: $('#edit-display'), article: article
   new EditAdmin el: $('#edit-admin'), article: article, channel: channel
+  
   React.render(
     SectionList(sections: article.sections)
     $('#edit-sections')[0]
@@ -30,3 +31,53 @@ HeroSection = React.createFactory require './components/hero_section/index.coffe
       HeroSection(section: article.heroSection, hasSection: article.get('section_ids')?.length > 0)
       $('#edit-hero-section')[0]
     )
+
+  convertToImageCollection = (callback) ->
+    console.log @props.sections
+    async.eachSeries @props.sections.models, (section, cb) ->
+      if section.get('type') is 'image'
+        @convertImages section, cb
+      else if section.get('type') is 'artwork'
+        @convertArtworks section, cb
+      else
+        cb()
+    , =>
+      callback()
+
+  convertImages = (section, callback) ->
+    (img = new Image(src: section.get('url'))).onload ->
+      image = {
+        type: 'image_collection'
+        images: [{
+          type: section.get('type')
+          url: section.get('url')
+          caption: section.get('caption')
+        }]
+        layout: section.get('layout') or 'overflow_fillwidth'
+        width: img.width
+        height: img.height
+      }
+      section.clear()
+      section.set image
+      console.log image
+      callback()
+
+  convertArtworks = (section, callback) ->
+    images = []
+    async.eachSeries section.artworks, (artwork, cb) ->
+      (img = new Image(src: section.get('image'))).onload ->
+        artwork.type = 'artwork'
+        artwork.width = img.width
+        artwork.height = img.height
+        images.push artwork
+        cb()
+    , =>
+      image = {
+        type: 'image_collection'
+        images: images
+        layout: section.get('layout') or 'overflow_fillwidth'
+      }
+      section.clear()
+      section.set artworks
+      console.log image
+      callback()

--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -51,14 +51,14 @@ convertSections = (article, callback) ->
 
 convertImageSet = (section, callback) ->
   async.parallel(
-    for image in section.get('images')
-      (cb) ->
-        img = new Image()
-        img.src = image.image or image.url # image or artwork
-        img.onload = ->
-          image.width = img.width
-          image.height = img.height
-          cb()
+    section.get('images').map (image) -> (cb) ->
+      img = new Image()
+      img.src = image.image or image.url # image or artwork
+      img.onload = ->
+        image.width = img.width
+        image.height = img.height
+        image.artists = [image.artist] if image.type is 'artwork'
+        cb()
   , =>
     callback()
   )
@@ -85,16 +85,15 @@ convertImages = (section, callback) ->
 convertArtworks = (section, callback) ->
   images = []
   async.parallel(
-    for artwork in section.get('artworks')
-      (cb) ->
-        img = new Image()
-        img.src = artwork.image
-        img.onload = ->
-          artwork.type = 'artwork'
-          artwork.width = img.width
-          artwork.height = img.height
-          images.push artwork
-          cb()
+    section.get('artworks').map (artwork) -> (cb) ->
+      img = new Image()
+      img.src = artwork.image
+      img.onload = ->
+        artwork.type = 'artwork'
+        artwork.width = img.width
+        artwork.height = img.height
+        images.push artwork
+        cb()
   , =>
     image = {
       type: 'image_collection'

--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -16,20 +16,20 @@ HeroSection = React.createFactory require './components/hero_section/index.coffe
 async = require 'async'
 
 @init = ->
-  article = new Article sd.ARTICLE
-  convertSections article, =>
+  @article = new Article sd.ARTICLE
+  convertSections @article, =>
     channel = new Channel sd.CURRENT_CHANNEL
-    new EditLayout el: $('#layout-content'), article: article, channel: channel
-    new EditHeader el: $('#edit-header'), article: article
-    new EditDisplay el: $('#edit-display'), article: article
-    new EditAdmin el: $('#edit-admin'), article: article, channel: channel
+    new EditLayout el: $('#layout-content'), article: @article, channel: channel
+    new EditHeader el: $('#edit-header'), article: @article
+    new EditDisplay el: $('#edit-display'), article: @article
+    new EditAdmin el: $('#edit-admin'), article: @article, channel: channel
     React.render(
-      SectionList(sections: article.sections)
+      SectionList(sections: @article.sections)
       $('#edit-sections')[0]
     )
-    if article.get('hero_section') != null or channel.hasFeature 'hero'
+    if @article.get('hero_section') != null or channel.hasFeature 'hero'
       React.render(
-        HeroSection(section: article.heroSection, hasSection: article.get('section_ids')?.length > 0)
+        HeroSection(section: @article.heroSection, hasSection: @article.get('section_ids')?.length > 0)
         $('#edit-hero-section')[0]
       )
 

--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -13,71 +13,95 @@ EditAdmin = require './components/admin/index.coffee'
 EditDisplay = require './components/display/index.coffee'
 SectionList = React.createFactory require './components/section_list/index.coffee'
 HeroSection = React.createFactory require './components/hero_section/index.coffee'
+async = require 'async'
 
 @init = ->
   article = new Article sd.ARTICLE
-  channel = new Channel sd.CURRENT_CHANNEL
-  new EditLayout el: $('#layout-content'), article: article, channel: channel
-  new EditHeader el: $('#edit-header'), article: article
-  new EditDisplay el: $('#edit-display'), article: article
-  new EditAdmin el: $('#edit-admin'), article: article, channel: channel
-  
-  React.render(
-    SectionList(sections: article.sections)
-    $('#edit-sections')[0]
-  )
-  if article.get('hero_section') != null or channel.hasFeature 'hero'
+  convertSections article, =>
+    channel = new Channel sd.CURRENT_CHANNEL
+    new EditLayout el: $('#layout-content'), article: article, channel: channel
+    new EditHeader el: $('#edit-header'), article: article
+    new EditDisplay el: $('#edit-display'), article: article
+    new EditAdmin el: $('#edit-admin'), article: article, channel: channel
     React.render(
-      HeroSection(section: article.heroSection, hasSection: article.get('section_ids')?.length > 0)
-      $('#edit-hero-section')[0]
+      SectionList(sections: article.sections)
+      $('#edit-sections')[0]
     )
+    if article.get('hero_section') != null or channel.hasFeature 'hero'
+      React.render(
+        HeroSection(section: article.heroSection, hasSection: article.get('section_ids')?.length > 0)
+        $('#edit-hero-section')[0]
+      )
 
-  convertToImageCollection = (callback) ->
-    console.log @props.sections
-    async.eachSeries @props.sections.models, (section, cb) ->
-      if section.get('type') is 'image'
-        @convertImages section, cb
-      else if section.get('type') is 'artwork'
-        @convertArtworks section, cb
-      else
-        cb()
-    , =>
-      callback()
+convertSections = (article, callback) ->
+  async.parallel(
+    article.sections.map (section) ->
+      (cb) ->
+        if section.get('type') is 'image'
+          convertImages section, cb
+        else if section.get('type') is 'artworks'
+          convertArtworks section, cb
+        else if section.get('type') is 'image_set'
+          convertImageSet section, cb
+        else
+          cb()
+  , =>
+    callback()
+  )
 
-  convertImages = (section, callback) ->
-    (img = new Image(src: section.get('url'))).onload ->
-      image = {
-        type: 'image_collection'
-        images: [{
-          type: section.get('type')
-          url: section.get('url')
-          caption: section.get('caption')
-        }]
-        layout: section.get('layout') or 'overflow_fillwidth'
+convertImageSet = (section, callback) ->
+  async.parallel(
+    for image in section.get('images')
+      (cb) ->
+        img = new Image()
+        img.src = image.image or image.url # image or artwork
+        img.onload = ->
+          image.width = img.width
+          image.height = img.height
+          cb()
+  , =>
+    callback()
+  )
+
+convertImages = (section, callback) ->
+  img = new Image()
+  img.src = section.get('url')
+  img.onload = ->
+    image = {
+      type: 'image_collection'
+      images: [{
+        type: 'image'
+        url: section.get('url')
+        caption: section.get('caption')
         width: img.width
         height: img.height
-      }
-      section.clear()
-      section.set image
-      console.log image
-      callback()
+      }]
+      layout: section.get('layout') or 'overflow_fillwidth'
+    }
+    section.clear()
+    section.set image
+    callback()
 
-  convertArtworks = (section, callback) ->
-    images = []
-    async.eachSeries section.artworks, (artwork, cb) ->
-      (img = new Image(src: section.get('image'))).onload ->
-        artwork.type = 'artwork'
-        artwork.width = img.width
-        artwork.height = img.height
-        images.push artwork
-        cb()
-    , =>
-      image = {
-        type: 'image_collection'
-        images: images
-        layout: section.get('layout') or 'overflow_fillwidth'
-      }
-      section.clear()
-      section.set artworks
-      console.log image
-      callback()
+convertArtworks = (section, callback) ->
+  images = []
+  async.parallel(
+    for artwork in section.get('artworks')
+      (cb) ->
+        img = new Image()
+        img.src = artwork.image
+        img.onload = ->
+          artwork.type = 'artwork'
+          artwork.width = img.width
+          artwork.height = img.height
+          images.push artwork
+          cb()
+  , =>
+    image = {
+      type: 'image_collection'
+      images: images
+      layout: section.get('layout') or 'overflow_fillwidth'
+    }
+    section.clear()
+    section.set image
+    callback()
+  )

--- a/client/apps/edit/components/section_image_collection/index.coffee
+++ b/client/apps/edit/components/section_image_collection/index.coffee
@@ -81,7 +81,12 @@ module.exports = React.createClass
         image = new Image()
         image.src = src
         image.onload = =>
-          newImages = @state.images.concat [ { url: src, type: 'image' } ]
+          newImages = @state.images.concat [{
+            url: src
+            type: 'image'
+            width: image.width
+            height: image.height
+          }]
           @setState images: newImages
           @props.section.set images: newImages
           imagesLoaded @$list, =>

--- a/client/apps/edit/components/section_image_collection/test/index.coffee
+++ b/client/apps/edit/components/section_image_collection/test/index.coffee
@@ -18,6 +18,8 @@ describe 'SectionImageCollection', ->
       constructor: ->
         setTimeout => @onload()
       onload: ->
+      width: 120
+      height: 90
     benv.setup =>
       benv.expose $: benv.require 'jquery'
       SectionImageCollection = benv.requireWithJadeify(
@@ -63,20 +65,14 @@ describe 'SectionImageCollection', ->
     benv.teardown()
     delete global.Image
 
-  it 'uploads to gemini', (done) ->
+  it 'saves image info after upload', (done) ->
     @component.upload target: files: ['foo']
-    @gemup.args[0][0].should.equal 'foo'
     @gemup.args[0][1].done('fooza')
     setTimeout =>
-      @component.setState.args[0][0].images[2].url.should.equal 'fooza'
       @component.setState.args[0][0].images[2].type.should.equal 'image'
-      done()
-
-  it 'saves the url after upload', (done) ->
-    @component.upload target: files: ['foo']
-    @gemup.args[0][1].done('fooza')
-    setTimeout =>
       @component.props.section.get('images')[2].url.should.equal 'fooza'
+      @component.props.section.get('images')[2].width.should.equal 120
+      @component.props.section.get('images')[2].height.should.equal 90
       done()
 
   it 'renders an image', ->

--- a/client/apps/edit/components/section_image_set/index.coffee
+++ b/client/apps/edit/components/section_image_set/index.coffee
@@ -119,6 +119,14 @@ module.exports = React.createClass
           else
             $(img).css('display', 'inline-block')
 
+  formatArtistNames: (artwork) ->
+    if artwork.artists?[0]
+      names = artwork.artists.map (artist) ->
+        artist.name
+      names.join ', '
+    else
+      artwork.artist?.name
+
   render: ->
     section {
       className: 'edit-section-image-set'
@@ -171,7 +179,7 @@ module.exports = React.createClass
                         className: 'esis-artwork'
                       }
                     p {},
-                      strong {}, item.artist.name if item.artist.name
+                      strong {}, @formatArtistNames item
                     p {}, item.title if item.title
                     p {}, item.partner.name if item.partner.name
                     button {

--- a/client/apps/edit/components/section_image_set/index.coffee
+++ b/client/apps/edit/components/section_image_set/index.coffee
@@ -77,7 +77,12 @@ module.exports = React.createClass
         image = new Image()
         image.src = src
         image.onload = =>
-          newImages = @state.images.concat [ { url: src, type: 'image' } ]
+          newImages = @state.images.concat [{
+            url: src
+            type: 'image'
+            width: image.width
+            height: image.height
+          }]
           @setState progress: null, images: newImages
 
   removeItem: (item) -> =>

--- a/client/apps/edit/components/section_image_set/test/index.coffee
+++ b/client/apps/edit/components/section_image_set/test/index.coffee
@@ -18,6 +18,8 @@ describe 'SectionImageSet', ->
       constructor: ->
         setTimeout => @onload()
       onload: ->
+      width: 120
+      height: 90
     benv.setup =>
       benv.expose $: benv.require 'jquery'
       SectionImageSet = benv.requireWithJadeify(
@@ -42,7 +44,7 @@ describe 'SectionImageSet', ->
               id: '123'
               image: 'https://artsy.net/artwork.jpg'
               partner: name: 'Guggenheim'
-              artist: name: 'Van Gogh'
+              artists: [ { name: 'Van Gogh' }, { name: 'Van Dogh' } ]
             }
           ]
         editing: false
@@ -68,12 +70,8 @@ describe 'SectionImageSet', ->
     setTimeout =>
       @component.setState.args[0][0].images[2].url.should.equal 'fooza'
       @component.setState.args[0][0].images[2].type.should.equal 'image'
-      done()
-
-  it 'saves the url after upload', (done) ->
-    @component.upload target: files: ['foo']
-    @gemup.args[0][1].done('fooza')
-    setTimeout =>
+      @component.setState.args[0][0].images[2].width.should.equal 120
+      @component.setState.args[0][0].images[2].height.should.equal 90
       @component.componentWillUpdate.called.should.be.ok
       done()
 
@@ -87,6 +85,7 @@ describe 'SectionImageSet', ->
     $(@component.getDOMNode()).html().should.containEql 'The Four Hedgehogs'
     $(@component.getDOMNode()).html().should.containEql 'Guggenheim'
     $(@component.getDOMNode()).html().should.containEql 'Van Gogh'
+    $(@component.getDOMNode()).html().should.containEql 'Van Dogh'
 
   it 'renders a preview', ->
     $(@component.getDOMNode()).html().should.containEql 'src="https://artsy.net/image.png" class="esis-preview-image"'

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -7,6 +7,7 @@ React = require 'react'
 SectionContainer = React.createFactory require '../section_container/index.coffee'
 SectionTool = React.createFactory require '../section_tool/index.coffee'
 { div } = React.DOM
+async = require 'async'
 
 module.exports = React.createClass
 
@@ -26,33 +27,6 @@ module.exports = React.createClass
   onNewSection: (section) ->
     @setState editingIndex: @props.sections.indexOf section
 
-  convertImages: (section) ->
-    image = {
-      type: 'image_collection'
-      images: [{
-        type: section.get('type')
-        url: section.get('url')
-        caption: section.get('caption')
-      }]
-      layout: section.get('layout') or 'overflow_fillwidth'
-    }
-    section.clear()
-    section.set image
-    return section
-
-  convertArtworks: (section) ->
-    images = section.get('artworks').map (artwork, i) ->
-      artwork.type = 'artwork'
-      return artwork
-    artworks = {
-      type: 'image_collection'
-      images: images
-      layout: section.get('layout') or 'overflow_fillwidth'
-    }
-    section.clear()
-    section.set(artworks)
-    return section
-
   render: ->
     div {},
       div {
@@ -62,10 +36,6 @@ module.exports = React.createClass
       },
         SectionTool { sections: @props.sections, index: -1 }
         @props.sections.map (section, i) =>
-          if section.get('type') is 'image'
-            section = @convertImages section
-          if section.get('type') is 'artworks'
-            section = @convertArtworks section
           [
             SectionContainer {
               sections: @props.sections

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -27,26 +27,30 @@ module.exports = React.createClass
     @setState editingIndex: @props.sections.indexOf section
 
   convertImages: (section) ->
-    images = [ {
-      type: section.get('type')
-      url: section.get('url')
-      caption: section.get('caption')
-    } ]
-    section.set('type', 'image_collection')
-    section.set('images', images)
-    section.set('layout', section.get('layout') || 'overflow_fillwidth')
-    section.unset('url')
-    section.unset('caption')
+    image = {
+      type: 'image_collection'
+      images: [{
+        type: section.get('type')
+        url: section.get('url')
+        caption: section.get('caption')
+      }]
+      layout: section.get('layout') or 'overflow_fillwidth'
+    }
+    section.clear()
+    section.set image
     return section
 
   convertArtworks: (section) ->
-    artworks = section.get('artworks').map (artwork, i) ->
+    images = section.get('artworks').map (artwork, i) ->
       artwork.type = 'artwork'
       return artwork
-    section.set('type', 'image_collection')
-    section.set('images', artworks)
-    section.unset('artworks')
-    section.unset('ids')
+    artworks = {
+      type: 'image_collection'
+      images: images
+      layout: section.get('layout') or 'overflow_fillwidth'
+    }
+    section.clear()
+    section.set(artworks)
     return section
 
   render: ->

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -7,7 +7,6 @@ React = require 'react'
 SectionContainer = React.createFactory require '../section_container/index.coffee'
 SectionTool = React.createFactory require '../section_tool/index.coffee'
 { div } = React.DOM
-async = require 'async'
 
 module.exports = React.createClass
 

--- a/client/apps/edit/components/section_list/test/index.coffee
+++ b/client/apps/edit/components/section_list/test/index.coffee
@@ -74,17 +74,6 @@ describe 'SectionList', ->
   xit 'renders the sections', ->
     @$el.html().should.containEql 'Foo to the bar'
 
-  it 'converts image components to image_collection', ->
-    @SectionContainer.args[2][0].section.attributes.type.should.equal 'image_collection'
-    @SectionContainer.args[2][0].section.attributes.images[0].type.should.equal 'image'
-    @SectionContainer.args[2][0].section.attributes.images[0].url.should.equal 'http://artsy.net/image.jpg'
-
-  it 'converts artwork components to image_collection', ->
-    @SectionContainer.args[3][0].section.attributes.type.should.equal 'image_collection'
-    @SectionContainer.args[3][0].section.attributes.images[0].type.should.equal 'artwork'
-    @SectionContainer.args[3][0].section.attributes.images[0].artists[0].slug.should.equal 'rodrigo-valenzuela'
-    @SectionContainer.args[3][0].section.attributes.images[1].artists[0].slug.should.equal 'rodrigo-valenzuela-2'
-
   it 'sets an index for the section tools', ->
     @SectionTool.args[0][0].index.should.equal -1
     @SectionTool.args[1][0].index.should.equal 0

--- a/client/apps/edit/test/client.coffee
+++ b/client/apps/edit/test/client.coffee
@@ -1,0 +1,49 @@
+benv = require 'benv'
+sinon = require 'sinon'
+Backbone = require 'backbone'
+rewire = require 'rewire'
+Client = rewire '../client.coffee'
+fixtures = require '../../../../test/helpers/fixtures'
+
+describe 'init', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose $: benv.require('jquery')
+      Backbone.$ = $
+      window.jQuery = $
+      sinon.stub Backbone, 'sync'
+      Client.__set__ 'EditLayout', @EditLayout = sinon.stub()
+      Client.__set__ 'EditHeader', @EditHeader = sinon.stub()
+      Client.__set__ 'EditAdmin', @EditAdmin = sinon.stub()
+      Client.__set__ 'EditDisplay', @EditDisplay = sinon.stub()
+      Client.__set__ 'SectionList', @SectionList = sinon.stub()
+      Client.__set__ 'HeroSection', @HeroSection = sinon.stub()
+      Client.__set__ 'React', sinon.stub()
+      Client.__set__ 'sd', { ARTICLE: fixtures().articles }
+      @view = new Client
+        el: $('body')
+        article: fixtures().articles
+      done()
+
+  afterEach ->
+    benv.teardown()
+    Backbone.sync.restore()
+
+  it 'initializes Backbone layouts and React components', ->
+    console.log @EditLayout.callCount()
+
+  it 'converts legacy articles to ImageCollection', ->
+
+  it 'makes sure ImageSets images have widths and heights', ->
+
+  it 'converts image components to image_collection', ->
+    @SectionContainer.args[2][0].section.attributes.type.should.equal 'image_collection'
+    @SectionContainer.args[2][0].section.attributes.images[0].type.should.equal 'image'
+    @SectionContainer.args[2][0].section.attributes.images[0].url.should.equal 'http://artsy.net/image.jpg'
+
+  it 'converts artwork components to image_collection', ->
+    @SectionContainer.args[3][0].section.attributes.type.should.equal 'image_collection'
+    @SectionContainer.args[3][0].section.attributes.images[0].type.should.equal 'artwork'
+    @SectionContainer.args[3][0].section.attributes.images[0].artists[0].slug.should.equal 'rodrigo-valenzuela'
+    @SectionContainer.args[3][0].section.attributes.images[1].artists[0].slug.should.equal 'rodrigo-valenzuela-2'

--- a/client/apps/edit/test/client.coffee
+++ b/client/apps/edit/test/client.coffee
@@ -19,9 +19,9 @@ describe 'init', ->
         _: require('underscore')
         $: benv.require('jquery')
         jQuery: benv.require('jquery')
+        sd: { ARTICLE: fixtures().articles }
       window.jQuery = jQuery
       @client = rewire '../client.coffee'
-      @client.__set__ 'sd', { USER: fixtures().users, ARTICLE: fixtures().articles }
       @client.__set__ 'EditLayout', @EditLayout = sinon.stub()
       @client.__set__ 'EditHeader', @EditHeader = sinon.stub()
       @client.__set__ 'EditAdmin', @EditAdmin = sinon.stub()
@@ -58,10 +58,10 @@ describe 'init', ->
       @client.article.sections.models[3].get('images')[1].image.should.equal 'https://artsy.net/artwork2.jpg'
       done()
 
-  it 'converts image sets components to image_collection', ->
+  it 'keeps image sets as is', ->
     @client.init()
     _.defer =>
-      @client.article.sections.models[6].get('type').should.equal 'image_collection'
+      @client.article.sections.models[6].get('type').should.equal 'image_set'
       @client.article.sections.models[6].get('layout').should.equal 'overflow_fillwidth'
       @client.article.sections.models[6].get('images')[0].image.should.equal 'https://artsy.net/artwork.jpg'
       @client.article.sections.models[6].get('images')[0].title.should.equal 'The Four Hedgehogs'
@@ -80,4 +80,10 @@ describe 'init', ->
       @client.article.sections.models[3].get('images')[0].height.should.equal 90
       @client.article.sections.models[3].get('images')[1].width.should.equal 120
       @client.article.sections.models[3].get('images')[1].height.should.equal 90
+      @client.article.sections.models[6].get('images')[0].height.should.equal 90
+      @client.article.sections.models[6].get('images')[0].height.should.equal 90
+      @client.article.sections.models[6].get('images')[1].height.should.equal 90
+      @client.article.sections.models[6].get('images')[1].height.should.equal 90
+      @client.article.sections.models[6].get('images')[2].height.should.equal 90
+      @client.article.sections.models[6].get('images')[2].height.should.equal 90
       done()

--- a/client/apps/edit/test/client.coffee
+++ b/client/apps/edit/test/client.coffee
@@ -58,22 +58,18 @@ describe 'init', ->
       @client.article.sections.models[3].get('images')[1].image.should.equal 'https://artsy.net/artwork2.jpg'
       done()
 
-  it 'keeps image sets as is', ->
+  it 'keeps image sets as is', (done) ->
     @client.init()
     _.defer =>
       @client.article.sections.models[6].get('type').should.equal 'image_set'
-      @client.article.sections.models[6].get('layout').should.equal 'overflow_fillwidth'
-      @client.article.sections.models[6].get('images')[0].image.should.equal 'https://artsy.net/artwork.jpg'
-      @client.article.sections.models[6].get('images')[0].title.should.equal 'The Four Hedgehogs'
-      @client.article.sections.models[6].get('images')[1].title.should.equal 'The Four Hedgehogs 2'
-      @client.article.sections.models[6].get('images')[1].id.should.equal '5321b71c275b24bcaa0001a5'
-      @client.article.sections.models[6].get('images')[1].image.should.equal 'https://artsy.net/artwork2.jpg'
-      @client.article.sections.models[6].get('images')[2].type.should.equal 'image'
-      @client.article.sections.models[6].get('images')[2].caption.should.equal 'This is a terrible caption'
-      @client.article.sections.models[6].get('images')[2].url.should.equal 'http://gemini.herokuapp.com/123/miaart-banner.jpg'
+      @client.article.sections.models[6].get('images')[0].image.should.equal 'https://artsy.net/artwork2.jpg'
+      @client.article.sections.models[6].get('images')[0].title.should.equal 'The Four Hedgehogs 2'
+      @client.article.sections.models[6].get('images')[1].type.should.equal 'image'
+      @client.article.sections.models[6].get('images')[1].caption.should.equal 'This is a terrible caption'
+      @client.article.sections.models[6].get('images')[1].url.should.equal 'http://gemini.herokuapp.com/123/miaart-banner.jpg'
       done()
 
-  it 'makes sure images have widths and heights', ->
+  it 'makes sure images have widths and heights', (done) ->
     @client.init()
     _.defer =>
       @client.article.sections.models[3].get('images')[0].width.should.equal 120
@@ -84,6 +80,4 @@ describe 'init', ->
       @client.article.sections.models[6].get('images')[0].height.should.equal 90
       @client.article.sections.models[6].get('images')[1].height.should.equal 90
       @client.article.sections.models[6].get('images')[1].height.should.equal 90
-      @client.article.sections.models[6].get('images')[2].height.should.equal 90
-      @client.article.sections.models[6].get('images')[2].height.should.equal 90
       done()

--- a/client/models/artwork.coffee
+++ b/client/models/artwork.coffee
@@ -30,6 +30,7 @@ module.exports = class Artwork extends Backbone.Model
       name: @getPartnerName()
       slug: @getPartnerLink()
     artists: @getArtists()
+    artist: @getArtists()[0]
     width: parseInt(@defaultImage().get('original_width'))
     height: parseInt(@defaultImage().get('original_height'))
 

--- a/client/models/artwork.coffee
+++ b/client/models/artwork.coffee
@@ -29,17 +29,18 @@ module.exports = class Artwork extends Backbone.Model
     partner:
       name: @getPartnerName()
       slug: @getPartnerLink()
-    artist:
-      name: @getArtistName()
-      slug: @get('artist')?.id
+    artists: @getArtists()
+    width: parseInt(@defaultImage().get('original_width'))
+    height: parseInt(@defaultImage().get('original_height'))
 
-  getArtistName: ->
-    if @get('artist')?.name
-      @get('artist').name
-    else if @get('artists')?.length > 0
-      _.compact(@get('artists').pluck('name'))[0]
+  getArtists: ->
+    artists = []
+    if @get('artists')?[0]
+      @get('artists').forEach (artist) ->
+         artists.push({name: artist.name, slug: artist.id})
     else
-      ''
+      artists.push({name: @get('artist')?.name, slug: @get('artist')?.id})
+    artists
 
   getPartnerName: ->
     if @get('collecting_institution')?.length > 0

--- a/client/test/models/article.coffee
+++ b/client/test/models/article.coffee
@@ -18,7 +18,7 @@ describe "Article", ->
   describe '#initialize', ->
 
     it 'sets up a related sections collection', ->
-      @article.sections.length.should.equal 6
+      @article.sections.length.should.equal 7
 
   describe '#toJSON', ->
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2622,7 +2622,8 @@
     "jquery-on-infinite-scroll": {
       "version": "1.0.1",
       "from": "jquery-on-infinite-scroll@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jquery-on-infinite-scroll/-/jquery-on-infinite-scroll-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/jquery-on-infinite-scroll/-/jquery-on-infinite-scroll-1.0.1.tgz",
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.0",

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -33,6 +33,7 @@ module.exports = ->
       {
         type: 'image',
         url: 'http://gemini.herokuapp.com/123/miaart-banner.jpg'
+        caption: 'This is a terrible caption'
       }
       {
         type: 'text',
@@ -42,6 +43,24 @@ module.exports = ->
         type: 'artworks',
         ids: ['5321b73dc9dc2458c4000196', '5321b71c275b24bcaa0001a5'],
         layout: 'overflow_fillwidth'
+        artworks: [
+          {
+            type: 'artwork'
+            title: 'The Four Hedgehogs'
+            id: '5321b73dc9dc2458c4000196'
+            image: 'https://artsy.net/artwork.jpg'
+            partner: name: 'Guggenheim'
+            artists: [ { name: 'Van Gogh' }, { name: 'Van Dogh' } ]
+          }
+          {
+            type: 'artwork'
+            title: 'The Four Hedgehogs 2'
+            id: '5321b71c275b24bcaa0001a5'
+            image: 'https://artsy.net/artwork2.jpg'
+            partner: name: 'Guggenheim'
+            artists: [ { name: 'Van Gogh' }]
+          }
+        ]
       }
       {
         type: 'text',
@@ -50,6 +69,24 @@ module.exports = ->
       {
         type: 'video',
         url: 'http://youtu.be/yYjLrJRuMnY'
+      }
+      {
+        type: 'image_set'
+        images: [
+          {
+            type: 'artwork'
+            title: 'The Four Hedgehogs 2'
+            id: '5321b71c275b24bcaa0001a5'
+            image: 'https://artsy.net/artwork2.jpg'
+            partner: name: 'Guggenheim'
+            artists: [ { name: 'Van Gogh' }]
+          }
+          {
+            type: 'image',
+            url: 'http://gemini.herokuapp.com/123/miaart-banner.jpg'
+            caption: 'This is a terrible caption'
+          }
+        ]
       }
     ]
     primary_featured_artist_ids: ['5086df098523e60002000012']


### PR DESCRIPTION
All `ImageCollection` sections will now also provide a width/height. Same for `ImageSet`.

The WIP part is for the conversion process. We'll have to fetch images/artworks when converting Image and Artwork sections to ImageCollection so we can provide the width/height info. I'm playing around with moving this logic to the `Sections` collection where it seems fit a little better...sorry it's taking a while to get this out! Really hate halting other deploys for this kinda thing but 🤷‍♀️ 