### PR TITLE
@kanaabe => Lock node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">=6.6.x",
+    "node": "7.7.1",
     "npm": "3.10.7"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "lokka-transport-http": "^1.6.1",
     "mocha": "^3.1.2",
     "moment": "^2.10.6",
-    "mongodb": "2.1.21",
     "mongojs": "^2.4.0",
     "morgan": "^1.6.1",
     "nib": "^1.1.0",


### PR DESCRIPTION
Whew...think this one is finally solved. The timing makes sense as well -- March 8, Node version got bumped to [7.7.2](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V7.md#2017-03-08-version-772-current-evanlucas). New Relic's lib wasn't ready for the change and is failing on a `TypeError: "listener" argument must be a function` which causes the app to crash. From there a bunch of restarts but the NR error wasn't always [reported](https://papertrailapp.com/systems/positron-staging/events?q=TypeError%3A+%22listener%22+argument+must+be+a+function) which made it hard to debug. Really it was the mongo errors that threw me off a bunch when it was actually just an effect. 

Issue posted here (but sadly no responses yet from NR):
https://discuss.newrelic.com/t/newrelic-nodejs-issue-with-newest-version-of-node-7-7-2/46962

This PR:
- Locks node version (temporary)
- Removes unnecessary mongodb package

Next we could consider not exiting the process when an Uncaught Exception occurs [here](https://github.com/artsy/artsy-newrelic/blob/master/index.js#L28). Will start a discussion there.