### PR TITLE
@eessex => Fixes filter zero state

### DIFF
--- a/api/apps/articles/model/retrieve.coffee
+++ b/api/apps/articles/model/retrieve.coffee
@@ -62,7 +62,7 @@ moment = require 'moment'
     ) if input.artist_id
 
     # Allow regex searching through the q param
-    query.thumbnail_title = { $regex: new RegExp(input.q, 'i') } if input.q
+    query.thumbnail_title = { $regex: new RegExp(input.q, 'i') } if input.q and input.q.length
 
     # # Look for articles that are scheduled
     query.scheduled_publish_at = { $ne: null } if input.scheduled

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -212,7 +212,7 @@ denormalizedArtwork = (->
   featured: @boolean()
   exclude_google_news: @boolean()
   super_article_for: @objectId()
-  q: @string()
+  q: @string().allow('')
   all_by_author: @objectId()
   tags: @array().items(@string())
   is_super_article: @boolean()

--- a/api/apps/articles/test/model/retrieve.coffee
+++ b/api/apps/articles/test/model/retrieve.coffee
@@ -62,7 +62,16 @@ describe 'Retrieve', ->
         q: 'Thumbnail Title 101'
         published: true
       }, (err, query) =>
+        query.hasOwnProperty('thumbnail_title').should.be.true()
         query.thumbnail_title['$regex'].should.be.ok()
+        done()
+
+    it 'ignores q if it is empty', (done) ->
+      Retrieve.toQuery {
+        q: ''
+        published: true
+      }, (err, query) =>
+        query.hasOwnProperty('thumbnail_title').should.be.false()
         done()
 
     it 'strips out unknown keys in the query', (done) ->

--- a/client/components/filter_search/index.coffee
+++ b/client/components/filter_search/index.coffee
@@ -21,10 +21,9 @@ module.exports = React.createClass
     @engine.initialize()
 
   search: ->
-    if @refs.searchQuery.value.length
-      if @engine.remote.url != @props.url then @engine.remote.url = @props.url
-      @engine.get @refs.searchQuery.value, ([results]) =>
-        @props.searchResults results
+    if @engine.remote.url != @props.url then @engine.remote.url = @props.url
+    @engine.get @refs.searchQuery.value, ([results]) =>
+      @props.searchResults results
 
   selected: (article) ->
     @props.selected article, 'select'


### PR DESCRIPTION
It's easier to see the actual issue when you have less records, but the empty input state should fetch the entire list of articles when the input is empty instead of ignoring it with [this line](https://github.com/artsy/positron/blob/master/client/components/filter_search/index.coffee#L24). 

![filterzero](https://cloud.githubusercontent.com/assets/2236794/24530203/82bb9244-157e-11e7-9211-9114693b8e5a.gif)
