### PR TITLE
@kanaabe => Fix #1005: Surface error on save.

### DIFF
--- a/client/apps/edit/components/header/index.jade
+++ b/client/apps/edit/components/header/index.jade
@@ -9,6 +9,7 @@ header#edit-header
     a#edit-publish.avant-garde-button( data-disabled='true' )
       = article.get('published') ? 'Unpublish' : 'Publish'
   #edit-header-right
+    span#edit-error.attention
     a#edit-delete.avant-garde-button Delete
     a#edit-save.avant-garde-button Save #{article.stateName()}
     a#edit-preview.avant-garde-button(

--- a/client/apps/edit/components/header/index.styl
+++ b/client/apps/edit/components/header/index.styl
@@ -64,6 +64,15 @@
   position absolute
   right margin-size
   top margin-size
+  span
+    top 0
+    left 0
+    width 100%
+    height 100%
+    padding 10px 0
+    text-align center
+    &.attention
+      color red-color
   a
     margin-right margin-size
     &:last-child

--- a/client/apps/edit/components/header/test/index.coffee
+++ b/client/apps/edit/components/header/test/index.coffee
@@ -30,7 +30,7 @@ describe 'EditHeader', ->
 
     it 'indicates saving on change', ->
       @view.article.trigger 'change'
-      @view.$('#edit-save').hasClass('is-saving').should.be.ok
+      @view.$('#edit-save').hasClass('is-saving').should.be.true()
 
   describe '#delete', ->
 
@@ -77,3 +77,9 @@ describe 'EditHeader', ->
       @view.save preventDefault: ->
       spy.called.should.be.ok
       Backbone.sync.args[0][0].should.equal 'create'
+      @view.$('#edit-error').text().should.equal('')
+
+    it 'reports the error', ->
+      @view.article.trigger 'error', @view.article, { responseText: 'unexpected error' }
+      @view.$('#edit-error').text().should.equal('unexpected error')
+


### PR DESCRIPTION
This is a fix for #1005. The error surfaces as a hover of an error state and the page doesn't navigate away.

![errors](https://cloud.githubusercontent.com/assets/542335/24766214/76972222-1ac8-11e7-81e7-ca35e3a2d3ab.gif)
