### PR TITLE
@kanaabe => Related artists format

### DIFF
--- a/client/apps/settings/client/curations/venice_section.coffee
+++ b/client/apps/settings/client/curations/venice_section.coffee
@@ -133,13 +133,13 @@ module.exports = VeniceSection = React.createClass
             url: "#{sd.ARTSY_URL}/api/v1/match/artists?term=%QUERY"
             placeholder: "Search artists by name..."
             filter: (res) -> for r in res
-              { id: r._id, value: r.name }
+              { id: r.id, value: r.name }
             selected: (e, item, items) =>
-              @onChange 'artist_ids', _.pluck items, 'id'
+              @onChange 'artist_ids', items
             removed: (e, item, items) =>
-              @onChange 'artist_ids', _.without(_.pluck(items, 'id'),item.id)
-            idsToFetch: @state.artist_ids
+              @onChange 'artist_ids', _.without(items, item)
+            idsToFetch: _.pluck @state.artist_ids, 'id'
             fetchUrl: (id) -> "#{sd.ARTSY_URL}/api/v1/artist/#{id}"
             resObject: (res) ->
-              id: res.body._id, value: res.body.name
+              id: res.body.id, value: res.body.name
           }

--- a/client/apps/settings/test/client/curations/venice_admin.coffee
+++ b/client/apps/settings/test/client/curations/venice_admin.coffee
@@ -23,6 +23,7 @@ describe 'VeniceSection', ->
           initialize: ->
           ttAdapter: ->
         )
+        _: benv.require 'underscore'
       $.fn.typeahead = sinon.stub()
       window.jQuery = $
       VeniceAdmin = benv.require resolve __dirname, '../../../client/curations/venice_admin.coffee'

--- a/client/apps/settings/test/client/curations/venice_section.coffee
+++ b/client/apps/settings/test/client/curations/venice_section.coffee
@@ -19,6 +19,7 @@ describe 'VeniceSection', ->
           initialize: ->
           ttAdapter: ->
         )
+        _: benv.require 'underscore'
       $.fn.typeahead = sinon.stub()
       window.jQuery = $
       VeniceSection = benv.require resolve __dirname, '../../../client/curations/venice_section.coffee'


### PR DESCRIPTION
To allow us to print a follow button without fetching the name, saves related artists as an object including verbose id and name, rather than mongo _id.
