### PR TITLE
@craigspaeth => Make count/total optional in API response

### DIFF
--- a/api/apps/articles/model/retrieve.coffee
+++ b/api/apps/articles/model/retrieve.coffee
@@ -9,30 +9,38 @@ moment = require 'moment'
   Joi.validate input, schema.querySchema, { stripUnknown: true }, (err, input) ->
     return callback err if err
     # Separate "find" query from sort/offest/limit
-    { limit, offset, sort } = input
-    query = _.omit input, 'limit', 'offset', 'sort', 'artist_id', 'artwork_id', 'super_article_for',
-      'fair_ids', 'fair_programming_id', 'fair_artsy_id', 'fair_about_id', 'partner_id', 'auction_id', 'show_id', 'q', 'all_by_author', 'section_id', 'tags', 'has_video', 'fair_id', 'channel_id', 'ids', 'scheduled'
+    { limit, offset, sort, count } = input
+    query = _.omit input, 'limit', 'offset', 'sort', 'artist_id', 'artwork_id',
+      'super_article_for', 'fair_ids', 'fair_programming_id', 'fair_artsy_id',
+      'fair_about_id', 'partner_id', 'auction_id', 'show_id', 'q',
+      'all_by_author', 'section_id', 'tags', 'has_video', 'fair_id',
+      'channel_id', 'ids', 'scheduled', 'count'
     # Type cast IDs
     # TODO: https://github.com/pebble/joi-objectid/issues/2#issuecomment-75189638
     query.author_id = ObjectId input.author_id if input.author_id
-    query.fair_ids = { $elemMatch: { $in: _.map(input.fair_ids, ObjectId) } } if input.fair_ids
+    if input.fair_ids
+      query.fair_ids = { $elemMatch: { $in: _.map(input.fair_ids, ObjectId) } }
     query.fair_ids = ObjectId input.fair_id if input.fair_id
-    query.fair_programming_ids = ObjectId input.fair_programming_id if input.fair_programming_id
+    if input.fair_programming_id
+      query.fair_programming_ids = ObjectId input.fair_programming_id
     query.fair_artsy_ids = ObjectId input.fair_artsy_id if input.fair_artsy_id
     query.fair_about_ids = ObjectId input.fair_about_id if input.fair_about_id
     query.partner_ids = ObjectId input.partner_id if input.partner_id
     query.show_ids = ObjectId input.show_id if input.show_id
     query.auction_ids = ObjectId input.auction_id if input.auction_id
     query.section_ids = ObjectId input.section_id if input.section_id
-    query.biography_for_artist_id = ObjectId input.biography_for_artist_id if input.biography_for_artist_id
+    if input.biography_for_artist_id
+      query.biography_for_artist_id = ObjectId input.biography_for_artist_id
     query.featured_artwork_ids = ObjectId input.artwork_id if input.artwork_id
     query.tags = { $in: input.tags } if input.tags
 
     # Convert query for super article for article
-    query['super_article.related_articles']= ObjectId(input.super_article_for) if input.super_article_for
+    if input.super_article_for
+      query['super_article.related_articles']= ObjectId(input.super_article_for)
 
     # Only add the $or array for queries that require it (blank $or array causes problems)
-    query.$or ?= [] if input.artist_id or input.all_by_author or input.has_video or input.channel_id
+    query.$or ?= [] if input.artist_id or input.all_by_author or
+      input.has_video or input.channel_id
 
     # Convert query for channel_id to include partner_channel_id
     query.$or.push(
@@ -70,7 +78,7 @@ moment = require 'moment'
       ids = _.map input.ids, (id) -> ObjectId(id)
       query._id = { $in: ids }
 
-    callback null, query, limit, offset, sortParamToQuery(sort)
+    callback null, query, limit, offset, sortParamToQuery(sort), count
 
 sortParamToQuery = (input) ->
   return { updated_at: -1 } unless input

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -224,4 +224,5 @@ denormalizedArtwork = (->
   daily_email: @boolean()
   weekly_email: @boolean()
   scheduled: @boolean()
+  count: @boolean().default(false)
 ).call Joi

--- a/api/apps/articles/test/integration.coffee
+++ b/api/apps/articles/test/integration.coffee
@@ -26,7 +26,7 @@ describe 'articles endpoints', ->
         { published: false }
       ], (err, articles) =>
         request
-          .get("http://localhost:5000/articles?published=true")
+          .get("http://localhost:5000/articles?published=true&count=true")
           .end (err, res) ->
               res.body.total.should.equal 3
               res.body.count.should.equal 2
@@ -73,7 +73,7 @@ describe 'articles endpoints', ->
         {}
       ], (err, articles) =>
         request
-          .get("http://localhost:5000/articles?author_id=#{@user._id}&published=true")
+          .get("http://localhost:5000/articles?author_id=#{@user._id}&published=true&count=true")
           .set('X-Access-Token': @user.access_token)
           .end (err, res) ->
             res.body.total.should.equal 3
@@ -86,7 +86,7 @@ describe 'articles endpoints', ->
         { title: 'Winter Is Coming', channel_id: ObjectId('5086df098523e60002000012'), published: true }
       ], (err, articles) =>
         request
-        .get("http://localhost:5000/articles?channel_id=5086df098523e60002000012&published=true")
+        .get("http://localhost:5000/articles?channel_id=5086df098523e60002000012&published=true&count=true")
         .set('X-Access-Token': @user.access_token)
         .end (err, res) ->
           res.body.total.should.equal 1

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -35,10 +35,18 @@ describe 'Article', ->
   describe '#where', ->
 
     it 'can return all articles along with total and counts', (done) ->
-      Article.where {}, (err, res) ->
+      Article.where { count: true }, (err, res) ->
         { total, count, results } = res
         total.should.equal 10
         count.should.equal 10
+        results[0].title.should.equal 'Top Ten Booths'
+        done()
+
+    it 'can return all articles along with total and counts', (done) ->
+      Article.where {}, (err, res) ->
+        { total, count, results } = res
+        total?.should.be.false()
+        count?.should.be.false()
         results[0].title.should.equal 'Top Ten Booths'
         done()
 
@@ -47,7 +55,7 @@ describe 'Article', ->
         author_id: aid = ObjectId '4d8cd73191a5c50ce220002a'
         title: 'Hello Wurld'
       }, ->
-        Article.where { author_id: aid.toString() }, (err, res) ->
+        Article.where { author_id: aid.toString(), count: true }, (err, res) ->
           { total, count, results } = res
           total.should.equal 11
           count.should.equal 1
@@ -56,7 +64,7 @@ describe 'Article', ->
 
     it 'can return articles by published', (done) ->
       fabricate 'articles', _.times(3, -> { published: false, title: 'Moo baz' }), ->
-        Article.where { published: false }, (err, { total, count, results }) ->
+        Article.where { published: false, count: true }, (err, { total, count, results }) ->
           total.should.equal 13
           count.should.equal 3
           results[0].title.should.equal 'Moo baz'
@@ -163,7 +171,7 @@ describe 'Article', ->
         title: 'Hello Wurld'
         fair_programming_ids: [ ObjectId('52617c6c8b3b81f094000013') ]
       }, ->
-        Article.where { fair_programming_id: '52617c6c8b3b81f094000013' }, (err, res) ->
+        Article.where { fair_programming_id: '52617c6c8b3b81f094000013', count: true }, (err, res) ->
           { total, count, results } = res
           total.should.equal 11
           count.should.equal 1
@@ -176,7 +184,7 @@ describe 'Article', ->
         title: 'Hello Wurld'
         fair_artsy_ids: [ ObjectId('53da550a726169083c0a0700') ]
       }, ->
-        Article.where { fair_artsy_id: '53da550a726169083c0a0700' }, (err, res) ->
+        Article.where { fair_artsy_id: '53da550a726169083c0a0700', count: true }, (err, res) ->
           { total, count, results } = res
           total.should.equal 11
           count.should.equal 1
@@ -189,7 +197,7 @@ describe 'Article', ->
         title: 'Hello Wurld'
         fair_about_ids: [ ObjectId('53da550a726169083c0a0700') ]
       }, ->
-        Article.where { fair_about_id: '53da550a726169083c0a0700' }, (err, res) ->
+        Article.where { fair_about_id: '53da550a726169083c0a0700', count: true }, (err, res) ->
           { total, count, results } = res
           total.should.equal 11
           count.should.equal 1
@@ -234,7 +242,7 @@ describe 'Article', ->
           title: 'Hello Waaarld'
         }
       ], =>
-        Article.where { all_by_author: '4d8cd73191a5c50ce220002b' }, (err, res) ->
+        Article.where { all_by_author: '4d8cd73191a5c50ce220002b', count: true }, (err, res) ->
           { total, count, results } = res
           total.should.equal 12
           count.should.equal 2
@@ -259,7 +267,7 @@ describe 'Article', ->
           title: 'Hello Waaarld'
         }
       ], =>
-        Article.where { is_super_article: true }, (err, res) ->
+        Article.where { is_super_article: true, count: true }, (err, res) ->
           { total, count, results } = res
           total.should.equal 13
           count.should.equal 1
@@ -285,7 +293,7 @@ describe 'Article', ->
             related_articles: [childArticleId]
         }
       ], =>
-        Article.where { super_article_for: childArticleId.toString() }, (err, res) ->
+        Article.where { super_article_for: childArticleId.toString(), count: true }, (err, res) ->
           { total, count, results } = res
           total.should.equal 12
           count.should.equal 1
@@ -315,7 +323,7 @@ describe 'Article', ->
           title: 'Hello I am Weiiird - Electronics'
         }
       ], =>
-        Article.where { tags: ['pickle', 'muffin'] }, (err, res) ->
+        Article.where { tags: ['pickle', 'muffin'], count: true }, (err, res) ->
           { total, count, results } = res
           total.should.equal 14
           count.should.equal 3
@@ -335,6 +343,7 @@ describe 'Article', ->
         Article.where {
           published: true
           biography_for_artist_id: '5086df098523e60002000016'
+          count: true
         }, (err, res) ->
           { total, count, results } = res
           count.should.equal 1
@@ -352,6 +361,7 @@ describe 'Article', ->
         Article.where {
           published: true
           channel_id: '5086df098523e60002000016'
+          count: true
         }, (err, res) ->
           { total, count, results } = res
           count.should.equal 1
@@ -369,6 +379,7 @@ describe 'Article', ->
         Article.where {
           published: true
           channel_id: '5086df098523e60002000016'
+          count: true
         }, (err, res) ->
           { total, count, results } = res
           count.should.equal 1
@@ -385,6 +396,7 @@ describe 'Article', ->
       ], ->
         Article.where {
           scheduled: true
+          count: true
         }, (err, res) ->
           { total, count, results } = res
           count.should.equal 1


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/838

There are a few places in Force/MG/maybe-Metaphysics that use `count`, so once this gets merged, I'll be sure to add `count: true` flags to those fetches before deploying this one to production. I considered making `count: true` the default, and make `count: false` optimizations manually on the client, but it probably doesn't make sense for a client to have to think about how it affects the database 👀 . 