### PR TITLE
@kanaabe => Rich text can accept multiple spaces

### DIFF
--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -148,7 +148,10 @@ module.exports = React.createClass
           return span { style: {textDecoration: 'line-through'}}
     })(editorState.getCurrentContent())
     # put the line breaks back for correct client rendering
-    html = html.replace('<p></p>', '<p><br></p>').replace('<p> </p>', '<p><br></p>').replace('  ', ' &nbsp;')
+    html = html
+      .replace '<p></p>', '<p><br></p>'
+      .replace '<p> </p>', '<p><br></p>'
+      .replace '  ', ' &nbsp;'
     return html
 
   stripGoogleStyles: (html) ->

--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -148,7 +148,7 @@ module.exports = React.createClass
           return span { style: {textDecoration: 'line-through'}}
     })(editorState.getCurrentContent())
     # put the line breaks back for correct client rendering
-    html = html.replace('<p></p>', '<p><br></p>').replace('<p> </p>', '<p><br></p>')
+    html = html.replace('<p></p>', '<p><br></p>').replace('<p> </p>', '<p><br></p>').replace('  ', ' &nbsp;')
     return html
 
   stripGoogleStyles: (html) ->

--- a/client/apps/edit/components/section_text/test/index.coffee
+++ b/client/apps/edit/components/section_text/test/index.coffee
@@ -36,7 +36,7 @@ describe 'SectionText', ->
       @props = {
         editing: true
         section: new Backbone.Model {
-          body: '<h2><a name="here" class="is-jump-link">here is a toc.</a></h2><p class="stuff">In 2016, K mounted a <a href="https://www.artsy.net/artist/kow-hiwa-k-this-lemon-tastes-of-apple" class="is-follow-link" target="_blank">solo show</a><a class="entity-follow artist-follow"></a> at prescient Berlin gallery <a href="https://www.artsy.net/kow" target="_blank">KOW</a>, restaging his installation <i>It’s Spring and the Weather is Great so let’s close all object matters</i> (2012), for which he created seven step ladders with microphones and instruments attached for a performance initially meant to take place at Speakers’ Corner in London’s Hyde Park that was eventually mounted in 2010 at the <a href="https://www.artsy.net/serpentineuk" target="_blank">Serpentine Galleries</a>.</p><p><br></p><br>'
+          body: '<h2>01  <a name="here" class="is-jump-link">here is a toc.</a></h2><p class="stuff">In 2016, K mounted a <a href="https://www.artsy.net/artist/kow-hiwa-k-this-lemon-tastes-of-apple" class="is-follow-link" target="_blank">solo show</a><a class="entity-follow artist-follow"></a> at prescient Berlin gallery <a href="https://www.artsy.net/kow" target="_blank">KOW</a>, restaging his installation <i>It’s Spring and the Weather is Great so let’s close all object matters</i> (2012), for which he created seven step ladders with microphones and instruments attached for a performance initially meant to take place at Speakers’ Corner in London’s Hyde Park that was eventually mounted in 2010 at the <a href="https://www.artsy.net/serpentineuk" target="_blank">Serpentine Galleries</a>.</p><p><br></p><br>'
         }
       }
       @altProps = {
@@ -95,7 +95,7 @@ describe 'SectionText', ->
 
     it 'Converts html on change only plugin supported classes', ->
       @component.onChange(@component.state.editorState)
-      @component.state.html.should.eql '<h2><a name="here" class="is-jump-link">here is a toc.</a></h2><p>In 2016, K mounted a <a href="https://www.artsy.net/artist/kow-hiwa-k-this-lemon-tastes-of-apple" class="is-follow-link">solo show</a><a data-id="kow-hiwa-k-this-lemon-tastes-of-apple" class="entity-follow artist-follow"></a> at prescient Berlin gallery <a href="https://www.artsy.net/kow">KOW</a>, restaging his installation <em>It’s Spring and the Weather is Great so let’s close all object matters</em> (2012), for which he created seven step ladders with microphones and instruments attached for a performance initially meant to take place at Speakers’ Corner in London’s Hyde Park that was eventually mounted in 2010 at the <a href="https://www.artsy.net/serpentineuk">Serpentine Galleries</a>.</p><p><br></p><p></p>'
+      @component.state.html.should.eql '<h2>01 &nbsp;<a name="here" class="is-jump-link">here is a toc.</a></h2><p>In 2016, K mounted a <a href="https://www.artsy.net/artist/kow-hiwa-k-this-lemon-tastes-of-apple" class="is-follow-link">solo show</a><a data-id="kow-hiwa-k-this-lemon-tastes-of-apple" class="entity-follow artist-follow"></a> at prescient Berlin gallery <a href="https://www.artsy.net/kow">KOW</a>, restaging his installation <em>It’s Spring and the Weather is Great so let’s close all object matters</em> (2012), for which he created seven step ladders with microphones and instruments attached for a performance initially meant to take place at Speakers’ Corner in London’s Hyde Park that was eventually mounted in 2010 at the <a href="https://www.artsy.net/serpentineuk">Serpentine Galleries</a>.</p><p><br></p><p></p>'
 
 
   describe 'Rich text menu events', ->
@@ -187,11 +187,15 @@ describe 'SectionText', ->
       component.onChange(component.state.editorState)
       component.state.html.should.eql '<h2><a href="https://www.artsy.net/artist/erin-shirreff" class="is-follow-link">Erin Shirreff</a><a data-id="erin-shirreff" class="entity-follow artist-follow"></a></h2>'
 
-    it 'Sets state to the correct plugin', ->
+    it 'Can toggle the artist plugin', ->
+      @component.setState = sinon.stub()
       @component.setPluginType('artist')
-      @component.state.pluginType.should.eql 'artist'
+      @component.setState.args[0][0].pluginType.should.eql 'artist'
+
+    it 'Can toggle the toc plugin', ->
+      @component.setState = sinon.stub()
       @component.setPluginType('toc')
-      @component.state.pluginType.should.eql 'toc'
+      @component.setState.args[0][0].pluginType.should.eql 'toc'
 
     it 'Calls promt for link if artist', ->
       @component.promptForLink = sinon.stub()

--- a/client/components/rich_text/components/input_paragraph.coffee
+++ b/client/components/rich_text/components/input_paragraph.coffee
@@ -52,6 +52,7 @@ module.exports = React.createClass
 
   convertToHtml: (editorState) ->
     html = convertToHTML({})(editorState.getCurrentContent())
+    html = html.replace('  ', ' &nbsp;')
     return html
 
   onPaste: (text, html) ->

--- a/client/components/rich_text/test/input_paragraph.coffee
+++ b/client/components/rich_text/test/input_paragraph.coffee
@@ -23,7 +23,7 @@ describe 'RichTextParagraph', ->
       global.HTMLAnchorElement = () => {}
       @RichTextParagraph = benv.require resolve __dirname, '../components/input_paragraph'
       @props = {
-        text: '<p>Here is the <em>lead</em> paragraph for <b>this</b> article.</p>'
+        text: '<p>Here is  the <em>lead</em> paragraph for <b>this</b> article.</p>'
         placeholder: 'Lead paragraph (optional)'
         onChange: sinon.stub()
         }
@@ -49,20 +49,20 @@ describe 'RichTextParagraph', ->
     $(@rendered).text().should.eql 'Lead paragraph (optional)'
 
   it 'Renders an existing lead paragraph', ->
-    $(ReactDOM.findDOMNode(@component)).text().should.eql 'Here is the lead paragraph for this article.'
-    @component.state.html.should.eql '<p>Here is the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
+    $(ReactDOM.findDOMNode(@component)).text().should.eql 'Here is  the lead paragraph for this article.'
+    @component.state.html.should.eql '<p>Here is &nbsp;the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
 
   it 'Can toggle bold styles by default', ->
     @component.handleKeyCommand('bold')
-    @component.state.html.should.eql '<p><strong>Here is</strong> the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
+    @component.state.html.should.eql '<p><strong>Here is</strong> &nbsp;the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
 
   it 'Can toggle italic styles by default', ->
     @component.handleKeyCommand('italic')
-    @component.state.html.should.eql '<p><em>Here is</em> the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
+    @component.state.html.should.eql '<p><em>Here is</em> &nbsp;the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
 
   it 'Ignores unsuppored styles', ->
     @component.handleKeyCommand('underline')
-    @component.state.html.should.eql '<p>Here is the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
+    @component.state.html.should.eql '<p>Here is &nbsp;the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
 
   it 'Can override default styles via props.styleMap', ->
     @props.styleMap = ['bold']
@@ -87,9 +87,9 @@ describe 'RichTextParagraph', ->
 
   it 'Strips unsuported html out of pasted text', ->
     @component.onPaste 'Available at: Espacio Valverde Galleries Sector, Booth 9F01', '<b style="font-weight:normal;" id="docs-internal-guid-ce2bb19a-cddb-9e53-cb18-18e71847df4e"><h1><span style="font-size:11pt;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">Available at: Espacio Valverde • Galleries Sector, Booth 9F01</span></h1>'
-    @component.state.html.should.eql '<p>Available at: Espacio Valverde • Galleries Sector, Booth 9F01 the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
+    @component.state.html.should.eql '<p>Available at: Espacio Valverde • Galleries Sector, Booth 9F01 &nbsp;the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
 
   it 'Sends converted html to parent onChange', ->
     @component.onChange @component.state.editorState
     @component.props.onChange.called.should.eql true
-    @component.props.onChange.args[0][0].should.eql '<p>Here is the <em>lead</em> paragraph for <strong>this</strong> article.</p>'
+    @component.props.onChange.args[0][0].should.eql '<p>Here is &nbsp;the <em>lead</em> paragraph for <strong>this</strong> article.</p>'

--- a/client/components/rich_text_caption/index.coffee
+++ b/client/components/rich_text_caption/index.coffee
@@ -81,7 +81,7 @@ module.exports = React.createClass
           return a { href: entity.data.url}
         return originalText
     })(editorState.getCurrentContent())
-    html = html.replace(/(\r\n|\n|\r)/gm,'').replace(/<\/p><p>/g, ' ')
+    html = html.replace(/(\r\n|\n|\r)/gm,'').replace(/<\/p><p>/g, ' ').replace('  ', ' &nbsp;')
     return html
 
   onPaste: (text, html) ->

--- a/client/components/rich_text_caption/index.coffee
+++ b/client/components/rich_text_caption/index.coffee
@@ -81,7 +81,10 @@ module.exports = React.createClass
           return a { href: entity.data.url}
         return originalText
     })(editorState.getCurrentContent())
-    html = html.replace(/(\r\n|\n|\r)/gm,'').replace(/<\/p><p>/g, ' ').replace('  ', ' &nbsp;')
+    html = html
+      .replace /(\r\n|\n|\r)/gm, ''
+      .replace /<\/p><p>/g, ' '
+      .replace '  ', ' &nbsp;'
     return html
 
   onPaste: (text, html) ->

--- a/client/components/rich_text_caption/test/index.coffee
+++ b/client/components/rich_text_caption/test/index.coffee
@@ -30,7 +30,7 @@ describe 'RichTextCaption', ->
           {
             type: 'image'
             url: 'https://artsy.net/image.png'
-            caption: '<p><a href="http://link.com">A link</a> is inside a <em>caption</em>.</p>'
+            caption: '<p><a href="http://link.com">A link</a> is  inside a <em>caption</em>.</p>'
           }
         }
       @component = ReactDOM.render React.createElement(@RichTextCaption, @props), (@$el = $ "<div></div>")[0], => setTimeout =>
@@ -60,7 +60,7 @@ describe 'RichTextCaption', ->
 
   it 'Renders an existing caption', ->
     @component.onChange(@component.state.editorState)
-    @component.state.html.should.eql '<p><a href="http://link.com/">A link</a> is inside a <em>caption</em>.</p>'
+    @component.state.html.should.eql '<p><a href="http://link.com/">A link</a> is &nbsp;inside a <em>caption</em>.</p>'
 
   it 'Opens a link input popup', ->
     @r.simulate.mouseDown @r.find @component, 'link'
@@ -75,8 +75,8 @@ describe 'RichTextCaption', ->
 
   it 'Can create italic blocks', ->
     @r.simulate.mouseDown @r.find @selectComponent, 'italic'
-    @selectComponent.state.html.should.eql '<p><em><a href="http://link.com/">A link</a></em> is inside a <em>caption</em>.</p>'
+    @selectComponent.state.html.should.eql '<p><em><a href="http://link.com/">A link</a></em> is &nbsp;inside a <em>caption</em>.</p>'
 
   it 'Strips unsupported html and linebreaks on paste', ->
     @component.onPaste('Here is a caption about an image yep.', '<p>Here is a</p><ul><li><b>caption</b></li><li>about an image</li></ul><p>yep.</p>')
-    @component.state.html.should.eql '<p>Here is a caption about an image yep.<a href="http://link.com/">A link</a> is inside a <em>caption</em>.</p>'
+    @component.state.html.should.eql '<p>Here is a caption about an image yep.<a href="http://link.com/">A link</a> is &nbsp;inside a <em>caption</em>.</p>'


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/989
Updates all rich-text components to allow multiple consecutive spaces when exporting html. 
Adds multiple spaces to tests for each component. 