### PR TITLE
@craigspaeth => move uglify to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "superagent": "^3.3.1",
     "superagent-bluebird-promise": "^3.0.0",
     "ua-parser": "^0.3.5",
+    "uglifyify": "^3.0.1",
     "underscore": "^1.8.3",
     "underscore.string": "^3.2.2",
     "xss": "^0.2.7",
@@ -103,7 +104,6 @@
     "sinon": "^1.17.1",
     "sqwish": "^0.2.2",
     "typeahead.js": "0.10.x",
-    "uglifyify": "^3.0.1",
     "zombie": "^4.1.0"
   },
   "license": "MIT"


### PR DESCRIPTION
One step closer on yarn -- for some reason this error doesn't even appear in staging, but in production heroku wants access to uglify