### PR TITLE
@kanaabe => Don't allow linebreaks in titles

### DIFF
--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -156,7 +156,7 @@ sanitize = (article) ->
   else
     sections = []
   sanitized = _.extend article,
-    title: sanitizeHtml article.title
+    title: sanitizeHtml article.title?.replace /\n/g, ''
     thumbnail_title: sanitizeHtml article.thumbnail_title
     lead_paragraph: sanitizeHtml article.lead_paragraph
     sections: sections

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -195,3 +195,19 @@ describe 'Save', ->
         ]
         description: 'Do not override me'
       })
+
+    it 'Strips linebreaks from titles', (done) ->
+      Save.sanitizeAndSave( ->
+        Article.find '5086df098523e60002000011', (err, article) =>
+          article.title.should.containEql 'A new title'
+          done()
+      )(null, {
+        author_id: '5086df098523e60002000018'
+        published: true
+        _id: '5086df098523e60002000011'
+        thumbnail_title: 'Thumbnail Title'
+        sections: [
+          { type: 'text', body: '<p>Testing 123</p>' }
+        ]
+        title: 'A new title \n'
+      })

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -103,6 +103,7 @@ module.exports = class EditLayout extends Backbone.View
     'click #edit-tabs > a:not(#edit-publish)': 'toggleTabs'
     'keyup :input:not(.tt-input,.edit-admin__fields .bordered-input, .edit-display__textarea,#edit-seo__focus-keyword), [contenteditable]:not(.tt-input)': 'onKeyup'
     'keyup .edit-display__textarea, #edit-seo__focus-keyword, [contenteditable]:not(.tt-input)': 'onYoastKeyup'
+    'keydown #edit-title textarea': 'onChangeTitle'
     'click .edit-section-container *': 'popLockControls'
     'click .edit-section-tool-menu li': -> _.defer => @popLockControls()
     'dragenter .dashed-file-upload-container': 'toggleDragover'
@@ -135,6 +136,10 @@ module.exports = class EditLayout extends Backbone.View
     for section in @article.sections.models when section.get('type') is 'text'
       @fullText.push section.get('body')
     @fullText = @fullText.join()
+
+  onChangeTitle: (e) =>
+    return unless e.key is 'Enter'
+    e.preventDefault()
 
   onKeyup: =>
     if @article.get('published')

--- a/client/apps/edit/components/layout/test/index.coffee
+++ b/client/apps/edit/components/layout/test/index.coffee
@@ -118,6 +118,20 @@ describe 'EditLayout', ->
       @view.setupOnBeforeUnload()
       window.onbeforeunload().should.containEql 'do you wish to continue'
 
+  describe '#onChangeTitle', ->
+
+    it 'prevents the keyup function from firing on enter key', ->
+      e = {key: 'Enter', preventDefault: sinon.stub()}
+      @view.onKeyup = sinon.stub()
+      @view.onChangeTitle(e)
+      e.preventDefault.called.should.eql true
+      @view.onKeyup.called.should.eql false
+
+    it 'does not prevent default on keys that are not enter', ->
+      e = {key: 's', preventDefault: sinon.stub()}
+      @view.onChangeTitle(e)
+      e.preventDefault.called.should.eql false
+
   describe '#getBodyText', ->
 
     it 'parses the article and pulls out an html string of its text', ->


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1011

- Strips linebreaks from titles on save
- Prevents use of enter key in title textarea