### PR TITLE
@kanaabe => Strip old author fields

### DIFF
--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -60,6 +60,7 @@ convertSections = (article, callback) ->
         else
           cb()
   , =>
+    convertAuthor(article)
     callback()
   )
 
@@ -118,3 +119,11 @@ convertArtworks = (section, callback) ->
     section.set image
     callback()
   )
+
+convertAuthor = (article) ->
+  if article.get('author')?.profile_id or article.get('author')?.profile_handle
+    author = {
+      id: article.get('author').id
+      name: article.get('author').name
+    }
+    article.set 'author', author

--- a/client/apps/edit/test/client.coffee
+++ b/client/apps/edit/test/client.coffee
@@ -14,12 +14,14 @@ describe 'init', ->
       onload: ->
       width: 120
       height: 90
+    @article = fixtures().articles
+    @article.author = {id: '123', name: 'Artsy Editorial', profile_id: '123', profile_handle: 'Artsy'}
     benv.setup =>
       benv.expose
         _: require('underscore')
         $: benv.require('jquery')
         jQuery: benv.require('jquery')
-        sd: { ARTICLE: fixtures().articles }
+        sd: { ARTICLE: @article }
       window.jQuery = jQuery
       @client = rewire '../client.coffee'
       @client.__set__ 'EditLayout', @EditLayout = sinon.stub()
@@ -80,4 +82,10 @@ describe 'init', ->
       @client.article.sections.models[6].get('images')[0].height.should.equal 90
       @client.article.sections.models[6].get('images')[1].height.should.equal 90
       @client.article.sections.models[6].get('images')[1].height.should.equal 90
+      done()
+
+  it 'strips profile_id and profile_handle from authors', (done) ->
+    @client.init()
+    _.defer =>
+      @client.article.get('author').should.eql {id: '123', name: 'Artsy Editorial'}
       done()


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1048
Checks if author has outdated fields `profile_id` or `profile_handle`, and strips them if present. 
Put this on the client side so all article conversion would be in the same place. 