### PR TITLE
@craigspaeth => Adds _id to presentation

### DIFF
--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -124,7 +124,7 @@ Q = require 'bluebird-q'
   published = if (date = article?.published_at) then moment(date).toISOString() else undefined
   _.extend article,
     id: article?._id?.toString()
-    _id: undefined
+    _id: article?._id?.toString()
     slug: _.last article.slugs
     slugs: undefined
     published_at: published

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -1107,9 +1107,9 @@ describe 'Article', ->
 
   describe '#present', ->
 
-    it 'converts _id to id', ->
+    it 'adds both _id and id', ->
       data = Article.present _.extend {}, fixtures().articles, _id: 'foo'
-      (data._id?).should.not.be.ok
+      (data._id?).should.be.ok
       data.id.should.equal 'foo'
 
     it 'converts dates to ISO strings', ->


### PR DESCRIPTION
At 10:07AM, this error started causing problems -- https://papertrailapp.com/systems/positron-production/events?focus=776149217075957783&selected=776149217075957783

I'm still trying to determine why, but those kinds of requests have started to pile up and even brought down some requests at one point. Positron recovered on its own but currently memory usage is high. 

[Here](https://github.com/artsy/force/blob/master/desktop/models/article.coffee#L69) is where we use the `super_article_for` field, and somehow, based on the logs, it's getting passed a slug instead of the id. Maybe this has to do with caching? We do set `id` [here](https://github.com/artsy/force/blob/master/desktop/apps/article/routes.coffee#L14). Anyway my idea to mitigate this is to add in the `_id` field for guaranteed mongoid. 