### PR TITLE
@eessex: Tolerate lowercase 'type' field in v2 search results

### DIFF
--- a/api/apps/shows/model.coffee
+++ b/api/apps/shows/model.coffee
@@ -17,7 +17,7 @@ request = require 'superagent'
     .set('X-Access-Token': accessToken)
     .end (err, res) ->
       return callback err if err
-      slugs = for result in res.body._embedded.results when result.type is 'Show'
+      slugs = for result in res.body._embedded.results when result.type?.toLowerCase() is 'show'
         href = result._links.self.href
         slug = _.last href.split('/')
       async.map slugs, (slug, cb) ->

--- a/client/apps/edit/components/section_artworks/index.coffee
+++ b/client/apps/edit/components/section_artworks/index.coffee
@@ -46,7 +46,7 @@ module.exports = React.createClass
       filter: (res) ->
         vals = []
         for r in res._embedded.results
-          if r.type == 'Artwork'
+          if r.type?.toLowerCase() == 'artwork'
             id = r._links.self.href.substr(r._links.self.href.lastIndexOf('/') + 1)
             vals.push
               id: id

--- a/client/apps/edit/components/section_image_collection/index.coffee
+++ b/client/apps/edit/components/section_image_collection/index.coffee
@@ -43,7 +43,7 @@ module.exports = React.createClass
       filter: (res) ->
         vals = []
         for r in res._embedded.results
-          if r.type == 'Artwork'
+          if r.type?.toLowerCase() == 'artwork'
             id = r._links.self.href.substr(r._links.self.href.lastIndexOf('/') + 1)
             vals.push
               id: id

--- a/client/apps/edit/components/section_image_set/index.coffee
+++ b/client/apps/edit/components/section_image_set/index.coffee
@@ -42,7 +42,7 @@ module.exports = React.createClass
       filter: (res) ->
         vals = []
         for r in res._embedded.results
-          if r.type == 'Artwork'
+          if r.type?.toLowerCase() == 'artwork'
             id = r._links.self.href.substr(r._links.self.href.lastIndexOf('/') + 1)
             vals.push
               id: id


### PR DESCRIPTION
We've moved away from search results being provided by Google on most clients. The v2 [api/search](https://github.com/artsy/gravity/blob/master/app/api/v2/search_endpoint.rb) endpoint is the last remaining part of the platform that depends on it.

I plan to update it shortly to be backed by Elasticsearch instead. In doing so, I hope to drop some of the more Google-focused properties if we can get away with that [without breaking clients]. The few references below to the capitalized forms of `"Artwork"` and `"Show"` could be more conveniently replaced by their lower-case forms that we're already returning from Elasticsearch. I tested that this change is compatible both with current results and the future/anticipated versions. (Of course we _could_ return _both_ the up-cased and down-cased values in different properties, but this seemed an easy and more consistent update to make instead.)

I don't really know what I'm doing in this repo, so feel free to point me in a different direction.