### PR TITLE
Handle missing thumbnails in search results

### DIFF
--- a/client/apps/edit/components/section_artworks/index.coffee
+++ b/client/apps/edit/components/section_artworks/index.coffee
@@ -51,7 +51,7 @@ module.exports = React.createClass
             vals.push
               id: id
               value: r.title
-              thumbnail: r._links.thumbnail.href
+              thumbnail: r._links.thumbnail?.href
         return vals
       templates:
         suggestion: (data) ->

--- a/client/apps/edit/components/section_image_collection/index.coffee
+++ b/client/apps/edit/components/section_image_collection/index.coffee
@@ -53,7 +53,7 @@ module.exports = React.createClass
             vals.push
               id: id
               value: r.title
-              thumbnail: r._links.thumbnail.href
+              thumbnail: r._links.thumbnail?.href
         return vals
       templates:
         suggestion: (data) ->

--- a/client/apps/edit/components/section_image_set/index.coffee
+++ b/client/apps/edit/components/section_image_set/index.coffee
@@ -48,7 +48,7 @@ module.exports = React.createClass
             vals.push
               id: id
               value: r.title
-              thumbnail: r._links.thumbnail.href
+              thumbnail: r._links.thumbnail?.href
         return vals
       templates:
         suggestion: (data) ->


### PR DESCRIPTION
I noticed client-side errors when hitting the v2 search API from this app:

    Uncaught TypeError: Cannot read property 'href' of undefined
      at Object.filter (main-e6c1d45e.js.jgz:3)

I reproduced it locally and it corresponds with article search results that don't have images. The new code tolerates that better. (This could use a test, but I couldn't find a close enough example and wasn't so bold as to create a new one.)

A reasonable question is why the new ES-backed search results lack some images while the Google-backed results didn't. I'm not sure, but [this](https://github.com/artsy/positron/blob/694736206d1998f5e956afa59ffe15f158f846ec/api/apps/articles/model/distribute.coffee#L125) is where we specify the corresponding image for ES. Maybe there's a better or more commonly available image instead?