### PR TITLE
@craigspaeth => Be able to save zero sections

### DIFF
--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -15,6 +15,7 @@ module.exports = class Article extends Backbone.Model
 
   initialize: ->
     @sections = new Sections @get 'sections'
+    @on 'change:sections', => @sections.set @get 'sections'
     @featuredPrimaryArtists = new Artists
     @featuredArtists = new Artists
     @mentionedArtists = new Artists
@@ -98,7 +99,7 @@ module.exports = class Article extends Backbone.Model
 
   toJSON: ->
     extended = {}
-    extended.sections = @sections.toJSON() if @sections.length
+    extended.sections = @sections.toJSON()
     if @heroSection.keys().length > 1
       extended.hero_section = @heroSection.toJSON()
     else

--- a/client/test/models/article.coffee
+++ b/client/test/models/article.coffee
@@ -26,11 +26,6 @@ describe "Article", ->
       @article.sections.reset { body: 'Foobar' }
       @article.toJSON().sections[0].body.should.equal 'Foobar'
 
-    it 'sections fall back to attrs', ->
-      @article.set sections: [{ body: 'Foobar' }]
-      @article.sections.reset []
-      @article.toJSON().sections[0].body.should.equal 'Foobar'
-
     it 'injects features artworks & artists', ->
       @article.featuredArtworks.set [fabricate('artist')]
       @article.featuredArtists.set [fabricate('artist')]


### PR DESCRIPTION
### Problem
If you go from having sections in an article to deleting all the sections and try to save an empty article, it will fall back to its previous attrs. 

I think this predates me, but i wonder what the reason we wanted to fallback on attrs was. It seems like the reason was that on the [edit router](https://github.com/kanaabe/positron/blob/master/client/apps/edit/routes.coffee), we need to do `article.toJSON()` before rendering but we didn't have `article.sections` [defined](https://github.com/artsy/positron/blob/master/client/models/article.coffee#L17) when first initializing.

I'm sure there was a good reason at the time but if we listen for changes to the article's `attrs`, we can set `article.sections` after the sync is triggered.

### Solution
Listen to changes on the article, and set `article.sections` after the fetch. 
It's actually just the same thing as HeroSection [here](https://github.com/artsy/positron/blob/master/client/models/article.coffee#L24).