### PR TITLE
@kanaabe => Fix staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ s:
 
 # Start the server using forever
 sf:
-	$(BIN)/forever $(BIN)/coffee index.coffee
+	$(BIN)/forever $(BIN)/coffee --nodejs --max_old_space_size=512 index.coffee
 
 # Run all of the project-level tests, followed by app-level tests
 test: assets


### PR DESCRIPTION
128mb per process, i think 960 was too high. Even after i reverted that, it didn't seem to like the default. going to try 512 since that's what's recommended for our standard-2x 1024MB memory