### PR TITLE
@kanaabe => Queue displays email headlines and images

### DIFF
--- a/client/apps/queue/client/client.coffee
+++ b/client/apps/queue/client/client.coffee
@@ -116,6 +116,7 @@ module.exports.QueueView = QueueView = React.createClass
             placeholder: 'Search Articles...'
             articles: @state.publishedArticles
             checkable: true
+            display: 'email'
             headerText: "Latest Articles"
             selected: @selected
             searchResults: @searchResults

--- a/client/apps/queue/query.coffee
+++ b/client/apps/queue/query.coffee
@@ -4,6 +4,10 @@ module.exports = (argString) ->
     articles(#{argString}){
       thumbnail_image
       thumbnail_title
+      email_metadata {
+        headline
+        image_url
+      }
       slug
       published_at
       scheduled_publish_at

--- a/client/components/article_list/index.coffee
+++ b/client/components/article_list/index.coffee
@@ -2,6 +2,7 @@
 # ArticleList {
 #   selected: () ->
 #   checkable: true
+#   display: 'email'
 #   articles: []
 # }
 
@@ -12,6 +13,12 @@ moment = require 'moment'
 icons = -> require('./icons.jade') arguments...
 
 module.exports = ArticleList = React.createClass
+
+  getDisplayAttrs: (article) ->
+    if @props.display is 'email' and article.email_metadata
+      return {headline: article.email_metadata.headline, image: article.email_metadata.image_url}
+    else
+      return {headline: article.thumbnail_title, image: article.thumbnail_image}
 
   publishText: (result) ->
     if result.published_at and result.published
@@ -28,20 +35,22 @@ module.exports = ArticleList = React.createClass
       unless @props.articles?.length
         div { className: 'article-list__no-results' }, "No Results Found"
       (@props.articles.map (result) =>
-        div { className: 'article-list__result paginated-list-item' },
+        attrs = @getDisplayAttrs(result)
+        div { className: 'article-list__result paginated-list-item', key: result.id},
           if @props.checkable
             div {
+              ref: result.id
               className: 'article-list__checkcircle'
               dangerouslySetInnerHTML: __html: $(icons()).filter('.check-circle').html()
               onClick: => @props.selected(result)
             }
           a { className: 'article-list__article', href: "/articles/#{result.id}/edit" },
-            div { className: 'article-list__image paginated-list-img', style: backgroundImage: "url(#{result.thumbnail_image})" },
-              unless result.thumbnail_image
+            div { className: 'article-list__image paginated-list-img', style: backgroundImage: "url(#{attrs.image})" },
+              unless attrs.image
                 div { className: 'missing-img'}, "Missing Thumbnail"
             div { className: 'article-list__title paginated-list-text-container' },
-              if result.thumbnail_title
-                h1 {}, result.thumbnail_title
+              if attrs.headline
+                h1 {}, attrs.headline
               else
                 h1 { className: 'missing-title'}, 'Missing Title'
               h2 {}, @publishText(result)

--- a/client/components/article_list/test/index.coffee
+++ b/client/components/article_list/test/index.coffee
@@ -20,9 +20,24 @@ describe 'ArticleList', ->
       ArticleList.__set__ 'sd', { FORCE_URL: 'http://artsy.net' }
       @component = React.render ArticleList(
         {
-          articles: [{id: '123', thumbnail_title: 'Game of Thrones', slug: 'artsy-editorial-game-of-thrones'}]
+          articles: [
+            {
+              id: '123'
+              thumbnail_title: 'Game of Thrones'
+              thumbnail_image: 'http://artsy.net/thumbnail_image.jpg'
+              slug: 'artsy-editorial-game-of-thrones'
+            },
+            {
+              id: '124'
+              thumbnail_title: 'Email Game of Thrones'
+              thumbnail_image: 'http://artsy.net/thumbnail_image2.jpg'
+              email_metadata: {headline: 'Email of Thrones', image_url: 'http://artsy.net/image_url.jpg'}
+              slug: 'artsy-editorial-email-of-thrones'
+            }
+          ]
           selected: sinon.stub()
           checkable: true
+          display: 'email'
         }
       ), (@$el = $ "<div></div>")[0], => setTimeout =>
         sinon.stub @component, 'setState'
@@ -36,7 +51,11 @@ describe 'ArticleList', ->
     $(@component.getDOMNode()).html().should.containEql 'http://artsy.net/article/artsy-editorial-game-of-thrones'
 
   it 'selects the article when clicking the check button', ->
-    r.simulate.click r.find @component, 'article-list__checkcircle'
+    r.simulate.click @component.refs['123'].getDOMNode()
     @component.props.selected.args[0][0].id.should.containEql '123'
     @component.props.selected.args[0][0].thumbnail_title.should.containEql 'Game of Thrones'
     @component.props.selected.args[0][0].slug.should.containEql 'artsy-editorial-game-of-thrones'
+
+  it 'can render email headlines and images', ->
+    $(@component.getDOMNode()).html().should.containEql 'Email of Thrones'
+    $(@component.getDOMNode()).html().should.containEql 'image_url.jpg'

--- a/client/components/filter_search/index.coffee
+++ b/client/components/filter_search/index.coffee
@@ -42,4 +42,5 @@ module.exports = FilterSearch = React.createClass
         articles: @props.articles
         checkable: @props.checkable
         selected: @selected
+        display: @props.display
       }


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/909

Queue/schedule panel displays email headline and image in list-views
Adds a 'display' prop to the articles list so email and potentially other metadata can be accessible in list views