### PR TITLE
@craigspaeth => Queue bug fix and loading/error flash

### DIFF
--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -15,6 +15,7 @@ imageSection = (->
     caption: @string().allow('', null)
     width: @number().allow(null)
     height: @number().allow(null)
+    layout: @string().allow('', null)
 ).call Joi
 
 videoSection = (->

--- a/client/apps/queue/client/client.coffee
+++ b/client/apps/queue/client/client.coffee
@@ -19,13 +19,23 @@ module.exports = QueueView = React.createClass
     queuedArticles: @props.queuedArticles or []
     scheduledArticles: @props.scheduledArticles or []
     feed: @props.feed or 'scheduled'
+    loading: false
+    errorMessage: ''
 
   saveSelected: (data, isQueued) ->
-    article = new Article
+    article =
       id: data.id
       channel_id: data.channel_id
       "#{@state.feed}": isQueued
-    article.save()
+    @setState loading: true
+    new Article().save article,
+      success: =>
+        @setState loading: false
+      error: =>
+        @setState
+          loading: false
+          errorMessage: 'There has been an error. Please contact support.'
+        setTimeout ( => @setState(errorMessage: '')), 2000
 
   selected: (article, type) ->
     if type is 'select'
@@ -81,7 +91,12 @@ module.exports = QueueView = React.createClass
     div {
       'data-state': @state.feed
       className: 'queue-root-container'
+      'data-loading': @state.loading
     },
+      div { className: 'queue-loading-container'},
+        div { className: 'loading-spinner' }
+        if @state.errorMessage
+          div { className: 'queue-loading__error' }, @state.errorMessage
       h1 { className: 'page-header' },
         div { className: 'max-width-container' },
           nav {className: 'nav-tabs'},

--- a/client/apps/queue/index.styl
+++ b/client/apps/queue/index.styl
@@ -1,3 +1,5 @@
+@import '../../components/stylus_lib'
+
 .queue-root-container
   &[data-state='scheduled']
     .queue-scheduled
@@ -9,6 +11,34 @@
       display none
     .queue-queued, .queue-filter-search
       display block
+  &[data-loading='true']
+    .loading-spinner
+      display block
+    .queue-loading-container
+      position fixed
+      top 0
+      left sidebar-width
+      width "calc(100% - %s)" % sidebar-width
+      height 100%
+      z-index 4
+      background rgba(255,255,255,0.8)
+  &[data-loading='false']
+    .loading-spinner
+      display none
+  .queue-loading__error
+    position fixed
+    display flex
+    justify-content center
+    align-items center
+    garamond 'headline'
+    top 0
+    bottom 0
+    right 0
+    left 0
+    z-index 4
+    background rgba(0,0,0,0.5)
+    color white
+
   .page-header
     .max-width-container
       display flex


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/944

It was reported that sometimes items to the queue take a few clicks to save properly. Attempting two things in this PR. First one is a real bug that happens when you try to save an article with an old 'image' section. It's solved by the first commit. Second is a preventative measure that displays a loading spinner until the save callback is finished, and also displays an error message if anything went wrong!

![queue-saving](https://cloud.githubusercontent.com/assets/2236794/23595457/01c5a00e-01f0-11e7-8b0e-a582038b3d67.gif)
![queue-error-msg](https://cloud.githubusercontent.com/assets/2236794/23595462/07ff1626-01f0-11e7-82ea-2a7da2ce5f43.gif)

