### PR TITLE
@eessex => Mark article as published when sending to FB

### DIFF
--- a/api/apps/articles/model/distribute.coffee
+++ b/api/apps/articles/model/distribute.coffee
@@ -60,6 +60,7 @@ postFacebookAPI = (article, cb) ->
         .send
           access_token: INSTANT_ARTICLE_ACCESS_TOKEN
           development_mode: NODE_ENV isnt 'production'
+          published: NODE_ENV is 'production'
           html_source: html
         .end (err, response) =>
           if err


### PR DESCRIPTION
We should indicate that the article is published if we're in NODE_ENV='production'. Currently staging articles are being published to FB's IA manager, but production isn't, and I think it's because of this flag. It works for me now if I do this locally with the flag set. 

https://developers.facebook.com/docs/instant-articles/api/