### PR TITLE
@kanaabe => Pasting from google doesn't strip em

### DIFF
--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -162,12 +162,17 @@ module.exports = React.createClass
     for block, i in boldBlocks
       if block.style.fontWeight is 'normal'
         $(doc.getElementsByTagName('B')[i]).replaceWith(doc.getElementsByTagName('B')[i].innerHTML)
-    # replace bold spans with actual b tags
-    boldSpans = doc.getElementsByTagName('SPAN')
-    for span, i in boldSpans
-      if span?.style.fontWeight is '700'
+    # replace bold and italic spans with actual b or em tags
+    spans = doc.getElementsByTagName('SPAN')
+    for span, i in spans
+      newSpan = span
+      if span?.style.fontStyle is 'italic' and span?.style.fontWeight is '700'
+        newSpan = '<strong><em>' + span.innerHTML + '</em></strong>'
+      else if span?.style.fontStyle is 'italic'
+        newSpan = '<em>' + span.innerHTML + '</em>'
+      else if span?.style.fontWeight is '700'
         newSpan = '<strong>' + span.innerHTML + '</strong>'
-        $(doc.getElementsByTagName('SPAN')[i]).replaceWith(newSpan)
+      $(doc.getElementsByTagName('SPAN')[i]).replaceWith(newSpan)
     return doc.innerHTML
 
   makePlainText: () ->
@@ -185,7 +190,7 @@ module.exports = React.createClass
     characterList = contentBlock.getCharacterList().map (character) ->
       if keepAllowed
         unless character.hasStyle 'UNDERLINE'
-          return character if character.hasStyle 'BOLD' or character.hasStyle 'ITALIC' or character.hasStyle 'STRIKETHROUGH'
+          return character if character.hasStyle('BOLD') || character.hasStyle('ITALIC') || character.hasStyle('STRIKETHROUGH')
       character.set 'style', character.get('style').clear()
     unstyled = contentBlock.set 'characterList', characterList
     return unstyled

--- a/client/apps/edit/components/section_text/test/index.coffee
+++ b/client/apps/edit/components/section_text/test/index.coffee
@@ -231,3 +231,11 @@ describe 'SectionText', ->
     it 'replaces bold spans with actual b tags', ->
       html = '<p><span style="font-size:11pt;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">B. 1981 in Madrid. Lives and works in Madrid.</span></p>'
       @component.stripGoogleStyles(html).should.eql '<p><strong>B. 1981 in Madrid. Lives and works in Madrid.</strong></p>'
+
+    it 'replaces italic spans with actual em tags', ->
+      html = '<p><span style="font-size:11pt;color:#000000;background-color:transparent;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">B. 1981 in Madrid. Lives and works in Madrid.</span></p>'
+      @component.stripGoogleStyles(html).should.eql '<p><em>B. 1981 in Madrid. Lives and works in Madrid.</em></p>'
+
+    it 'Can replaces spans that are bold and italic', ->
+      html = '<p><span style="font-size:11pt;color:#000000;background-color:transparent;font-weight:700;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">B. 1981 in Madrid. Lives and works in Madrid.</span></p>'
+      @component.stripGoogleStyles(html).should.eql '<p><strong><em>B. 1981 in Madrid. Lives and works in Madrid.</em></strong></p>'


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/974

Updates #stripCharacterStyles if statement (was not making it through or clause)
Adds explicit span replacement to #stripGoogleStyles
Adds support for span that is bold and italic
Additional tests

![google-styles](https://cloud.githubusercontent.com/assets/1497424/24118737/3e2eaef0-0d85-11e7-9b62-9f1b19ad98e8.gif)
