### PR TITLE
Revert #915

### DIFF
--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -15,7 +15,6 @@ module.exports = class Article extends Backbone.Model
 
   initialize: ->
     @sections = new Sections @get 'sections'
-    @on 'change:sections', => @sections.set @get 'sections'
     @featuredPrimaryArtists = new Artists
     @featuredArtists = new Artists
     @mentionedArtists = new Artists
@@ -99,7 +98,7 @@ module.exports = class Article extends Backbone.Model
 
   toJSON: ->
     extended = {}
-    extended.sections = @sections.toJSON()
+    extended.sections = @sections.toJSON() if @sections.length
     if @heroSection.keys().length > 1
       extended.hero_section = @heroSection.toJSON()
     else

--- a/client/test/models/article.coffee
+++ b/client/test/models/article.coffee
@@ -26,6 +26,11 @@ describe "Article", ->
       @article.sections.reset { body: 'Foobar' }
       @article.toJSON().sections[0].body.should.equal 'Foobar'
 
+    it 'sections fall back to attrs', ->
+      @article.set sections: [{ body: 'Foobar' }]
+      @article.sections.reset []
+      @article.toJSON().sections[0].body.should.equal 'Foobar'
+
     it 'injects features artworks & artists', ->
       @article.featuredArtworks.set [fabricate('artist')]
       @article.featuredArtists.set [fabricate('artist')]


### PR DESCRIPTION
https://github.com/artsy/positron/pull/915

This approach was naive because we shouldn't add a listener on the sections since our React components are listening to changes on these sections as well. So on the save it was triggering a bunch of mounts/unmounts that was causing the page to jump around. Whewwwwwwwwwww. 😓 