### PR TITLE
@eessex => Fix autocomplete list

### DIFF
--- a/client/apps/settings/client/channels.coffee
+++ b/client/apps/settings/client/channels.coffee
@@ -7,6 +7,8 @@ Channel = require '../../../models/channel.coffee'
 sd = require('sharify').data
 async = require 'async'
 request = require 'superagent'
+React = require 'react'
+ReactDOM = require 'react-dom'
 
 module.exports.EditChannel = class EditChannel extends Backbone.View
 
@@ -21,7 +23,7 @@ module.exports.EditChannel = class EditChannel extends Backbone.View
 
   setupUserAutocomplete: ->
     @user_ids = @channel.get 'user_ids' or []
-    new AutocompleteList $('#channel-edit__users')[0],
+    props =
       name: 'user_ids[]'
       url: "#{sd.ARTSY_URL}/api/v1/match/users?term=%QUERY"
       placeholder: 'Search by user name or email...'
@@ -37,6 +39,7 @@ module.exports.EditChannel = class EditChannel extends Backbone.View
         id: res.body.id,
         value: _.compact([res.body.name, res.body.email]).join(', ')
       }
+    ReactDOM.render React.createElement(AutocompleteList, props), $('#channel-edit__users')[0]
 
   setupPinnedArticlesAutocomplete: ->
     @pinnedArticles = @channel.get('pinned_articles') or []

--- a/client/components/autocomplete_list/index.coffee
+++ b/client/components/autocomplete_list/index.coffee
@@ -7,9 +7,6 @@ sd = require('sharify').data
 async = require 'async'
 request = require 'superagent'
 
-module.exports = (el, props) ->
-  ReactDOM.render React.createElement(AutocompleteList, props), el
-
 module.exports = AutocompleteList = React.createClass
   displayName: 'AutocompleteList'
 
@@ -70,7 +67,7 @@ module.exports = AutocompleteList = React.createClass
 
   removeItem: (item) -> (e) =>
     e.preventDefault()
-    @$input.typeahead('destroy').val('')
+    @$input.typeahead('destroy')?.val('')
     newItems = _.reject(@state.items, (i) -> i.id is item.id)
     @setState items: newItems
     @props.removed? e, item, newItems

--- a/client/components/autocomplete_list/test/index.coffee
+++ b/client/components/autocomplete_list/test/index.coffee
@@ -5,6 +5,7 @@ React = require 'react'
 ReactDOM = require 'react-dom'
 ReactTestUtils = require 'react-addons-test-utils'
 ReactDOMServer = require 'react-dom/server'
+_ = require 'underscore'
 
 describe 'AutocompleteList', ->
 
@@ -17,8 +18,8 @@ describe 'AutocompleteList', ->
           ttAdapter: ->
         )
       $.fn.typeahead = sinon.stub()
-      { AutocompleteList } = mod = benv.require resolve __dirname, '../index'
-      mod.__set__ 'request', get: sinon.stub().returns
+      AutocompleteList = benv.require resolve __dirname, '../index'
+      AutocompleteList.__set__ 'request', get: sinon.stub().returns
         set: sinon.stub().returns
           end: sinon.stub().yields(null, { id: '123', value: 'Andy Warhol'})
       props =
@@ -47,14 +48,11 @@ describe 'AutocompleteList', ->
 
   it 'selects an item', ->
     @component.onSelect {}, { id: '1234', value: 'Yayoi Kusama' }
-    @setState.args[0][0].value.should.equal ''
     @setState.args[0][0].items[0].value.should.equal 'Andy Warhol'
     @setState.args[0][0].items[1].value.should.equal 'Yayoi Kusama'
     @selected.callCount.should.equal 1
 
   it 'removes an item', ->
-    @component.onSelect {}, { id: '1234', value: 'Yayoi Kusama' }
-    @setState.args[0][0].value.should.equal ''
-    @setState.args[0][0].items[0].value.should.equal 'Andy Warhol'
-    @setState.args[0][0].items[1].value.should.equal 'Yayoi Kusama'
-    @selected.callCount.should.equal 1
+    @component.removeItem({ id: '123', value: 'Andy Warhol' })({preventDefault: ->})
+    @setState.args[0][0].items.length.should.equal 0
+    @removed.callCount.should.equal 1

--- a/client/components/autocomplete_list/test/index.coffee
+++ b/client/components/autocomplete_list/test/index.coffee
@@ -5,7 +5,6 @@ React = require 'react'
 ReactDOM = require 'react-dom'
 ReactTestUtils = require 'react-addons-test-utils'
 ReactDOMServer = require 'react-dom/server'
-_ = require 'underscore'
 
 describe 'AutocompleteList', ->
 
@@ -33,8 +32,8 @@ describe 'AutocompleteList', ->
         resObject: (res) -> id: res.id, value: res.value
       @rendered = ReactDOMServer.renderToString React.createElement(AutocompleteList, props)
       @component = ReactDOM.render React.createElement(AutocompleteList, props), (@$el = $ "<div></div>")[0], => setTimeout =>
-        @setState = sinon.stub @component, 'setState'
-        done()
+          @setState = sinon.stub @component, 'setState'
+          done()
 
   afterEach ->
     benv.teardown()


### PR DESCRIPTION
Paired with @orta on this one!

Channel page's AutocompleteList was breaking because we were resetting the first `module.export` where we call `React.render`. 

This moves the `React.render` call to the Channel page since it's the only non-React place that uses this. 