### PR TITLE
@kanaabe => Tagging admin QA

### DIFF
--- a/api/apps/tags/model.coffee
+++ b/api/apps/tags/model.coffee
@@ -26,7 +26,7 @@ Joi.objectId = require('joi-objectid') Joi
   offset: @number()
   count: @boolean().default(false)
   public: @boolean()
-  safe: @boolean().default(false)
+  strict: @boolean().default(false)
 ).call Joi
 
 #
@@ -39,8 +39,8 @@ Joi.objectId = require('joi-objectid') Joi
 @where = (input, callback) ->
   Joi.validate input, @querySchema, (err, input) =>
     return callback err if err
-    query = _.omit input, 'q', 'limit', 'offset', 'count', 'safe'
-    if input.safe
+    query = _.omit input, 'q', 'limit', 'offset', 'count', 'strict'
+    if input.strict
       query.name = { $eq: input.q } if input.q and input.q.length
     else
       query.name = { $regex: ///#{input.q}///i } if input.q and input.q.length

--- a/api/apps/tags/model.coffee
+++ b/api/apps/tags/model.coffee
@@ -26,6 +26,7 @@ Joi.objectId = require('joi-objectid') Joi
   offset: @number()
   count: @boolean().default(false)
   public: @boolean()
+  safe: @boolean().default(false)
 ).call Joi
 
 #
@@ -38,8 +39,11 @@ Joi.objectId = require('joi-objectid') Joi
 @where = (input, callback) ->
   Joi.validate input, @querySchema, (err, input) =>
     return callback err if err
-    query = _.omit input, 'q', 'limit', 'offset', 'count'
-    query.name = { $regex: ///#{input.q}///i } if input.q and input.q.length
+    query = _.omit input, 'q', 'limit', 'offset', 'count', 'safe'
+    if input.safe
+      query.name = { $eq: input.q } if input.q and input.q.length
+    else
+      query.name = { $regex: ///#{input.q}///i } if input.q and input.q.length
     cursor = db.tags
       .find(query)
       .limit(input.limit)

--- a/api/apps/tags/test/integration.coffee
+++ b/api/apps/tags/test/integration.coffee
@@ -29,7 +29,7 @@ describe 'tags endpoints', ->
           res.body.results[0].name.should.equal 'Asia'
           done()
 
-  it 'safe mode gets a list of tags by exact match', (done) ->
+  it 'strict mode gets a list of tags by exact match', (done) ->
     fabricate 'tags', [
       { name: 'Market' }
       { name: 'Analysis' }
@@ -37,7 +37,7 @@ describe 'tags endpoints', ->
       {}
     ], (err, tags) ->
       request
-        .get("http://localhost:5000/tags?q=Market&count=true&safe=true")
+        .get("http://localhost:5000/tags?q=Market&count=true&strict=true")
         .end (err, res) ->
           res.body.total.should.equal 4
           res.body.count.should.equal 1

--- a/api/apps/tags/test/integration.coffee
+++ b/api/apps/tags/test/integration.coffee
@@ -29,6 +29,21 @@ describe 'tags endpoints', ->
           res.body.results[0].name.should.equal 'Asia'
           done()
 
+  it 'safe mode gets a list of tags by exact match', (done) ->
+    fabricate 'tags', [
+      { name: 'Market' }
+      { name: 'Analysis' }
+      { name: 'Market Analysis' }
+      {}
+    ], (err, tags) ->
+      request
+        .get("http://localhost:5000/tags?q=Market&count=true&safe=true")
+        .end (err, res) ->
+          res.body.total.should.equal 4
+          res.body.count.should.equal 1
+          res.body.results[0].name.should.equal 'Market'
+          done()
+
   it 'gets a list of tags by publicity', (done) ->
     fabricate 'tags', [
       { name: 'Asia', public: true }

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -4,7 +4,8 @@ ReactDOM = require 'react-dom'
 _ = require 'underscore'
 
 Article = React.createFactory require './article/index.coffee'
-VerticalsTags = React.createFactory require './verticals_tags/index.coffee'
+VerticalsTags = React.createFactory require './verticals_tags/editorial.coffee'
+Tags = React.createFactory require './verticals_tags/index.coffee'
 Featuring = React.createFactory require './featuring/index.coffee'
 SuperArticle = React.createFactory require './super_article/index.coffee'
 Appearances = React.createFactory require './appearances/index.coffee'
@@ -47,17 +48,21 @@ module.exports = React.createClass
 
   render: ->
     div { className: 'edit-admin' },
-
       section {
         className: 'edit-admin--verticals-tags' + @getActiveSection 'verticals-tags'
       },
         printTitle {
-          section: 'Verticals & Tagging'
+          section: if sd.CURRENT_CHANNEL.type is 'editorial' then 'Verticals & Tagging' else 'Tagging'
           className: 'verticals-tags'
           onClick: @setActiveSection
         }
-        if @isActiveSection 'verticals-tags'
+        if sd.CURRENT_CHANNEL.type is 'editorial' and @isActiveSection 'verticals-tags'
           VerticalsTags {
+            article: @props.article
+            onChange: @onChange
+          }
+        else if @isActiveSection 'verticals-tags'
+          Tags {
             article: @props.article
             onChange: @onChange
           }

--- a/client/apps/edit/components/admin/index.coffee
+++ b/client/apps/edit/components/admin/index.coffee
@@ -52,11 +52,11 @@ module.exports = React.createClass
         className: 'edit-admin--verticals-tags' + @getActiveSection 'verticals-tags'
       },
         printTitle {
-          section: if sd.CURRENT_CHANNEL.type is 'editorial' then 'Verticals & Tagging' else 'Tagging'
+          section: if @props.channel.isEditorial() then 'Verticals & Tagging' else 'Tagging'
           className: 'verticals-tags'
           onClick: @setActiveSection
         }
-        if sd.CURRENT_CHANNEL.type is 'editorial' and @isActiveSection 'verticals-tags'
+        if @props.channel.isEditorial() and @isActiveSection 'verticals-tags'
           VerticalsTags {
             article: @props.article
             onChange: @onChange

--- a/client/apps/edit/components/admin/test/index.coffee
+++ b/client/apps/edit/components/admin/test/index.coffee
@@ -35,9 +35,9 @@ describe 'AdminSections', ->
       @AdminSections.__set__ 'VerticalsTags', @VerticalsTags = sinon.stub()
       @AdminSections.__set__ 'Tags', @Tags = sinon.stub()
       @channel = {id: '123'}
+      @channel.isEditorial = sinon.stub().returns false
       @channel.hasFeature = sinon.stub().returns false
-      @article = new Article
-      @article.attributes = fixtures().articles
+      @article = new Article fixtures().articles
       @props = {
         article: @article
         channel: @channel
@@ -65,11 +65,7 @@ describe 'AdminSections', ->
     @VerticalsTags.callCount.should.eql 0
 
   it 'Renders the verticals panel if channel is editorial', ->
-    @AdminSections.__set__ 'sd', {
-      API_URL: 'http://localhost:3005/api'
-      CURRENT_CHANNEL: id: '123', type: 'editorial'
-      USER: access_token: ''
-    }
+    @channel.isEditorial = sinon.stub().returns true
     render = ReactDOMServer.renderToString React.createElement(@AdminSections, @props)
     render.should.containEql 'Verticals &amp; Tagging'
     @VerticalsTags.called.should.eql true

--- a/client/apps/edit/components/admin/test/verticals_tags.coffee
+++ b/client/apps/edit/components/admin/test/verticals_tags.coffee
@@ -27,7 +27,7 @@ describe 'AdminVerticalsTags', ->
         _: benv.require 'underscore'
       window.jQuery = $
       $.fn.typeahead = sinon.stub()
-      @AdminVerticalsTags = benv.require resolve __dirname, '../verticals_tags/index.coffee'
+      @AdminVerticalsTags = benv.require resolve __dirname, '../verticals_tags/editorial.coffee'
       @AdminVerticalsTags.__set__ 'sd', {
         API_URL: 'http://localhost:3005/api'
         CURRENT_CHANNEL: id: '123'
@@ -96,3 +96,65 @@ describe 'AdminVerticalsTags', ->
       @component.state.vertical.should.eql { name: 'Art', id: '1' }
       @component.props.onChange.args[0][0].should.eql 'vertical'
       @component.props.onChange.args[0][1].should.eql { name: 'Art', id: '1' }
+
+    it 'Unsets the vertical if already selected', ->
+      @component.setState vertical: { id: '1', name: 'Art'}
+      r.simulate.click r.find(@component, 'avant-garde-button')[0]
+      @component.props.onChange.args[0].should.eql [ 'vertical', null ]
+
+describe 'AdminTags', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose
+        $: benv.require 'jquery'
+        _: benv.require 'underscore'
+        _s: benv.require 'underscore.string'
+      window.jQuery = $
+      @AdminTags = benv.require resolve __dirname, '../verticals_tags/index.coffee'
+      @AdminTags.__set__ 'sd', {}
+      @article = new Article
+      @article.attributes = fixtures().articles
+      @article.set 'tags', ['Artists']
+      @article.set 'tracking_tags', ['op-ed', 'profile']
+      props = {
+        article: @article
+        onChange: sinon.stub()
+      }
+      sinon.stub Backbone, 'sync'
+      @component = ReactDOM.render React.createElement(@AdminTags, props), (@$el = $ "<div></div>")[0], =>
+        setTimeout =>
+          done()
+
+  afterEach ->
+    Backbone.sync.restore()
+    benv.teardown()
+
+  describe 'Topic Tags', ->
+
+    it 'Renders text input', ->
+      $(ReactDOM.findDOMNode(@component)).find('input[name=tags]').prop('placeholder').should.eql 'Start typing a topic tag...'
+
+    it 'Renders saved tags', ->
+      $(ReactDOM.findDOMNode(@component)).find('input[name=tags]').val().should.eql 'Artists'
+
+    it 'Calls onChange with user input', ->
+      input = r.find(@component, 'bordered-input')[0]
+      input.value = 'new, tags'
+      r.simulate.change input
+      @component.props.onChange.args[0][1].should.eql [ 'new', 'tags' ]
+
+  describe 'Tracking Tags', ->
+
+    it 'Renders text input', ->
+      $(ReactDOM.findDOMNode(@component)).find('input[name=tracking_tags]').prop('placeholder').should.eql 'Start typing a tracking tag...'
+
+    it 'Renders saved tags', ->
+      $(ReactDOM.findDOMNode(@component)).find('input[name=tracking_tags]').val()
+      $(ReactDOM.findDOMNode(@component)).find('input[name=tracking_tags]').val().should.eql 'op-ed, profile'
+
+    it 'Calls onChange with user input', ->
+      input = r.find(@component, 'bordered-input')[1]
+      input.value = 'new, tags'
+      r.simulate.change input
+      @component.props.onChange.args[0][1].should.eql [ 'new', 'tags' ]

--- a/client/apps/edit/components/admin/test/verticals_tags.coffee
+++ b/client/apps/edit/components/admin/test/verticals_tags.coffee
@@ -38,7 +38,10 @@ describe 'AdminVerticalsTags', ->
         set: sinon.stub().returns
           end: sinon.stub().yields(null, body: {results: [{ id: '123', name: 'Artists'}]})
       @AdminVerticalsTags.__set__ 'AutocompleteList', React.createFactory AutocompleteList
-      @article = new Article
+      @article = new Article _.extend fixtures().articles,
+        tags: ['Artists']
+        tracking_tags: []
+        vertical: {}
       @Verticals = new Verticals([
         { id: '1', name: 'Art'}
         { id: '2', name: 'Art Market'}
@@ -46,10 +49,6 @@ describe 'AdminVerticalsTags', ->
         { id: '4', name: 'Culture'}
       ])
       _.first = sinon.stub().returns new Vertical({ id: '1', name: 'Art'})
-      @article.attributes = fixtures().articles
-      @article.set 'tags', ['Artists']
-      @article.set 'tracking_tags', []
-      @article.set 'vertical', {}
       props = {
         article: @article
         onChange: sinon.stub()
@@ -113,10 +112,9 @@ describe 'AdminTags', ->
       window.jQuery = $
       @AdminTags = benv.require resolve __dirname, '../verticals_tags/index.coffee'
       @AdminTags.__set__ 'sd', {}
-      @article = new Article
-      @article.attributes = fixtures().articles
-      @article.set 'tags', ['Artists']
-      @article.set 'tracking_tags', ['op-ed', 'profile']
+      @article = new Article _.extend fixtures().articles,
+        tags: ['Artists']
+        tracking_tags: ['op-ed', 'profile']
       props = {
         article: @article
         onChange: sinon.stub()
@@ -142,7 +140,7 @@ describe 'AdminTags', ->
       input = r.find(@component, 'bordered-input')[0]
       input.value = 'new, tags'
       r.simulate.change input
-      @component.props.onChange.args[0][1].should.eql [ 'new', 'tags' ]
+      @component.props.onChange.args[0].should.eql [ 'tags', [ 'new', 'tags' ] ]
 
   describe 'Tracking Tags', ->
 
@@ -157,4 +155,4 @@ describe 'AdminTags', ->
       input = r.find(@component, 'bordered-input')[1]
       input.value = 'new, tags'
       r.simulate.change input
-      @component.props.onChange.args[0][1].should.eql [ 'new', 'tags' ]
+      @component.props.onChange.args[0].should.eql [ 'tracking_tags', [ 'new', 'tags' ] ]

--- a/client/apps/edit/components/admin/verticals_tags/editorial.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/editorial.coffee
@@ -69,7 +69,7 @@ module.exports = React.createClass
             removed: (e, item, items) =>
               newTags = _.without @props.article.get('tags'), item.value
               @props.onChange 'tags', newTags
-            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=true&q=#{name}&safe=true"
+            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=true&q=#{name}&strict=true"
             resObject: (res) ->
               return unless res.body.results.length
               id: res.body.results[0].id, value: "#{res.body.results[0].name}"
@@ -91,7 +91,7 @@ module.exports = React.createClass
             removed: (e, item, items) =>
               newTags = _.without @props.article.get('tracking_tag'), item.value
               @props.onChange 'tracking_tags', newTags
-            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=false&q=#{name}&safe=true"
+            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=false&q=#{name}&strict=true"
             resObject: (res) ->
               return unless res.body.results.length
               id: res.body.results[0].id, value: "#{res.body.results[0].name}"

--- a/client/apps/edit/components/admin/verticals_tags/editorial.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/editorial.coffee
@@ -1,0 +1,98 @@
+React = require 'react'
+ReactDOM = require 'react-dom'
+Verticals = require '../../../../../collections/verticals.coffee'
+AutocompleteList = React.createFactory require '../../../../../components/autocomplete_list/index.coffee'
+{ div, section, label, button, input } = React.DOM
+
+module.exports = React.createClass
+  displayName: 'AdminVerticalsTags'
+
+  getInitialState: ->
+    vertical: null or @props.article.get('vertical')
+    verticals: []
+
+  componentDidMount: ->
+    ReactDOM.findDOMNode(@refs.container).classList += ' active'
+    @fetchVerticals()
+
+  fetchVerticals: ->
+    new Verticals().fetch
+      cache: true
+      success: (verticals) =>
+        sortedVerticals = verticals.sortBy('name')
+        @setState verticals: sortedVerticals
+
+  printVerticals: (verticals, handleToggle) ->
+    verticals.map (vertical, i) =>
+      active = ''
+      if @state.vertical?.name is vertical.get 'name'
+        active = ' avant-garde-button-black'
+      button {
+        key: i
+        name: vertical.get 'name'
+        onClick: handleToggle
+        className: 'avant-garde-button' + active
+      }, vertical.get 'name'
+    , @
+
+  verticalToggle: (e) ->
+    verticals = new Verticals @state.verticals
+    active = _.first verticals.where name: e.target.name
+    newVertical =
+      name: active.get 'name'
+      id: active.get 'id'
+    newVertical = null if newVertical.name is @state.vertical?.name
+    @setState vertical: newVertical
+    @props.onChange('vertical', newVertical)
+
+  render: ->
+    section { className: 'edit-admin--verticals-tags edit-admin__fields', ref: 'container'},
+      div {className: 'fields-left'},
+        div { className: 'field-group' },
+          label {}, 'Editorial Vertical'
+          @printVerticals @state.verticals, @verticalToggle
+
+      div {className: 'fields-right'},
+        div {className: 'field-group'},
+          label {}, 'Topic Tags'
+          AutocompleteList {
+            url: "#{sd.API_URL}/tags?public=true&q=%QUERY"
+            placeholder: 'Start typing a topic tag...'
+            idsToFetch: @props.article.get 'tags'
+            inline: true
+            filter: (tags) ->
+              for tag in tags.results
+                { id: tag.id, value: "#{tag.name}"}
+            selected: (e, item, items) =>
+              newTags = _.pluck items, 'value'
+              @props.onChange 'tags', newTags
+            removed: (e, item, items) =>
+              newTags = _.without @props.article.get('tags'), item.value
+              @props.onChange 'tags', newTags
+            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=true&q=#{name}"
+            resObject: (res) ->
+              return unless res.body.results.length
+              id: res.body.results[0].id, value: "#{res.body.results[0].name}"
+          }
+
+        div {className: 'field-group'},
+          label {}, 'Tracking Tags'
+          AutocompleteList {
+            url: "#{sd.API_URL}/tags?public=false&q=%QUERY"
+            placeholder: 'Start typing a tracking tag...'
+            idsToFetch: @props.article.get 'tracking_tags'
+            inline: true
+            filter: (tracking_tags) ->
+              for tracking_tag in tracking_tags.results
+                { id: tracking_tag.id, value: "#{tracking_tag.name}"}
+            selected: (e, item, items) =>
+              newTags = _.pluck items, 'value'
+              @props.onChange 'tracking_tags', newTags
+            removed: (e, item, items) =>
+              newTags = _.without @props.article.get('tracking_tags'), item.value
+              @props.onChange 'tracking_tags', newTags
+            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=false&q=#{name}"
+            resObject: (res) ->
+              return unless res.body.results.length
+              id: res.body.results[0].id, value: "#{res.body.results[0].name}"
+          }

--- a/client/apps/edit/components/admin/verticals_tags/editorial.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/editorial.coffee
@@ -64,12 +64,12 @@ module.exports = React.createClass
               for tag in tags.results
                 { id: tag.id, value: "#{tag.name}"}
             selected: (e, item, items) =>
-              newTags = _.pluck items, 'value'
+              newTags = _.union @props.article.get('tags'), _.pluck(items, 'value')
               @props.onChange 'tags', newTags
             removed: (e, item, items) =>
               newTags = _.without @props.article.get('tags'), item.value
               @props.onChange 'tags', newTags
-            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=true&q=#{name}"
+            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=true&q=#{name}&safe=true"
             resObject: (res) ->
               return unless res.body.results.length
               id: res.body.results[0].id, value: "#{res.body.results[0].name}"
@@ -86,12 +86,12 @@ module.exports = React.createClass
               for tracking_tag in tracking_tags.results
                 { id: tracking_tag.id, value: "#{tracking_tag.name}"}
             selected: (e, item, items) =>
-              newTags = _.pluck items, 'value'
+              newTags = _.union @props.article.get('tracking_tag'), _.pluck(items, 'value')
               @props.onChange 'tracking_tags', newTags
             removed: (e, item, items) =>
-              newTags = _.without @props.article.get('tracking_tags'), item.value
+              newTags = _.without @props.article.get('tracking_tag'), item.value
               @props.onChange 'tracking_tags', newTags
-            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=false&q=#{name}"
+            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=false&q=#{name}&safe=true"
             resObject: (res) ->
               return unless res.body.results.length
               id: res.body.results[0].id, value: "#{res.body.results[0].name}"

--- a/client/apps/edit/components/admin/verticals_tags/index.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/index.coffee
@@ -1,97 +1,39 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
-Verticals = require '../../../../../collections/verticals.coffee'
-AutocompleteList = React.createFactory require '../../../../../components/autocomplete_list/index.coffee'
-{ div, section, label, button, input } = React.DOM
+_ = require 'underscore'
+_s = require 'underscore.string'
+{ div, section, label, input } = React.DOM
 
 module.exports = React.createClass
-  displayName: 'AdminVerticalsTags'
-
-  getInitialState: ->
-    vertical: null or @props.article.get('vertical')
-    verticals: []
+  displayName: 'AdminTags'
 
   componentDidMount: ->
     ReactDOM.findDOMNode(@refs.container).classList += ' active'
-    @fetchVerticals()
 
-  fetchVerticals: ->
-    new Verticals().fetch
-      cache: true
-      success: (verticals) =>
-        sortedVerticals = verticals.sortBy('name')
-        @setState verticals: sortedVerticals
-
-  printVerticals: (verticals, handleToggle) ->
-    verticals.map (vertical, i) =>
-      active = ''
-      if @state.vertical?.name is vertical.get 'name'
-        active = ' avant-garde-button-black'
-      button {
-        key: i
-        name: vertical.get 'name'
-        onClick: handleToggle
-        className: 'avant-garde-button' + active
-      }, vertical.get 'name'
-    , @
-
-  verticalToggle: (e) ->
-    verticals = new Verticals @state.verticals
-    active = _.first verticals.where name: e.target.name
-    newVertical =
-      name: active.get 'name'
-      id: active.get 'id'
-    @setState vertical: newVertical
-    @props.onChange('vertical', newVertical)
+  onChange: (e) ->
+    tagsArray = e.target.value.split(",").map (tag) -> _s.clean(tag)
+    tagsArray = if tagsArray.length is 0 then [] else tagsArray.filter(Boolean)
+    @props.onChange e.target.name, _.uniq(tagsArray)
 
   render: ->
     section { className: 'edit-admin--verticals-tags edit-admin__fields', ref: 'container'},
-      div {className: 'fields-left'},
-        div { className: 'field-group' },
-          label {}, 'Editorial Vertical'
-          @printVerticals @state.verticals, @verticalToggle
-
       div {className: 'fields-right'},
         div {className: 'field-group'},
           label {}, 'Topic Tags'
-          AutocompleteList {
-            url: "#{sd.API_URL}/tags?public=true&q=%QUERY"
+          input {
+            className: 'bordered-input'
             placeholder: 'Start typing a topic tag...'
-            idsToFetch: @props.article.get 'tags'
-            inline: true
-            filter: (tags) ->
-              for tag in tags.results
-                { id: tag.id, value: "#{tag.name}"}
-            selected: (e, item, items) =>
-              newTags = _.pluck items, 'value'
-              @props.onChange 'tags', newTags
-            removed: (e, item, items) =>
-              newTags = _.without @props.article.get('tags'), item.value
-              @props.onChange 'tags', newTags
-            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=true&q=#{name}"
-            resObject: (res) ->
-              return unless res.body.results.length
-              id: res.body.results[0].id, value: "#{res.body.results[0].name}"
+            defaultValue: @props.article.get('tags')?.join(', ') or ''
+            name: 'tags'
+            onChange: @onChange
           }
-
+      div {className: 'fields-left'},
         div {className: 'field-group'},
           label {}, 'Tracking Tags'
-          AutocompleteList {
-            url: "#{sd.API_URL}/tags?public=false&q=%QUERY"
+          input {
+            className: 'bordered-input'
             placeholder: 'Start typing a tracking tag...'
-            idsToFetch: @props.article.get 'tracking_tags'
-            inline: true
-            filter: (tracking_tags) ->
-              for tracking_tag in tracking_tags.results
-                { id: tracking_tag.id, value: "#{tracking_tag.name}"}
-            selected: (e, item, items) =>
-              newTags = _.pluck items, 'value'
-              @props.onChange 'tracking_tags', newTags
-            removed: (e, item, items) =>
-              newTags = _.without @props.article.get('tracking_tags'), item.value
-              @props.onChange 'tracking_tags', newTags
-            fetchUrl: (name) -> "#{sd.API_URL}/tags?public=false&q=#{name}"
-            resObject: (res) ->
-              return unless res.body.results.length
-              id: res.body.results[0].id, value: "#{res.body.results[0].name}"
+            defaultValue: @props.article.get('tracking_tags')?.join(', ') or ''
+            name: 'tracking_tags'
+            onChange: @onChange
           }


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1053
- Adds tags-only component for non-editorial admin panel
- Allows verticals to be unset
- Adds safe mode to tag query api for exact name match
- Kills problem of tags surfacing with partial name match
- Does not remove tags that are not in DB