### PR TITLE
@kanaabe => Vertical/Tags admin

### DIFF
--- a/api/apps/articles/model/distribute.coffee
+++ b/api/apps/articles/model/distribute.coffee
@@ -70,7 +70,9 @@ postFacebookAPI = (article, cb) ->
 postSailthruAPI = (article, cb) ->
   tags = ['article']
   tags = tags.concat ['magazine'] if article.featured is true
-  tags = tags.concat article.keywords
+  tags = tags.concat article.keywords if article.keywords
+  tags = tags.concat article.tracking_tags if article.tracking_tags
+  tags = tags.concat article.vertical.name if article.vertical
   imageSrc = article.email_metadata?.image_url
   images =
     full: url: crop(imageSrc, { width: 1200, height: 706 } )
@@ -104,7 +106,8 @@ postSailthruAPI = (article, cb) ->
   if article.sections
     sections = for section in article.sections
       section.body
-
+  tags = article.tags
+  tags = tags.concat article.vertical if article.vertical
   search.client.index(
     index: search.index,
     type: 'article',
@@ -119,7 +122,7 @@ postSailthruAPI = (article, cb) ->
       visible_to_public: article.published and sections?.length > 0 and article.channel_id and article.channel_id.toString() is EDITORIAL_CHANNEL
       author: article.author and article.author.name or ''
       featured: article.featured
-      tags: article.tags
+      tags: tags
       body: sections and stripHtmlTags(sections.join(' ')) or ''
       image_url: crop(article.thumbnail_image, { width: 70, height: 70 })
     , (error, response) ->

--- a/api/apps/articles/model/retrieve.coffee
+++ b/api/apps/articles/model/retrieve.coffee
@@ -13,7 +13,7 @@ moment = require 'moment'
     query = _.omit input, 'limit', 'offset', 'sort', 'artist_id', 'artwork_id',
       'super_article_for', 'fair_ids', 'fair_programming_id', 'fair_artsy_id',
       'fair_about_id', 'partner_id', 'auction_id', 'show_id', 'q',
-      'all_by_author', 'section_id', 'tags', 'has_video', 'fair_id',
+      'all_by_author', 'section_id', 'tags', 'tracking_tags', 'has_video', 'fair_id',
       'channel_id', 'ids', 'scheduled', 'count'
     # Type cast IDs
     # TODO: https://github.com/pebble/joi-objectid/issues/2#issuecomment-75189638
@@ -33,6 +33,7 @@ moment = require 'moment'
       query.biography_for_artist_id = ObjectId input.biography_for_artist_id
     query.featured_artwork_ids = ObjectId input.artwork_id if input.artwork_id
     query.tags = { $in: input.tags } if input.tags
+    query.tracking_tags = { $in: input.tracking_tags } if input.tracking_tags
 
     # Convert query for super article for article
     if input.super_article_for

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -222,6 +222,7 @@ denormalizedArtwork = (->
   q: @string().allow('')
   all_by_author: @objectId()
   tags: @array().items(@string())
+  tracking_tags: @array().items(@string())
   is_super_article: @boolean()
   biography_for_artist_id: @objectId()
   layout: @string()

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -77,6 +77,7 @@ denormalizedArtwork = (->
   thumbnail_teaser: @string().allow('', null)
   thumbnail_image: @string().allow('', null)
   tags: @array().items(@string()).default([])
+  tracking_tags: @array().items(@string()).default([])
   vertical: @object().keys(
     name: @string()
     id: @objectId()

--- a/api/apps/articles/test/model/distribute.coffee
+++ b/api/apps/articles/test/model/distribute.coffee
@@ -43,6 +43,21 @@ describe 'Save', ->
           @sailthru.apiPost.args[0][1].tags.should.not.containEql 'artsy-editorial'
           done()
 
+      it 'concats the tracking_tags and vertical', (done) ->
+        Distribute.distributeArticle {
+          author_id: '5086df098523e60002000018'
+          published: true
+          keywords: ['China']
+          tracking_tags: ['explainers', 'profiles']
+          vertical: {name: 'culture', id: '591b0babc88a280f5e9efa7a'}
+        }, (err, article) =>
+          @sailthru.apiPost.calledOnce.should.be.true()
+          @sailthru.apiPost.args[0][1].tags.should.containEql 'China'
+          @sailthru.apiPost.args[0][1].tags.should.containEql 'explainers'
+          @sailthru.apiPost.args[0][1].tags.should.containEql 'profiles'
+          @sailthru.apiPost.args[0][1].tags.should.containEql 'culture'
+          done()
+
       it 'concats the artsy-editorial and magazine tags for specialized articles', (done) ->
         Distribute.distributeArticle {
           author_id: '5086df098523e60002000018'

--- a/api/apps/articles/test/model/index.coffee
+++ b/api/apps/articles/test/model/index.coffee
@@ -332,6 +332,39 @@ describe 'Article', ->
           results[2].title.should.equal 'Hello Wuuuurld - Food'
           done()
 
+    it 'can find articles by tracking_tags', (done) ->
+      fabricate 'articles', [
+        {
+          author_id: ObjectId '4d8cd73191a5c50ce220002a'
+          tracking_tags: [ 'video', 'evergreen' ]
+          title: 'The Shanghai Art Project That’s Working to Save Us from a Dystopian Future'
+        }
+        {
+          author_id: ObjectId '4d8cd73191a5c50ce220002b'
+          tracking_tags: [ 'video', 'evergreen' ]
+          title: '$448 Million Christie’s Post-War and Contemporary Sale Led by Bacon and Twombly'
+        }
+        {
+          author_id: ObjectId '4d8cd73191a5c50ce220002c'
+          tracking_tags: [ 'podcast', 'evergreen' ]
+          title: '8 Works to Collect at ARCOlisboa'
+        }
+        {
+          author_id: ObjectId '4d8cd73191a5c50ce220002e'
+          tracking_tags: [ 'op-eds', 'explainers' ]
+          title: 'NYC Releases Data That Will Help Shape the City’s Cultural Future'
+        }
+      ], =>
+        Article.where { tracking_tags: ['video', 'evergreen'], count: true }, (err, res) ->
+          { total, count, results } = res
+          # console.log res
+          total.should.equal 14
+          count.should.equal 3
+          results[0].title.should.equal '8 Works to Collect at ARCOlisboa'
+          results[1].title.should.equal '$448 Million Christie’s Post-War and Contemporary Sale Led by Bacon and Twombly'
+          results[2].title.should.equal 'The Shanghai Art Project That’s Working to Save Us from a Dystopian Future'
+          done()
+
     it 'can find articles by artist biography', (done) ->
       fabricate 'articles', [
         {
@@ -429,9 +462,11 @@ describe 'Article', ->
         author_id: '5086df098523e60002000018'
         id: '5086df098523e60002002222'
         channel_id: '5086df098523e60002002223'
+        vertical: {name: 'Culture', id: '55356a9deca560a0137bb4a7'}
       }, 'foo', (err, article) ->
         article.title.should.equal 'Top Ten Shows'
         article.channel_id.toString().should.equal '5086df098523e60002002223'
+        article.vertical.name.should.eql 'Culture'
         db.articles.count (err, count) ->
           count.should.equal 11
           done()
@@ -989,6 +1024,15 @@ describe 'Article', ->
       }, 'foo', (err, article) ->
         return done err if err
         article.vertical.name.should.eql 'Culture'
+        done()
+
+    it 'saves tracking_tags', (done) ->
+      Article.save {
+        author_id: '5086df098523e60002000018'
+        tracking_tags: ['evergreen', 'video']
+      }, 'foo', (err, article) ->
+        return done err if err
+        article.tracking_tags.should.eql ['evergreen', 'video']
         done()
 
     it 'saves social metadata', (done) ->

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -4,7 +4,7 @@ ReactDOM = require 'react-dom'
 _ = require 'underscore'
 
 Article = React.createFactory require './article/index.coffee'
-VerticalsTags = React.createFactory require './verticals_tags/index.coffee'
+VerticalsTags = React.createFactory require './verticals_tags/index2.coffee'
 Featuring = React.createFactory require './featuring/index.coffee'
 SuperArticle = React.createFactory require './super_article/index.coffee'
 Appearances = React.createFactory require './appearances/index.coffee'

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -4,7 +4,7 @@ ReactDOM = require 'react-dom'
 _ = require 'underscore'
 
 Article = React.createFactory require './article/index.coffee'
-VerticalsTags = React.createFactory require './verticals_tags/index2.coffee'
+VerticalsTags = React.createFactory require './verticals_tags/index.coffee'
 Featuring = React.createFactory require './featuring/index.coffee'
 SuperArticle = React.createFactory require './super_article/index.coffee'
 Appearances = React.createFactory require './appearances/index.coffee'

--- a/client/apps/edit/components/admin/index.styl
+++ b/client/apps/edit/components/admin/index.styl
@@ -38,6 +38,7 @@
       height initial
       opacity 1
       transition all .65s
+      overflow visible
     .fields-left,
     .fields-right
       width calc(50% \- 15px)

--- a/client/apps/edit/components/admin/test/index.coffee
+++ b/client/apps/edit/components/admin/test/index.coffee
@@ -31,6 +31,7 @@ describe 'AdminSections', ->
       }
       AdminSections.__set__ 'Article', sinon.stub()
       AdminSections.__set__ 'Featuring', sinon.stub()
+      AdminSections.__set__ 'VerticalsTags', sinon.stub()
       @channel = {id: '123'}
       @channel.hasFeature = sinon.stub().returns false
       @article = new Article
@@ -76,10 +77,9 @@ describe 'AdminSections', ->
     @component.onChange('tier', 2)
     @component.props.article.get('tier').should.eql 2
 
-  it 'If unpublished, #onChange does not save and shows indicator', ->
+  it 'If unpublished, #onChange does not save', ->
     @component.onChange('tier', 2)
     @component.props.article.save.callCount.should.eql 0
-    # is there a way to show jquery changes outside the component?
 
   it '#onChange saves the article if unpublished', ->
     @component.debouncedSave = @component.props.article.save

--- a/client/apps/edit/components/admin/test/verticals_tags2.coffee
+++ b/client/apps/edit/components/admin/test/verticals_tags2.coffee
@@ -3,86 +3,96 @@ sinon = require 'sinon'
 { resolve } = require 'path'
 React = require 'react'
 ReactDOM = require 'react-dom'
-ReactTestUtils = require 'react-addons-test-utils'
-ReactDOMServer = require 'react-dom/server'
-fixtures = require '../../../../../../test/helpers/fixtures.coffee'
-Article = require '../../../../../models/article.coffee'
 Backbone = require 'backbone'
+ReactDOMServer = require 'react-dom/server'
+ReactTestUtils = require 'react-addons-test-utils'
 r =
   find: ReactTestUtils.scryRenderedDOMComponentsWithClass
   simulate: ReactTestUtils.Simulate
+fixtures = require '../../../../../../test/helpers/fixtures.coffee'
+Article = require '../../../../../models/article.coffee'
+Vertical = require '../../../../../models/vertical.coffee'
+Verticals = require '../../../../../collections/verticals.coffee'
 
 describe 'AdminVerticalsTags', ->
 
   beforeEach (done) ->
     benv.setup =>
-      benv.expose $: benv.require 'jquery'
+      benv.expose
+        $: benv.require 'jquery'
+        Bloodhound: (Bloodhound = sinon.stub()).returns(
+          initialize: ->
+          ttAdapter: ->
+        )
+        _: benv.require 'underscore'
       window.jQuery = $
+      $.fn.typeahead = sinon.stub()
       @AdminVerticalsTags = benv.require resolve __dirname, '../verticals_tags/index2.coffee'
       @AdminVerticalsTags.__set__ 'sd', {
         API_URL: 'http://localhost:3005/api'
         CURRENT_CHANNEL: id: '123'
         USER: access_token: ''
       }
+      AutocompleteList = benv.require resolve __dirname, '../../../../../components/autocomplete_list/index.coffee'
+      AutocompleteList.__set__ 'request', get: sinon.stub().returns
+        set: sinon.stub().returns
+          end: sinon.stub().yields(null, body: {results: [{ id: '123', name: 'Artists'}]})
+      @AdminVerticalsTags.__set__ 'AutocompleteList', React.createFactory AutocompleteList
       @article = new Article
+      @Verticals = new Verticals([
+        { id: '1', name: 'Art'}
+        { id: '2', name: 'Art Market'}
+        { id: '3', name: 'Creativity'}
+        { id: '4', name: 'Culture'}
+      ])
+      _.first = sinon.stub().returns new Vertical({ id: '1', name: 'Art'})
       @article.attributes = fixtures().articles
-      @article.set 'tags', ['features', 'emerging artists', 'awi', 'asp', 'commissioned photography', 'product boost']
-      @channel = {id: '123'}
+      @article.set 'tags', ['Artists']
+      @article.set 'tracking_tags', []
+      @article.set 'vertical', {}
       props = {
         article: @article
         onChange: sinon.stub()
-        channel: @channel
-        }
+      }
+      sinon.stub Backbone, 'sync'
       @component = ReactDOM.render React.createElement(@AdminVerticalsTags, props), (@$el = $ "<div></div>")[0], =>
         setTimeout =>
+          @component.setState verticals: @Verticals
           done()
 
   afterEach ->
+    Backbone.sync.restore()
     benv.teardown()
 
   describe 'Tags', ->
 
-    it 'Renders a text input for tags', ->
-      $(ReactDOM.findDOMNode(@component)).find('input').prop('placeholder').should.eql 'Start typing tags...'
+    it 'Renders text inputs for tags', ->
+      $(ReactDOM.findDOMNode(@component)).find('.autocomplete-container--inline').length.should.eql 2
+      $(ReactDOM.findDOMNode(@component)).find('input').first().prop('placeholder').should.eql ''
+      $(ReactDOM.findDOMNode(@component)).find('input').last().prop('placeholder').should.eql 'Start typing a tracking tag...'
 
     it 'Pre-populates the input with article tags', ->
-      $(ReactDOM.findDOMNode(@component)).find('input').val().should.eql 'features, emerging artists, awi, asp, commissioned photography, product boost'
+      $(ReactDOM.findDOMNode(@component)).find('.autocomplete-container').first().html().should.containEql '<span class="selected">Artists</span>'
 
-    it 'does not render tags when tags do not exist', ->
+    it 'does not render tags when empty', ->
       @article.unset 'tags'
-      props = {
-        article: @article
-        onChange: sinon.stub()
-        channel: @channel
-        }
-      rendered = ReactDOMServer.renderToString React.createElement(@AdminVerticalsTags, props)
-      rendered.should.containEql 'value=""'
-
-  describe '#onChange', ->
-
-    it 'Calls onChange with user input', ->
-      input = r.find(@component, 'bordered-input')[0]
-      input.value = 'new, tags'
-      r.simulate.change input
-      @component.props.onChange.args[0][1].should.eql [ 'new', 'tags' ]
-
-    it 'Strips spaces outsite terms, not between terms', ->
-      input = r.find(@component, 'bordered-input')[0]
-      input.value = '   a new   , these   tags    '
-      r.simulate.change input
-      @component.props.onChange.args[0][1].should.eql [ 'a new', 'these tags' ]
-
-    it 'Does not save empty items', ->
-      input = r.find(@component, 'bordered-input')[0]
-      input.value = ' , new, tags, , , '
-      r.simulate.change input
-      @component.props.onChange.args[0][1].should.eql [ 'new', 'tags' ]
+      rendered = ReactDOMServer.renderToString React.createElement(@AdminVerticalsTags, { article: @article })
+      rendered.should.containEql 'placeholder="Start typing a topic tag..."'
 
   describe 'Verticals', ->
 
-    xit 'Renders fields for Vertical and SubVertical', ->
+    it 'Renders buttons for Verticals', ->
       $(ReactDOM.findDOMNode(@component)).find('.fields-left .field-group').first().html().should.containEql 'Editorial Vertical'
       $(ReactDOM.findDOMNode(@component)).find('.field-group').first().find('button').length.should.eql 4
-      $(ReactDOM.findDOMNode(@component)).find('.fields-left .field-group').last().html().should.containEql 'Editorial SubVertical'
-      $(ReactDOM.findDOMNode(@component)).find('.fields-left .field-group').last().find('button').text().should.eql 'Please select a vertical first'
+      $(ReactDOM.findDOMNode(@component)).find('.field-group').first().find('button.avant-garde-button-black').length.should.eql 0
 
+    it 'Can render a saved vertical', ->
+      @component.setState vertical: { id: '1', name: 'Art'}
+      $(ReactDOM.findDOMNode(@component)).find('.field-group').first().find('button.avant-garde-button-black').length.should.eql 1
+
+    it 'Updates the vertical on click', ->
+      @component.state.vertical.should.eql {}
+      r.simulate.click r.find(@component, 'avant-garde-button')[0]
+      @component.state.vertical.should.eql { name: 'Art', id: '1' }
+      @component.props.onChange.args[0][0].should.eql 'vertical'
+      @component.props.onChange.args[0][1].should.eql { name: 'Art', id: '1' }

--- a/client/apps/edit/components/admin/test/verticals_tags2.coffee
+++ b/client/apps/edit/components/admin/test/verticals_tags2.coffee
@@ -1,0 +1,88 @@
+benv = require 'benv'
+sinon = require 'sinon'
+{ resolve } = require 'path'
+React = require 'react'
+ReactDOM = require 'react-dom'
+ReactTestUtils = require 'react-addons-test-utils'
+ReactDOMServer = require 'react-dom/server'
+fixtures = require '../../../../../../test/helpers/fixtures.coffee'
+Article = require '../../../../../models/article.coffee'
+Backbone = require 'backbone'
+r =
+  find: ReactTestUtils.scryRenderedDOMComponentsWithClass
+  simulate: ReactTestUtils.Simulate
+
+describe 'AdminVerticalsTags', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose $: benv.require 'jquery'
+      window.jQuery = $
+      @AdminVerticalsTags = benv.require resolve __dirname, '../verticals_tags/index2.coffee'
+      @AdminVerticalsTags.__set__ 'sd', {
+        API_URL: 'http://localhost:3005/api'
+        CURRENT_CHANNEL: id: '123'
+        USER: access_token: ''
+      }
+      @article = new Article
+      @article.attributes = fixtures().articles
+      @article.set 'tags', ['features', 'emerging artists', 'awi', 'asp', 'commissioned photography', 'product boost']
+      @channel = {id: '123'}
+      props = {
+        article: @article
+        onChange: sinon.stub()
+        channel: @channel
+        }
+      @component = ReactDOM.render React.createElement(@AdminVerticalsTags, props), (@$el = $ "<div></div>")[0], =>
+        setTimeout =>
+          done()
+
+  afterEach ->
+    benv.teardown()
+
+  describe 'Tags', ->
+
+    it 'Renders a text input for tags', ->
+      $(ReactDOM.findDOMNode(@component)).find('input').prop('placeholder').should.eql 'Start typing tags...'
+
+    it 'Pre-populates the input with article tags', ->
+      $(ReactDOM.findDOMNode(@component)).find('input').val().should.eql 'features, emerging artists, awi, asp, commissioned photography, product boost'
+
+    it 'does not render tags when tags do not exist', ->
+      @article.unset 'tags'
+      props = {
+        article: @article
+        onChange: sinon.stub()
+        channel: @channel
+        }
+      rendered = ReactDOMServer.renderToString React.createElement(@AdminVerticalsTags, props)
+      rendered.should.containEql 'value=""'
+
+  describe '#onChange', ->
+
+    it 'Calls onChange with user input', ->
+      input = r.find(@component, 'bordered-input')[0]
+      input.value = 'new, tags'
+      r.simulate.change input
+      @component.props.onChange.args[0][1].should.eql [ 'new', 'tags' ]
+
+    it 'Strips spaces outsite terms, not between terms', ->
+      input = r.find(@component, 'bordered-input')[0]
+      input.value = '   a new   , these   tags    '
+      r.simulate.change input
+      @component.props.onChange.args[0][1].should.eql [ 'a new', 'these tags' ]
+
+    it 'Does not save empty items', ->
+      input = r.find(@component, 'bordered-input')[0]
+      input.value = ' , new, tags, , , '
+      r.simulate.change input
+      @component.props.onChange.args[0][1].should.eql [ 'new', 'tags' ]
+
+  describe 'Verticals', ->
+
+    xit 'Renders fields for Vertical and SubVertical', ->
+      $(ReactDOM.findDOMNode(@component)).find('.fields-left .field-group').first().html().should.containEql 'Editorial Vertical'
+      $(ReactDOM.findDOMNode(@component)).find('.field-group').first().find('button').length.should.eql 4
+      $(ReactDOM.findDOMNode(@component)).find('.fields-left .field-group').last().html().should.containEql 'Editorial SubVertical'
+      $(ReactDOM.findDOMNode(@component)).find('.fields-left .field-group').last().find('button').text().should.eql 'Please select a vertical first'
+

--- a/client/apps/edit/components/admin/verticals_tags/index.styl
+++ b/client/apps/edit/components/admin/verticals_tags/index.styl
@@ -13,3 +13,27 @@
       background black
     .field-group:first-child
       margin-bottom 30px
+
+  .autocomplete-container
+    position relative
+    .autocomplete-selected
+      display inline-block
+      position absolute
+      left 0
+      top 13px
+      z-index 100
+      .remove-button
+        height 20px
+        width 15px
+        background transparent center center no-repeat url(/icons/remove.svg)
+        background-size 8px
+    .autocomplete-select-selected
+      display inline-block
+      width inherit
+      background gray-lighter-color
+      color black
+      margin 0 0 0 10px
+      border-radius 2px
+      line-height 1em
+      padding 2px 20px 1px 4px
+      text-transform capitalize

--- a/client/apps/edit/components/admin/verticals_tags/index.styl
+++ b/client/apps/edit/components/admin/verticals_tags/index.styl
@@ -1,5 +1,5 @@
 .edit-admin--verticals-tags
-  button
+  button.avant-garde-button
     margin 5px 8px 8px 0px
     border-radius 1px
     padding 13px 15px

--- a/client/apps/edit/components/admin/verticals_tags/index.styl
+++ b/client/apps/edit/components/admin/verticals_tags/index.styl
@@ -13,27 +13,3 @@
       background black
     .field-group:first-child
       margin-bottom 30px
-
-  .autocomplete-container
-    position relative
-    .autocomplete-selected
-      display inline-block
-      position absolute
-      left 0
-      top 13px
-      z-index 100
-      .remove-button
-        height 20px
-        width 15px
-        background transparent center center no-repeat url(/icons/remove.svg)
-        background-size 8px
-    .autocomplete-select-selected
-      display inline-block
-      width inherit
-      background gray-lighter-color
-      color black
-      margin 0 0 0 10px
-      border-radius 2px
-      line-height 1em
-      padding 2px 20px 1px 4px
-      text-transform capitalize

--- a/client/apps/edit/components/admin/verticals_tags/index2.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/index2.coffee
@@ -8,7 +8,7 @@ module.exports = React.createClass
   displayName: 'AdminVerticalsTags'
 
   getInitialState: ->
-    vertical: null || @props.article.get('vertical')
+    vertical: null or @props.article.get('vertical')
     verticals: []
 
   componentDidMount: ->

--- a/client/apps/edit/components/admin/verticals_tags/index2.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/index2.coffee
@@ -17,13 +17,13 @@ module.exports = React.createClass
 
   fetchVerticals: ->
     new Verticals().fetch
-      data: limit: 10
+      cache: true
       success: (verticals) =>
         sortedVerticals = verticals.sortBy('name')
         @setState verticals: sortedVerticals
 
-  printButtons: (buttons, handleToggle) ->
-    buttons.map (vertical, i) =>
+  printVerticals: (verticals, handleToggle) ->
+    verticals.map (vertical, i) =>
       active = ''
       if @state.vertical?.name is vertical.get 'name'
         active = ' avant-garde-button-black'
@@ -44,16 +44,12 @@ module.exports = React.createClass
     @setState vertical: newVertical
     @props.onChange('vertical', newVertical)
 
-  onAddTag: (value) ->
-    tags = _.uniq @props.article.get('tags').concat(value)
-    @props.onChange('tags', tags)
-
   render: ->
     section { className: 'edit-admin--verticals-tags edit-admin__fields', ref: 'container'},
       div {className: 'fields-left'},
         div { className: 'field-group' },
           label {}, 'Editorial Vertical'
-          @printButtons @state.verticals, @verticalToggle
+          @printVerticals @state.verticals, @verticalToggle
 
       div {className: 'fields-right'},
         div {className: 'field-group'},
@@ -67,11 +63,10 @@ module.exports = React.createClass
               for tag in tags.results
                 { id: tag.id, value: "#{tag.name}"}
             selected: (e, item, items) =>
-              tags = _.pluck items, 'value'
-              @onAddTag tags
+              newTags = _.pluck items, 'value'
+              @props.onChange 'tags', newTags
             removed: (e, item, items) =>
-              tags = _.uniq @props.article.get 'tags'
-              newTags = _.without(tags,item.value)
+              newTags = _.without @props.article.get('tags'), item.value
               @props.onChange 'tags', newTags
             fetchUrl: (name) -> "#{sd.API_URL}/tags?public=true&q=#{name}"
             resObject: (res) ->
@@ -84,18 +79,17 @@ module.exports = React.createClass
           AutocompleteList {
             url: "#{sd.API_URL}/tags?public=false&q=%QUERY"
             placeholder: 'Start typing a tracking tag...'
-            idsToFetch: @props.article.get 'tags'
+            idsToFetch: @props.article.get 'tracking_tags'
             inline: true
-            filter: (tags) ->
-              for tag in tags.results
-                { id: tag.id, value: "#{tag.name}"}
+            filter: (tracking_tags) ->
+              for tracking_tag in tracking_tags.results
+                { id: tracking_tag.id, value: "#{tracking_tag.name}"}
             selected: (e, item, items) =>
-              tags = _.pluck items, 'value'
-              @onAddTag tags
+              newTags = _.pluck items, 'value'
+              @props.onChange 'tracking_tags', newTags
             removed: (e, item, items) =>
-              tags = _.uniq @props.article.get 'tags'
-              newTags = _.without(tags,item.value)
-              @props.onChange 'tags', newTags
+              newTags = _.without @props.article.get('tracking_tags'), item.value
+              @props.onChange 'tracking_tags', newTags
             fetchUrl: (name) -> "#{sd.API_URL}/tags?public=false&q=#{name}"
             resObject: (res) ->
               return unless res.body.results.length

--- a/client/apps/edit/components/admin/verticals_tags/index2.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/index2.coffee
@@ -1,5 +1,6 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
+AutocompleteList = React.createFactory require '../../../../../components/autocomplete_list/index.coffee'
 { div, section, label, button, input } = React.DOM
 
 module.exports = React.createClass
@@ -29,6 +30,10 @@ module.exports = React.createClass
     active = @state.verticals.indexOf e.target.name
     @setState vertical: e.target.name
 
+  onAddTag: (value) ->
+    tags = _.uniq @props.article.get('tags').concat(value)
+    @props.onChange('tags', tags)
+
   render: ->
     section { className: 'edit-admin--verticals-tags edit-admin__fields', ref: 'container'},
       div {className: 'fields-left'},
@@ -39,13 +44,43 @@ module.exports = React.createClass
       div {className: 'fields-right'},
         div {className: 'field-group'},
           label {}, 'Topic Tags'
-          input {
-            className: 'bordered-input'
+          AutocompleteList {
+            url: "#{sd.API_URL}/tags?public=true&q=%QUERY"
             placeholder: 'Start typing a topic tag...'
+            idsToFetch: @props.article.get 'tags'
+            filter: (tags) ->
+              for tag in tags.results
+                { id: tag.id, value: "#{tag.name}"}
+            selected: (e, item, items) =>
+              tags = _.pluck items, 'value'
+              @onAddTag tags
+            removed: (e, item, items) =>
+              tags = _.uniq @props.article.get 'tags'
+              newTags = _.without(tags,item.value)
+              @props.onChange 'tags', newTags
+            fetchUrl: (id) -> "#{sd.API_URL}/tags?public=true&q=#{id}"
+            resObject: (res) ->
+              return unless res.body.results.length
+              id: res.body.results[0].id, value: "#{res.body.results[0].name}"
           }
         div {className: 'field-group'},
           label {}, 'Tracking Tags'
-          input {
-            className: 'bordered-input'
+          AutocompleteList {
+            url: "#{sd.API_URL}/tags?public=false&q=%QUERY"
             placeholder: 'Start typing a tracking tag...'
+            idsToFetch: @props.article.get 'tags'
+            filter: (tags) ->
+              for tag in tags.results
+                { id: tag.id, value: "#{tag.name}"}
+            selected: (e, item, items) =>
+              tags = _.pluck items, 'value'
+              @onAddTag tags
+            removed: (e, item, items) =>
+              tags = _.uniq @props.article.get 'tags'
+              newTags = _.without(tags,item.value)
+              @props.onChange 'tags', newTags
+            fetchUrl: (id) -> "#{sd.API_URL}/tags?public=false&q=#{id}"
+            resObject: (res) ->
+              return unless res.body.results.length
+              id: res.body.results[0].id, value: "#{res.body.results[0].name}"
           }

--- a/client/apps/edit/components/admin/verticals_tags/index2.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/index2.coffee
@@ -14,7 +14,6 @@ module.exports = React.createClass
   componentDidMount: ->
     ReactDOM.findDOMNode(@refs.container).classList += ' active'
     @fetchVerticals()
-    @formatTags()
 
   fetchVerticals: ->
     new Verticals().fetch
@@ -47,14 +46,7 @@ module.exports = React.createClass
 
   onAddTag: (value) ->
     tags = _.uniq @props.article.get('tags').concat(value)
-    @formatTags()
     @props.onChange('tags', tags)
-
-  formatTags: ->
-    $('.edit-admin--verticals-tags .autocomplete-container').each (i, container) ->
-      input = $(container).find('.autocomplete-input.tt-input')
-      selected = $(container).find('.autocomplete-selected').width() + 10
-      $(input).css('padding-left', selected)
 
   render: ->
     section { className: 'edit-admin--verticals-tags edit-admin__fields', ref: 'container'},
@@ -70,6 +62,7 @@ module.exports = React.createClass
             url: "#{sd.API_URL}/tags?public=true&q=%QUERY"
             placeholder: 'Start typing a topic tag...'
             idsToFetch: @props.article.get 'tags'
+            inline: true
             filter: (tags) ->
               for tag in tags.results
                 { id: tag.id, value: "#{tag.name}"}
@@ -79,7 +72,6 @@ module.exports = React.createClass
             removed: (e, item, items) =>
               tags = _.uniq @props.article.get 'tags'
               newTags = _.without(tags,item.value)
-              @formatTags()
               @props.onChange 'tags', newTags
             fetchUrl: (name) -> "#{sd.API_URL}/tags?public=true&q=#{name}"
             resObject: (res) ->
@@ -93,6 +85,7 @@ module.exports = React.createClass
             url: "#{sd.API_URL}/tags?public=false&q=%QUERY"
             placeholder: 'Start typing a tracking tag...'
             idsToFetch: @props.article.get 'tags'
+            inline: true
             filter: (tags) ->
               for tag in tags.results
                 { id: tag.id, value: "#{tag.name}"}
@@ -102,7 +95,6 @@ module.exports = React.createClass
             removed: (e, item, items) =>
               tags = _.uniq @props.article.get 'tags'
               newTags = _.without(tags,item.value)
-              @formatTags()
               @props.onChange 'tags', newTags
             fetchUrl: (name) -> "#{sd.API_URL}/tags?public=false&q=#{name}"
             resObject: (res) ->

--- a/client/collections/verticals.coffee
+++ b/client/collections/verticals.coffee
@@ -1,0 +1,13 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+Vertical = require '../models/vertical.coffee'
+sd = require('sharify').data
+{ ApiCollection } = require './mixins.coffee'
+
+module.exports = class Verticals extends Backbone.Collection
+
+  _.extend @prototype, ApiCollection
+
+  url: "#{sd.API_URL}/verticals"
+
+  model: Vertical

--- a/client/components/autocomplete/index.styl
+++ b/client/components/autocomplete/index.styl
@@ -63,3 +63,45 @@
   padding 10px
   background gray-lighter-color
   font-weight bold
+
+.autocomplete-container--inline
+  position relative
+  display flex
+  flex-wrap wrap
+  padding 5px 10px 0 10px
+  margin-top 5px
+  border 2px solid gray-lighter-color
+  min-height 40px
+  &.is-focus
+    border-color purple-color
+  .bordered-input
+    border none
+    padding 0
+  .remove-button
+    height 20px
+    width 15px
+    background transparent center center no-repeat url(/icons/remove.svg)
+    background-size 8px
+    &:hover
+      background-image url(/icons/remove_r.svg)
+  .twitter-typeahead
+    width initial
+    flex 1
+    position static !important
+    input
+      background none transparent
+      margin 0
+  .tt-dropdown-menu
+    top calc(100% \+ 2px) !important
+    right 0px !important
+    left -2px !important
+    min-width calc(100% \+ 4px)
+.admin-form-container .autocomplete-container--inline .autocomplete-select-selected
+  width initial
+  background gray-lighter-color
+  color black
+  margin 0 10px 5px 0px
+  border-radius 2px
+  line-height 1em
+  padding 2px 20px 1px 4px
+  text-transform capitalize

--- a/client/components/autocomplete_list/index.coffee
+++ b/client/components/autocomplete_list/index.coffee
@@ -23,6 +23,7 @@ module.exports = AutocompleteList = React.createClass
     if @props.idsToFetch?.length > 0
       fetchedItems = []
       async.each @props.idsToFetch, (id, cb) =>
+        id = id.replace(' ', '%20')
         request
           .get(@props.fetchUrl(id))
           .set('X-Access-Token': sd.USER?.access_token)
@@ -30,7 +31,7 @@ module.exports = AutocompleteList = React.createClass
             fetchedItems.push(@props.resObject(res))
             cb()
       , =>
-        @setState loading: false, items: fetchedItems
+        @setState loading: false, items: _.compact fetchedItems
     else
       @setState loading: false
 

--- a/client/components/autocomplete_list/index.coffee
+++ b/client/components/autocomplete_list/index.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore'
 React = require 'react'
 ReactDOM = require 'react-dom'
 Autocomplete = null
-{ label, input, div, button } = React.DOM
+{ label, input, div, button, span } = React.DOM
 sd = require('sharify').data
 async = require 'async'
 request = require 'superagent'
@@ -13,6 +13,7 @@ module.exports = AutocompleteList = React.createClass
   getInitialState: ->
     loading: true
     items: []
+    focus: false
 
   componentDidMount: ->
     @$input = $(ReactDOM.findDOMNode(this)).find('.autocomplete-input')
@@ -59,33 +60,51 @@ module.exports = AutocompleteList = React.createClass
     @$input.on 'typeahead:selected', @onSelect
 
   onSelect: (e, item) ->
-    @setState items: _.uniq @state.items.concat [item]
-    @props.selected? e, item, @state.items
-    @$input.val('')
+    items = _.reject(@state.items, (i) -> i.id is item.id).concat [item]
+    unless items.length and items.length is @state.items.length
+      @props.selected? e, item, items
+      @setState items: items
+    @$input.typeahead('val', '')
 
   onBlur: ->
-    @$input.val('')
+    @setState focus: false
+    @$input.typeahead('val', '')
+
+  onFocus: ->
+    @setState focus: true
 
   removeItem: (item) -> (e) =>
     e.preventDefault()
     @$input.typeahead('destroy')?.val('')
-    newItems = _.reject(@state.items, (i) -> i.id is item.id)
-    @setState items: _.uniq newItems
-    @props.removed? e, item, newItems
+    items = _.reject(@state.items, (i) -> i.id is item.id)
+    @setState items: _.uniq items
+    @props.removed? e, item, items
     @addAutocomplete()
+    @$input.focus()
+
+  printItems: ->
+    for item, i in @state.items
+      div { className: 'autocomplete-select-selected', key: 'selected-' + item.id },
+        span {className: 'selected' }, item.value
+        input { type: 'hidden', value: item.id, name: @props.name }
+        button { className: 'remove-button', onClick: @removeItem(item) }
 
   render: ->
-    div { className: 'autocomplete-container' },
+    inline = if @props.inline then ' autocomplete-container--inline' else ''
+    focus = if @props.inline and @state.focus then ' is-focus' else ''
+
+    div { className: 'autocomplete-container' + inline + focus},
       (
-        div { className: 'autocomplete-selected'},
-          for item in @state.items
-            div { className: 'autocomplete-select-selected', key: 'selected-' + item.value }, item.value,
-              input { type: 'hidden', value: item.id, name: @props.name }
-              button { className: 'remove-button', onClick: @removeItem(item) }
+        if @props.inline
+          @printItems()
+        else
+          div { className: 'autocomplete-selected'},
+            @printItems()
       )
       input {
         className: 'bordered-input autocomplete-input'
-        placeholder: @props.placeholder
+        placeholder: if @state.items.length and @props.inline then '' else @props.placeholder
         onBlur: @onBlur
         disabled: @props.disabled
+        onFocus: @onFocus
       }

--- a/client/components/autocomplete_list/index.coffee
+++ b/client/components/autocomplete_list/index.coffee
@@ -59,7 +59,7 @@ module.exports = AutocompleteList = React.createClass
     @$input.on 'typeahead:selected', @onSelect
 
   onSelect: (e, item) ->
-    @setState items: @state.items.concat [item]
+    @setState items: _.uniq @state.items.concat [item]
     @props.selected? e, item, @state.items
     @$input.val('')
 
@@ -70,7 +70,7 @@ module.exports = AutocompleteList = React.createClass
     e.preventDefault()
     @$input.typeahead('destroy')?.val('')
     newItems = _.reject(@state.items, (i) -> i.id is item.id)
-    @setState items: newItems
+    @setState items: _.uniq newItems
     @props.removed? e, item, newItems
     @addAutocomplete()
 
@@ -79,7 +79,7 @@ module.exports = AutocompleteList = React.createClass
       (
         div { className: 'autocomplete-selected'},
           for item in @state.items
-            div { className: 'autocomplete-select-selected', key: item.value }, item.value,
+            div { className: 'autocomplete-select-selected', key: 'selected-' + item.value }, item.value,
               input { type: 'hidden', value: item.id, name: @props.name }
               button { className: 'remove-button', onClick: @removeItem(item) }
       )

--- a/client/components/autocomplete_list/index.coffee
+++ b/client/components/autocomplete_list/index.coffee
@@ -24,7 +24,6 @@ module.exports = AutocompleteList = React.createClass
     if @props.idsToFetch?.length > 0
       fetchedItems = []
       async.each @props.idsToFetch, (id, cb) =>
-        id = id.replace(' ', '%20')
         request
           .get(@props.fetchUrl(id))
           .set('X-Access-Token': sd.USER?.access_token)
@@ -76,9 +75,9 @@ module.exports = AutocompleteList = React.createClass
   removeItem: (item) -> (e) =>
     e.preventDefault()
     @$input.typeahead('destroy')?.val('')
-    items = _.reject(@state.items, (i) -> i.id is item.id)
-    @setState items: _.uniq items
-    @props.removed? e, item, items
+    newItems = _.reject(@state.items, (i) -> i.id is item.id)
+    @setState items: _.uniq newItems
+    @props.removed? e, item, newItems
     @addAutocomplete()
     @$input.focus()
 

--- a/client/components/autocomplete_list/test/index.coffee
+++ b/client/components/autocomplete_list/test/index.coffee
@@ -17,11 +17,11 @@ describe 'AutocompleteList', ->
           ttAdapter: ->
         )
       $.fn.typeahead = sinon.stub()
-      AutocompleteList = benv.require resolve __dirname, '../index'
-      AutocompleteList.__set__ 'request', get: sinon.stub().returns
+      @AutocompleteList = benv.require resolve __dirname, '../index'
+      @AutocompleteList.__set__ 'request', get: sinon.stub().returns
         set: sinon.stub().returns
           end: sinon.stub().yields(null, { id: '123', value: 'Andy Warhol'})
-      props =
+      @props =
         url: 'https://api.artsy.net/search?term=%QUERY'
         placeholder: 'Search for an artist...'
         filter: @filter = sinon.stub()
@@ -30,10 +30,10 @@ describe 'AutocompleteList', ->
         idsToFetch: ['123']
         fetchUrl: (id) -> 'https://api.artsy.net/search/' + id
         resObject: (res) -> id: res.id, value: res.value
-      @rendered = ReactDOMServer.renderToString React.createElement(AutocompleteList, props)
-      @component = ReactDOM.render React.createElement(AutocompleteList, props), (@$el = $ "<div></div>")[0], => setTimeout =>
-          @setState = sinon.stub @component, 'setState'
-          done()
+      @rendered = ReactDOMServer.renderToString React.createElement(@AutocompleteList, @props)
+      @component = ReactDOM.render React.createElement(@AutocompleteList, @props), (@$el = $ "<div></div>")[0], => setTimeout =>
+        @setState = sinon.stub @component, 'setState'
+        done()
 
   afterEach ->
     benv.teardown()
@@ -55,3 +55,8 @@ describe 'AutocompleteList', ->
     @component.removeItem({ id: '123', value: 'Andy Warhol' })({preventDefault: ->})
     @setState.args[0][0].items.length.should.equal 0
     @removed.callCount.should.equal 1
+
+  it 'Accepts an inline option', ->
+    @props.inline = true
+    rendered = ReactDOMServer.renderToString React.createElement(@AutocompleteList, @props)
+    rendered.should.containEql 'autocomplete-container--inline'

--- a/client/models/vertical.coffee
+++ b/client/models/vertical.coffee
@@ -1,0 +1,6 @@
+Backbone = require 'backbone'
+sd = require('sharify').data
+
+module.exports = class Vertical extends Backbone.Model
+
+  urlRoot: "#{sd.API_URL}/verticals"

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -16,6 +16,7 @@ module.exports = ->
     tier: 1,
     vertical: {name: 'Culture', id: '55356a9deca560a0137bb4a7'}
     tags: ['Fair Coverage', 'Magazine']
+    tracking_tags: ['Newsfeed', 'Video']
     title: 'Top Ten Booths',
     lead_paragraph: '<p>Just before the lines start forming...</p>',
     description: 'Just before the lines start forming, we predict where they will go.',


### PR DESCRIPTION
- Finalizes component for new verticals/tags/tracking_tags
      * this component is not yet used, we still need to turn it on after the backfill is finished!
- Adds 'inline' option to AutocompleteList
- Adds `tracking_tags` to article model
- Adds come logic to AutocompleteList to avoid duplicate entries

![tag-admin](https://cloud.githubusercontent.com/assets/1497424/26174796/850f5b78-3b1e-11e7-8778-7fc43d0f087e.gif)

