### PR TITLE
@kanaabe => Additional Venice fields

### DIFF
--- a/client/apps/settings/client/curations/venice_admin.coffee
+++ b/client/apps/settings/client/curations/venice_admin.coffee
@@ -4,6 +4,8 @@ _ = require 'underscore'
 { div, section, label, span, textarea, button } = React.DOM
 dropdownHeader = React.createFactory require '../../../edit/components/admin/components/dropdown_header.coffee'
 sectionFields = React.createFactory require './venice_section.coffee'
+AutocompleteList = React.createFactory require '../../../../components/autocomplete_list/index.coffee'
+
 
 module.exports = VeniceAdmin = React.createClass
   displayName: 'VeniceAdmin'
@@ -38,9 +40,12 @@ module.exports = VeniceAdmin = React.createClass
     newSections[id] = section
     @state.curation.set 'sections', newSections
 
-  onInputChange: (e) ->
+  onDescriptionChange: (e) ->
+    @onChange e.target.name, e.target.value
+
+  onChange: (key, value) ->
     @setState isChanged: true
-    @state.curation.set 'description', e.target.value
+    @state.curation.set key, value
 
   save: ->
     @setState isSaving: true
@@ -97,6 +102,28 @@ module.exports = VeniceAdmin = React.createClass
         textarea {
           className: 'bordered-input'
           placeholder: 'Description'
+          name: 'description'
           defaultValue: @state.curation.get 'description'
-          onChange: @onInputChange
+          onChange: @onDescriptionChange
+        }
+      div {className: 'field-group sub-articles'},
+        label {}, 'Related Articles'
+        AutocompleteList {
+          url: "#{sd.API_URL}/articles?published=true&q=%QUERY"
+          placeholder: "Search articles by title..."
+          filter: (articles) ->
+            for article in articles.results
+              { id: article.id, value: "#{article.title}, #{article.author?.name}"}
+          selected: (e, item, items) =>
+            subArticles = @state.curation.get 'sub_articles'
+            subArticles = _.pluck items, 'id'
+            @onChange 'sub_articles', subArticles
+          removed: (e, item, items) =>
+            subArticles = @state.curation.get 'sub_articles'
+            subArticles = _.without(_.pluck(items,'id'),item.id)
+            @onChange 'sub_articles', subArticles
+          idsToFetch: @state.curation.get 'sub_articles'
+          fetchUrl: (id) -> "#{sd.API_URL}/articles/#{id}"
+          resObject: (res) ->
+            id: res.body.id, value: "#{res.body.title}, #{res.body.author?.name}"
         }

--- a/client/apps/settings/client/curations/venice_admin.coffee
+++ b/client/apps/settings/client/curations/venice_admin.coffee
@@ -115,11 +115,9 @@ module.exports = VeniceAdmin = React.createClass
             for article in articles.results
               { id: article.id, value: "#{article.title}, #{article.author?.name}"}
           selected: (e, item, items) =>
-            subArticles = @state.curation.get 'sub_articles'
             subArticles = _.pluck items, 'id'
             @onChange 'sub_articles', subArticles
           removed: (e, item, items) =>
-            subArticles = @state.curation.get 'sub_articles'
             subArticles = _.without(_.pluck(items,'id'),item.id)
             @onChange 'sub_articles', subArticles
           idsToFetch: @state.curation.get 'sub_articles'

--- a/client/apps/settings/client/curations/venice_section.coffee
+++ b/client/apps/settings/client/curations/venice_section.coffee
@@ -13,6 +13,7 @@ module.exports = VeniceSection = React.createClass
     title: @props.section.title or ''
     description: @props.section.description or ''
     video_url: @props.section.video_url or ''
+    video_length: @props.section.video_length or null
     artist_ids: @props.section.artist_ids or []
     cover_image: @props.section.cover_image or ''
     published: @props.section.published or false
@@ -88,15 +89,25 @@ module.exports = VeniceSection = React.createClass
                 readOnly: true
               }
               label {},'Published'
-          div { className: 'field-group' },
-            label {},'Video URL'
-            input {
-              className: 'bordered-input'
-              placeholder: 'Enter a link'
-              defaultValue: @state.video_url
-              onChange: @onInputChange
-              name: 'video_url'
-            }
+          div { className: 'fields--full video' },
+            div { className: 'field-group video-url' },
+              label {},'Video URL'
+              input {
+                className: 'bordered-input'
+                placeholder: 'Enter a link'
+                defaultValue: @state.video_url
+                onChange: @onInputChange
+                name: 'video_url'
+              }
+            div { className: 'field-group time' },
+              label {},'Video Length'
+              input {
+                className: 'bordered-input'
+                defaultValue: @state.video_length
+                placeholder: '4:33'
+                onChange: @onInputChange
+                name: 'video_length'
+              }
       div { className: 'field-group' },
         label {},
           span {}, 'Description'

--- a/client/apps/settings/client/curations/venice_section.coffee
+++ b/client/apps/settings/client/curations/venice_section.coffee
@@ -1,6 +1,7 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
 moment = require 'moment'
+_s = require 'underscore.string'
 { div, input, label, span, textarea } = React.DOM
 AutocompleteList = React.createFactory require '../../../../components/autocomplete_list/index.coffee'
 imageUpload = React.createFactory require '../../../edit/components/admin/components/image_upload.coffee'
@@ -16,14 +17,22 @@ module.exports = VeniceSection = React.createClass
     cover_image: @props.section.cover_image or ''
     published: @props.section.published or false
     release_date: moment(@props.section.release_date).format('YYYY-MM-DD') or null
+    slug: @props.section.slug or ''
 
   componentDidMount: ->
     ReactDOM.findDOMNode(@refs.container).classList += ' active'
+    @setupSlug()
+
+  setupSlug: ->
+    if !@props.section.slug and @props.section.title
+      @setState slug: _s.slugify @props.section.title
 
   onInputChange: (e) ->
     @onChange e.target.name, e.target.value
 
   onChange: (key, value) ->
+    if key is 'slug'
+      value = _s.slugify value
     newState = @state
     newState[key] = value
     @setState newState
@@ -49,6 +58,37 @@ module.exports = VeniceSection = React.createClass
               name: 'title'
             }
           div { className: 'field-group' },
+            label {},'Slug'
+            input {
+              className: 'bordered-input'
+              placeholder: 'enter-a-slug'
+              value: @state.slug
+              onChange: @onInputChange
+              name: 'slug'
+              disabled: @state.published
+            }
+        div { className: 'fields--right' },
+          div { className: 'fields--full published' },
+            div { className: 'field-group date' },
+              label {},'Release Date'
+              input {
+                type: 'date'
+                className: 'bordered-input'
+                defaultValue: moment(@state.release_date).format('YYYY-MM-DD')
+                onChange: @onDateChange
+              }
+            div {
+              className: 'field-group--inline flat-checkbox'
+              onClick: @onCheckboxChange
+            },
+              input {
+                type: 'checkbox'
+                checked: @state.published
+                value: @state.published
+                readOnly: true
+              }
+              label {},'Published'
+          div { className: 'field-group' },
             label {},'Video URL'
             input {
               className: 'bordered-input'
@@ -57,26 +97,6 @@ module.exports = VeniceSection = React.createClass
               onChange: @onInputChange
               name: 'video_url'
             }
-        div { className: 'fields--right' },
-          div { className: 'field-group' },
-            label {},'Release Date'
-            input {
-              type: 'date'
-              className: 'bordered-input'
-              defaultValue: moment(@state.release_date).format('YYYY-MM-DD')
-              onChange: @onDateChange
-            }
-          div {
-            className: 'field-group--inline flat-checkbox'
-            onClick: @onCheckboxChange
-          },
-            input {
-              type: 'checkbox'
-              checked: @state.published
-              value: @state.published
-              readOnly: true
-            }
-            label {},'Published'
       div { className: 'field-group' },
         label {},
           span {}, 'Description'

--- a/client/apps/settings/stylesheets/venice_admin.styl
+++ b/client/apps/settings/stylesheets/venice_admin.styl
@@ -26,10 +26,18 @@
     align-items center
     .date
       width 70%
+  .video
+    .video-url
+      width 70%
+    .time
+      width 115px
+      input
+        height 40px
   .flat-checkbox
     display flex
     align-items center
     margin-top -10px
+    width 110px
     label
       margin-bottom 0
   .image-upload-form

--- a/client/apps/settings/stylesheets/venice_admin.styl
+++ b/client/apps/settings/stylesheets/venice_admin.styl
@@ -21,10 +21,15 @@
       width 100%
     textarea
       min-height 10em
+  .published
+    display flex
+    align-items center
+    .date
+      width 70%
   .flat-checkbox
     display flex
     align-items center
-    margin-top 4.5em
+    margin-top -10px
     label
       margin-bottom 0
   .image-upload-form
@@ -39,6 +44,9 @@
     justify-content space-between
   .fields--left, .fields--right
     width calc(50% \- 15px)
+  input[disabled]
+    background-color gray-lightest-color
+    cursor not-allowed
   label
     avant-garde s-headline
     margin-bottom 5px
@@ -46,6 +54,12 @@
     justify-content space-between
     .subtitle
       color gray-color
+  .sub-articles .autocomplete-container
+    display flex
+    flex-direction row-reverse
+    justify-content space-between
+    .autocomplete-selected, .twitter-typeahead
+      width calc(50% \- 15px)
   .save
     position fixed
     top 10px

--- a/client/apps/settings/test/client/curations/venice_admin.coffee
+++ b/client/apps/settings/test/client/curations/venice_admin.coffee
@@ -31,6 +31,11 @@ describe 'VeniceSection', ->
       )
       VeniceAdmin.__set__ 'dropdownHeader', React.createFactory dropdownHeader
       VeniceSection = benv.require resolve __dirname, '../../../client/curations/venice_section.coffee'
+      Autocomplete = benv.require resolve __dirname, '../../../../../components/autocomplete_list/index.coffee'
+      VeniceAdmin.__set__ 'AutocompleteList', React.createFactory Autocomplete
+      Autocomplete.__set__ 'request', get: sinon.stub().returns
+        set: sinon.stub().returns
+          end: sinon.stub().yields(null, body: { id: '123', name: 'An Artist'})
       VeniceSection.__set__ 'sd', {
         ARTSY_URL: 'http://localhost:3005'
         USER: access_token: ''
@@ -52,17 +57,19 @@ describe 'VeniceSection', ->
     $(ReactDOM.findDOMNode(@component)).find('button').length.should.eql 1
     $(ReactDOM.findDOMNode(@component)).find('section').length.should.eql 2
     $(ReactDOM.findDOMNode(@component)).find('textarea').length.should.eql 1
+    $(ReactDOM.findDOMNode(@component)).find('input').length.should.eql 1
 
   it '#revealSection triggers a dropdown', ->
     r.simulate.click r.find(@component, 'dropdown-header')[0]
     $(ReactDOM.findDOMNode(@component)).find('.venice-admin__fields.active').length.should.eql 1
 
-  it '#onInputChange sets the description state', ->
+  it '#onDescriptionChange sets the description state and shows a save warning', ->
     input = r.findTag(@component, 'textarea')[0]
     input.value = 'New Description'
     r.simulate.change input
     @component.state.curation.get('description').should.eql 'New Description'
     @component.state.isChanged.should.eql true
+    $(ReactDOM.findDOMNode(@component)).find('button').hasClass('attention').should.eql true
 
   it '#onChangeSection updates state.curation and shows a save warning', ->
     @component.onChangeSection {title: 'Dawn Kasper', published: true}, 1

--- a/client/apps/settings/test/client/curations/venice_section.coffee
+++ b/client/apps/settings/test/client/curations/venice_section.coffee
@@ -53,21 +53,31 @@ describe 'VeniceSection', ->
 
   describe 'Render', ->
     it 'Renders the input fields', ->
-      $(ReactDOM.findDOMNode(@component)).find('label').length.should.eql 7
-      $(ReactDOM.findDOMNode(@component)).find('input').length.should.eql 7
+      $(ReactDOM.findDOMNode(@component)).find('label').length.should.eql 8
+      $(ReactDOM.findDOMNode(@component)).find('input').length.should.eql 8
       $(ReactDOM.findDOMNode(@component)).find('input[type=date]').length.should.eql 1
       $(ReactDOM.findDOMNode(@component)).find('input[type=checkbox]').length.should.eql 1
       $(ReactDOM.findDOMNode(@component)).find('textarea').length.should.eql 1
       $(ReactDOM.findDOMNode(@component)).find('.autocomplete-input').length.should.eql 1
 
     it 'Populates inputs with saved data', ->
+      @component.setState slug: 'dawn-kasper'
       $(ReactDOM.findDOMNode(@component)).find('input[name=title]').val().should.eql 'The Title'
+      $(ReactDOM.findDOMNode(@component)).find('input[name=slug]').val().should.eql 'dawn-kasper'
       $(ReactDOM.findDOMNode(@component)).find('input[name=video_url]').val().should.eql 'http://artsy.net/360.mp4'
       $(ReactDOM.findDOMNode(@component)).find('input[type=date]').val().should.eql moment().format('YYYY-MM-DD')
       $(ReactDOM.findDOMNode(@component)).find('textarea').val().should.eql 'Cool description'
       $(ReactDOM.findDOMNode(@component)).find('input[type=checkbox]').val().should.eql 'false'
       $(ReactDOM.findDOMNode(@component)).find('.autocomplete-select-selected').text().should.eql 'An Artist'
       $(ReactDOM.findDOMNode(@component)).html().should.containEql 'background-image: url(http://artsy.net/cover.jpg)'
+
+  describe 'Slugs', ->
+    it 'If slug is undefined, autofills a slug based on a saved section title', ->
+      $(ReactDOM.findDOMNode(@component)).find('input[name=slug]').val().should.eql 'the-title'
+
+    it 'Disables the slug field on published sections', ->
+      @component.setState published: true
+      $(ReactDOM.findDOMNode(@component)).find('input[name=slug]').prop('disabled').should.eql true
 
   describe '#onChange', ->
 

--- a/client/apps/settings/test/client/curations/venice_section.coffee
+++ b/client/apps/settings/test/client/curations/venice_section.coffee
@@ -36,6 +36,7 @@ describe 'VeniceSection', ->
           title: 'The Title'
           description: 'Cool description'
           video_url: 'http://artsy.net/360.mp4'
+          video_length: '11:22'
           artist_ids: ['123']
           cover_image: 'http://artsy.net/cover.jpg'
           release_date: moment().toISOString()
@@ -53,8 +54,8 @@ describe 'VeniceSection', ->
 
   describe 'Render', ->
     it 'Renders the input fields', ->
-      $(ReactDOM.findDOMNode(@component)).find('label').length.should.eql 8
-      $(ReactDOM.findDOMNode(@component)).find('input').length.should.eql 8
+      $(ReactDOM.findDOMNode(@component)).find('label').length.should.eql 9
+      $(ReactDOM.findDOMNode(@component)).find('input').length.should.eql 9
       $(ReactDOM.findDOMNode(@component)).find('input[type=date]').length.should.eql 1
       $(ReactDOM.findDOMNode(@component)).find('input[type=checkbox]').length.should.eql 1
       $(ReactDOM.findDOMNode(@component)).find('textarea').length.should.eql 1
@@ -65,6 +66,7 @@ describe 'VeniceSection', ->
       $(ReactDOM.findDOMNode(@component)).find('input[name=title]').val().should.eql 'The Title'
       $(ReactDOM.findDOMNode(@component)).find('input[name=slug]').val().should.eql 'dawn-kasper'
       $(ReactDOM.findDOMNode(@component)).find('input[name=video_url]').val().should.eql 'http://artsy.net/360.mp4'
+      $(ReactDOM.findDOMNode(@component)).find('input[name=video_length]').val().should.eql '11:22'
       $(ReactDOM.findDOMNode(@component)).find('input[type=date]').val().should.eql moment().format('YYYY-MM-DD')
       $(ReactDOM.findDOMNode(@component)).find('textarea').val().should.eql 'Cool description'
       $(ReactDOM.findDOMNode(@component)).find('input[type=checkbox]').val().should.eql 'false'

--- a/client/components/autocomplete_list/index.coffee
+++ b/client/components/autocomplete_list/index.coffee
@@ -76,10 +76,11 @@ module.exports = AutocompleteList = React.createClass
   render: ->
     div { className: 'autocomplete-container' },
       (
-        for item in @state.items
-          div { className: 'autocomplete-select-selected', key: item.value }, item.value,
-            input { type: 'hidden', value: item.id, name: @props.name }
-            button { className: 'remove-button', onClick: @removeItem(item) }
+        div { className: 'autocomplete-selected'},
+          for item in @state.items
+            div { className: 'autocomplete-select-selected', key: item.value }, item.value,
+              input { type: 'hidden', value: item.id, name: @props.name }
+              button { className: 'remove-button', onClick: @removeItem(item) }
       )
       input {
         className: 'bordered-input autocomplete-input'


### PR DESCRIPTION
Adds related articles (for footer carousel)

Adds slug input for sections:
- autofills a slug based on title if slug doesn't exist and title has been saved
- shows an empty field if no title and no slug
- disables the slug if published is true