### PR TITLE
@craigspaeth => Drag & drop sections

### DIFF
--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -30,7 +30,7 @@ async = require 'async'
       $('#edit-admin')[0]
     )
     ReactDOM.render(
-      SectionList(sections: @article.sections)
+      SectionList(sections: @article.sections, article: @article)
       $('#edit-sections')[0]
     )
     ReactDOM.render(

--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -30,7 +30,7 @@ async = require 'async'
       $('#edit-admin')[0]
     )
     ReactDOM.render(
-      SectionList(sections: @article.sections, article: @article)
+      SectionList(sections: @article.sections)
       $('#edit-sections')[0]
     )
     ReactDOM.render(

--- a/client/apps/edit/components/hero_section/index.coffee
+++ b/client/apps/edit/components/hero_section/index.coffee
@@ -36,4 +36,5 @@ module.exports = React.createClass
         section: @props.section
         editing: @state.editing
         onSetEditing: @onSetEditing
+        isHero: true
       }

--- a/client/apps/edit/components/layout/index.styl
+++ b/client/apps/edit/components/layout/index.styl
@@ -26,6 +26,19 @@
     polygon
       fill white !important
 
+.edit-section-drag
+  position absolute
+  top -(section-tool-size / 2)
+  left -(section-tool-size / 2)
+  background-color gray-color
+  z-index 2
+  width section-tool-size
+  height section-tool-size
+  border-radius 50%
+  svg
+    width section-tool-size
+    fill-color white
+
 // Fields with red asktericks
 .edit-required
   &::after

--- a/client/apps/edit/components/section_container/icons.jade
+++ b/client/apps/edit/components/section_container/icons.jade
@@ -1,2 +1,5 @@
 .remove
   include ../../public/icons/edit_section_remove.svg
+
+.draggable
+  include ../../public/icons/edit_draggable.svg

--- a/client/apps/edit/components/section_container/index.coffee
+++ b/client/apps/edit/components/section_container/index.coffee
@@ -50,7 +50,8 @@ module.exports = React.createClass
     dragOverID = $dragOver.data('id')
     dragOverTop = $dragOver.position().top + 20 - window.scrollY
     dragOverCenter = dragOverTop + ($dragOver.height() / 2)
-    if mousePosition > dragOverCenter and dragOverID is !@props.sections.length or dragOverID is @props.dragging + 1
+    if mousePosition > dragOverCenter and dragOverID is !@props.sections.length or
+     dragOverID is @props.dragging + 1
       @setState dropPosition: 'bottom'
     else
       @setState dropPosition: 'top'
@@ -64,14 +65,21 @@ module.exports = React.createClass
           style: height: @props.draggingHeight
         }
 
-  render: ->
-    div {
+  getContainerProps: ->
+    props = {}
+    unless @props.isHero
+      props = {
         draggable: !@props.editing
         onDragStart: @onDragStart
         onDragEnd: @props.onDragEnd
         onDragOver: @onDragOver
-      },
-      if @state.dropPosition is 'top'
+        style: {'opacity': .65} if @props.dragging is @props.index
+      }
+    return props
+
+  render: ->
+    div @getContainerProps(),
+      if @state.dropPosition is 'top' and !@props.isHero
         @printDropPlaceholder()
       div {
         className: 'edit-section-container'
@@ -79,21 +87,23 @@ module.exports = React.createClass
         'data-type': @props.section.get('type')
         'data-layout': @props.section.get('layout')
         'data-id': @props.index
-        'data-dragging': @props.dragging is @props.index
+        'data-dragging': if @props.isHero then false else (@props.dragging is @props.index)
       },
-        div {
-          className: 'edit-section-hover-controls'
-          onClick: @setEditing(on)
-        },
-          button {
-            className: "edit-section-drag button-reset #{'is-hidden' if @props.section.get('type') is 'fullscreen'}"
-            dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
-          }
-          button {
-            className: "edit-section-remove button-reset #{'is-hidden' if @props.section.get('type') is 'fullscreen'}"
-            onClick: @removeSection
-            dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
-          }
+        unless @props.section.get('type') is 'fullscreen'
+          div {
+            className: 'edit-section-hover-controls'
+            onClick: @setEditing(on)
+          },
+            unless @props.isHero
+              button {
+                className: "edit-section-drag button-reset"
+                dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
+              }
+            button {
+              className: "edit-section-remove button-reset"
+              onClick: @removeSection
+              dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
+            }
         (switch @props.section.get('type')
           when 'text' then SectionText
           when 'video' then SectionVideo
@@ -120,6 +130,6 @@ module.exports = React.createClass
         if @props.section.get('type') is 'fullscreen'
           div { className: 'edit-section-container-block' }
       )
-      if @state.dropPosition is 'bottom'
+      if @state.dropPosition is 'bottom' and !@props.isHero
         @printDropPlaceholder()
 

--- a/client/apps/edit/components/section_container/index.coffee
+++ b/client/apps/edit/components/section_container/index.coffee
@@ -41,29 +41,39 @@ module.exports = React.createClass
     @props.section.destroy()
 
   onDragStart: (e) ->
-    dragStart = e.clientY - ($(e.currentTarget).position().top - window.scrollY)
-    @props.onDragStart e, dragStart
+    dragStartY = e.clientY - ($(e.currentTarget).position().top - window.scrollY)
+    @props.onDragStart e, dragStartY
 
   onDragOver: (e) ->
-    mousePosition = e.clientY - @props.dragStart
+    mouseY = e.clientY - @props.dragStartY
     $dragOver = $(e.currentTarget).find('.edit-section-container')
     dragOverID = $dragOver.data('id')
-    dragOverTop = $dragOver.position().top + 20 - window.scrollY
-    dragOverCenter = dragOverTop + ($dragOver.height() / 2)
-    if mousePosition > dragOverCenter and dragOverID is !@props.sections.length or
-     dragOverID is @props.dragging + 1
-      @setState dropPosition: 'bottom'
-    else
-      @setState dropPosition: 'top'
+    @setState
+      dropPosition: @getDropZonePosition(mouseY, $dragOver, dragOverID)
     @props.onSetDragOver dragOverID unless dragOverID is @props.dragOver
 
-  printDropPlaceholder: ->
-    if @props.dragOver is @props.index
-      unless @props.index is @props.dragging
-        div {
-          className: 'edit-section-drag-placeholder'
-          style: height: @props.draggingHeight
-        }
+  getDropZonePosition: (mouseY, $dragOver, dragOverID) ->
+    dragOverTop = $dragOver.position().top + 20 - window.scrollY
+    dragOverCenter = dragOverTop + ($dragOver.height() / 2)
+    mouseBelowCenter = mouseY > dragOverCenter and dragOverID is !@props.sections.length
+    if mouseBelowCenter or dragOverID is @props.dragging + 1
+      dropZonePosition = 'bottom'
+    else
+      dropZonePosition = 'top'
+    dropZonePosition
+
+  isDragOver: ->
+    return true if @props.dragOver is @props.index and !@props.isHero
+
+  isDragging: ->
+    return true if @props.dragging is @props.index and !@props.isHero
+
+  dropZone: ->
+    if @isDragOver() and !@isDragging()
+      div {
+        className: 'edit-section-drag-placeholder'
+        style: height: @props.draggingHeight
+      }
 
   getContainerProps: ->
     props = {}
@@ -73,21 +83,20 @@ module.exports = React.createClass
         onDragStart: @onDragStart
         onDragEnd: @props.onDragEnd
         onDragOver: @onDragOver
-        style: {'opacity': .65} if @props.dragging is @props.index
+        style: {'opacity': .65} if @isDragging()
       }
     return props
 
   render: ->
     div @getContainerProps(),
-      if @state.dropPosition is 'top' and !@props.isHero
-        @printDropPlaceholder()
+      @dropZone() if @state.dropPosition is 'top'
       div {
         className: 'edit-section-container'
         'data-editing': @props.editing
         'data-type': @props.section.get('type')
         'data-layout': @props.section.get('layout')
         'data-id': @props.index
-        'data-dragging': if @props.isHero then false else (@props.dragging is @props.index)
+        'data-dragging': @isDragging()
       },
         unless @props.section.get('type') is 'fullscreen'
           div {
@@ -130,6 +139,5 @@ module.exports = React.createClass
         if @props.section.get('type') is 'fullscreen'
           div { className: 'edit-section-container-block' }
       )
-      if @state.dropPosition is 'bottom' and !@props.isHero
-        @printDropPlaceholder()
+      @dropZone() if @state.dropPosition is 'bottom'
 

--- a/client/apps/edit/components/section_container/index.coffee
+++ b/client/apps/edit/components/section_container/index.coffee
@@ -29,6 +29,7 @@ module.exports = React.createClass
 
   componentDidMount: ->
     @props.section.on 'change:layout', => @forceUpdate()
+    $(".edit-section-container[data-id=#{@props.dragEnd}]").animate({'opacity': 1}, .5)
 
   setEditing: (editing) -> =>
     @props.onSetEditing if editing then @props.index ? true else null
@@ -37,18 +38,49 @@ module.exports = React.createClass
     e.stopPropagation()
     @props.section.destroy()
 
+  onDragOver: (e) ->
+    isDraggingHeight = $(".edit-section-container[data-id=#{@props.dragging}]").height()
+    isDragOverTop = $(e.currentTarget).position().top
+    isDragOverHeight = $(e.currentTarget).height()
+    mousePosition = e.clientY
+    dragOver = $(e.currentTarget).find('.edit-section-container').data('id')
+    @props.onSetDragOver dragOver unless dragOver is @props.dragOver
+
+  printDropPlaceholder: ->
+    if @props.dragOver is @props.index
+      unless @props.index is @props.dragging
+        div {
+          className: 'edit-section-drag-placeholder'
+          style: height: @props.draggingHeight
+        }
+
   render: ->
-    div {},
+    div {
+        draggable: true
+        onDragStart: @props.onDragStart
+        onDragEnd: @props.onDragEnd
+        onDragOver: @onDragOver
+      },
+      if @props.dragOver < @props.dragging
+        @printDropPlaceholder()
+
       div {
         className: 'edit-section-container'
         'data-editing': @props.editing
         'data-type': @props.section.get('type')
         'data-layout': @props.section.get('layout')
+        'data-id': @props.index
+        'data-dragging': @props.dragging is @props.index
+        'data-dragend': @props.dragEnd is @props.index
       },
         div {
           className: 'edit-section-hover-controls'
           onClick: @setEditing(on)
         },
+          button {
+            className: "edit-section-drag button-reset #{'is-hidden' if @props.section.get('type') is 'fullscreen'}"
+            dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
+          }
           button {
             className: "edit-section-remove button-reset #{'is-hidden' if @props.section.get('type') is 'fullscreen'}"
             onClick: @removeSection
@@ -80,3 +112,6 @@ module.exports = React.createClass
         if @props.section.get('type') is 'fullscreen'
           div { className: 'edit-section-container-block' }
       )
+      if @props.dragOver > @props.dragging
+        @printDropPlaceholder()
+

--- a/client/apps/edit/components/section_container/index.styl
+++ b/client/apps/edit/components/section_container/index.styl
@@ -77,6 +77,6 @@
   width calc(100% \- 40px)
   height 2em
   background-color white
-  margin 0 20px 20px 20px
+  margin 20px
   border 2px dashed gray-lighter-color
   max-height 30vh

--- a/client/apps/edit/components/section_container/index.styl
+++ b/client/apps/edit/components/section_container/index.styl
@@ -75,7 +75,7 @@
 
 .edit-section-drag-placeholder
   width calc(100% \- 40px)
-  height 2em
+  min-height 2em
   background-color white
   margin 20px
   border 2px dashed gray-lighter-color

--- a/client/apps/edit/components/section_container/index.styl
+++ b/client/apps/edit/components/section_container/index.styl
@@ -11,6 +11,7 @@
 .edit-section-container
   animation fadein 0.15s
   z-index 1
+  transition transform .15s
 
 .edit-section-container-bg
   width 100%
@@ -66,3 +67,19 @@
 .edit-section-container[data-layout=column_width]
   width 620px
   margin auto
+
+.edit-section-container[data-dragging=true]
+  background-color gray-lightest-color
+  user-select none
+  transform scale(.95)
+
+.edit-section-container[data-dragend=true]
+  opacity 0
+
+.edit-section-drag-placeholder
+  width calc(100% \- 40px)
+  height 2em
+  background-color white
+  margin 20px
+  border 2px dashed gray-lighter-color
+  max-height 30vh

--- a/client/apps/edit/components/section_container/index.styl
+++ b/client/apps/edit/components/section_container/index.styl
@@ -71,15 +71,12 @@
 .edit-section-container[data-dragging=true]
   background-color gray-lightest-color
   user-select none
-  transform scale(.95)
-
-.edit-section-container[data-dragend=true]
-  opacity 0
+  transform scale(.925)
 
 .edit-section-drag-placeholder
   width calc(100% \- 40px)
   height 2em
   background-color white
-  margin 20px
+  margin 0 20px 20px 20px
   border 2px dashed gray-lighter-color
   max-height 30vh

--- a/client/apps/edit/components/section_container/test/index.coffee
+++ b/client/apps/edit/components/section_container/test/index.coffee
@@ -16,16 +16,22 @@ describe 'SectionContainer', ->
   beforeEach (done) ->
     benv.setup =>
       benv.expose $: benv.require 'jquery'
-      SectionContainer = benv.requireWithJadeify(
+      $.fn.position = sinon.stub().returns(top: 800)
+      @SectionContainer = benv.requireWithJadeify(
         resolve(__dirname, '../index'), ['icons']
       )
-      SectionContainer.__set__ 'SectionText', ->
-      @component = ReactDOM.render React.createElement(SectionContainer,
+      @props = {
         section: new Backbone.Model(
           { body: 'Foo to the bar', type: 'text', layout: 'foo' }
         )
         onSetEditing: @onSetEditing = sinon.stub()
         index: 4
+        onDragStart: @onDragStart = sinon.stub()
+        onDragEnd: @onDragEnd = sinon.stub()
+        dragOver: 4
+      }
+      @SectionContainer.__set__ 'SectionText', ->
+      @component = ReactDOM.render React.createElement(@SectionContainer, @props
       ), $("<div></div>")[0], => setTimeout =>
         @component.setState = sinon.stub()
         done()
@@ -46,3 +52,45 @@ describe 'SectionContainer', ->
   it 'exits editing mode when clicking off and callsback a parent', ->
     r.simulate.click r.find @component, 'edit-section-container-bg'
     (@component.props.onSetEditing.args[0][0]?).should.not.be.ok
+
+  it 'is draggable by default', ->
+    $(ReactDOM.findDOMNode(@component)).attr('draggable').should.eql 'true'
+
+  it 'is not draggable if hero section', ->
+    @props.isHero = true
+    rendered = ReactDOMServer.renderToString React.createElement(@SectionContainer, @props)
+    rendered.should.not.containEql 'draggable'
+    rendered.should.not.containEql 'edit-section-drag'
+
+  it 'hides container controls if fullscreen', ->
+    @props.isHero = true
+    @props.section.set 'type', 'fullscreen'
+    @SectionContainer.__set__ 'SectionFullscreen', ->
+    rendered = ReactDOMServer.renderToString React.createElement(@SectionContainer, @props)
+    rendered.should.not.containEql 'edit-section-hover-controls'
+
+  it 'triggers onDragStart and calls props.onDragStart when section is dragged', ->
+    r.simulate.dragStart r.find @component, 'edit-section-container'
+    @onDragStart.called.should.be.ok
+
+  it 'calls props.onDragEnd when drag ends', ->
+    r.simulate.dragEnd r.find @component, 'edit-section-container'
+    @onDragEnd.called.should.be.ok
+
+  it 'toggles data-dragging if section is being dragged', ->
+    @props.dragging = 4
+    rendered = ReactDOMServer.renderToString React.createElement(@SectionContainer, @props)
+    rendered.should.containEql 'data-dragging="true"'
+
+  it 'prints a drop zone if an item is dragged over', ->
+    @props.dragging = 3
+    @props.draggingHeight = 300
+    rendered = ReactDOMServer.renderToString React.createElement(@SectionContainer, @props)
+    rendered.should.containEql 'edit-section-drag-placeholder" style="height:300px;"'
+
+  it 'does not print a drop zone if dragging over original position', ->
+    @props.dragging = 4
+    rendered = ReactDOMServer.renderToString React.createElement(@SectionContainer, @props)
+    rendered.should.not.containEql 'edit-section-drag-placeholder'
+
+

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -12,7 +12,10 @@ module.exports = React.createClass
   displayName: 'SectionList'
 
   getInitialState: ->
-    { editingIndex: null }
+    editingIndex: null
+    dragging: null
+    dragOver: null
+    draggingHeight: 0
 
   componentDidMount: ->
     @props.sections.on 'add remove reset', => @forceUpdate()
@@ -23,6 +26,30 @@ module.exports = React.createClass
 
   onNewSection: (section) ->
     @setState editingIndex: @props.sections.indexOf section
+
+  onDragStart: (e) ->
+    $(e.currentTarget).find('.edit-section-container').css('opacity', .65)
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/html', e.currentTarget)
+    @setState
+      dragEnd: null
+      dragging: $(e.currentTarget).find('.edit-section-container').data('id')
+      draggingHeight: $(e.currentTarget).find('.edit-section-container').height()
+
+  onDragEnd: (e) ->
+    dragEnd = @state.dragOver
+    $(e.currentTarget).find('.edit-section-container').animate({'opacity': 0}, .35)
+    newSections = @props.sections.models
+    removed = newSections.splice(@state.dragging, 1)
+    newSections.splice(@state.dragOver, 0, removed[0])
+    @setState
+      dragging: null
+      dragOver: null
+      draggingHeight: 0
+      dragEnd: dragEnd
+
+  onSetDragOver: (section) ->
+    @setState dragOver: section
 
   render: ->
     div {},
@@ -42,6 +69,13 @@ module.exports = React.createClass
               ref: 'section' + i
               key: section.cid
               onSetEditing: @onSetEditing
+              onSetDragOver: @onSetDragOver
+              onDragStart: @onDragStart
+              onDragEnd: @onDragEnd
+              dragOver: @state.dragOver
+              dragging: @state.dragging
+              draggingHeight: @state.draggingHeight
+              dragEnd: @state.dragEnd
             }
             SectionTool { sections: @props.sections, index: i, key: i}
           ]

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -15,6 +15,7 @@ module.exports = React.createClass
     editingIndex: null
     dragging: null
     dragOver: null
+    dragStart: null
     draggingHeight: 0
 
   componentDidMount: ->
@@ -27,26 +28,26 @@ module.exports = React.createClass
   onNewSection: (section) ->
     @setState editingIndex: @props.sections.indexOf section
 
-  onDragStart: (e) ->
-    $(e.currentTarget).find('.edit-section-container').css('opacity', .65)
+  onDragStart: (e, dragStart) ->
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/html', e.currentTarget)
+    $dragged = $(e.currentTarget).find('.edit-section-container')
+    $dragged.css('opacity', .65)
     @setState
-      dragEnd: null
-      dragging: $(e.currentTarget).find('.edit-section-container').data('id')
-      draggingHeight: $(e.currentTarget).find('.edit-section-container').height()
+      dragStart: dragStart
+      dragging: $dragged.data('id')
+      draggingHeight: $dragged.height() - 20
 
   onDragEnd: (e) ->
-    dragEnd = @state.dragOver
-    $(e.currentTarget).find('.edit-section-container').animate({'opacity': 0}, .35)
     newSections = @props.sections.models
     removed = newSections.splice(@state.dragging, 1)
     newSections.splice(@state.dragOver, 0, removed[0])
+    @props.sections.reset(newSections)
     @setState
       dragging: null
       dragOver: null
       draggingHeight: 0
-      dragEnd: dragEnd
+      dragStart: null
 
   onSetDragOver: (section) ->
     @setState dragOver: section
@@ -75,7 +76,7 @@ module.exports = React.createClass
               dragOver: @state.dragOver
               dragging: @state.dragging
               draggingHeight: @state.draggingHeight
-              dragEnd: @state.dragEnd
+              dragStart: @state.dragStart
             }
             SectionTool { sections: @props.sections, index: i, key: i}
           ]

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -32,7 +32,6 @@ module.exports = React.createClass
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/html', e.currentTarget)
     $dragged = $(e.currentTarget).find('.edit-section-container')
-    $dragged.css('opacity', .65)
     @setState
       dragStart: dragStart
       dragging: $dragged.data('id')
@@ -40,9 +39,9 @@ module.exports = React.createClass
 
   onDragEnd: (e) ->
     newSections = @props.sections.models
-    removed = newSections.splice(@state.dragging, 1)
-    newSections.splice(@state.dragOver, 0, removed[0])
-    @props.sections.reset(newSections)
+    removed = newSections.splice @state.dragging, 1
+    newSections.splice @state.dragOver, 0, removed[0]
+    @props.sections.reset newSections
     @setState
       dragging: null
       dragOver: null

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -37,7 +37,7 @@ module.exports = React.createClass
       dragging: $dragged.data('id')
       draggingHeight: $dragged.height() - 20
 
-  onDragEnd: (e) ->
+  onDragEnd: ->
     newSections = @props.sections.models
     removed = newSections.splice @state.dragging, 1
     newSections.splice @state.dragOver, 0, removed[0]
@@ -48,8 +48,8 @@ module.exports = React.createClass
       draggingHeight: 0
       dragStart: null
 
-  onSetDragOver: (section) ->
-    @setState dragOver: section
+  onSetDragOver: (sectionId) ->
+    @setState dragOver: sectionId
 
   render: ->
     div {},

--- a/client/apps/edit/components/section_list/index.coffee
+++ b/client/apps/edit/components/section_list/index.coffee
@@ -15,7 +15,7 @@ module.exports = React.createClass
     editingIndex: null
     dragging: null
     dragOver: null
-    dragStart: null
+    dragStartY: null
     draggingHeight: 0
 
   componentDidMount: ->
@@ -28,12 +28,12 @@ module.exports = React.createClass
   onNewSection: (section) ->
     @setState editingIndex: @props.sections.indexOf section
 
-  onDragStart: (e, dragStart) ->
+  onDragStart: (e, dragStartY) ->
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/html', e.currentTarget)
     $dragged = $(e.currentTarget).find('.edit-section-container')
     @setState
-      dragStart: dragStart
+      dragStartY: dragStartY
       dragging: $dragged.data('id')
       draggingHeight: $dragged.height() - 20
 
@@ -46,7 +46,7 @@ module.exports = React.createClass
       dragging: null
       dragOver: null
       draggingHeight: 0
-      dragStart: null
+      dragStartY: null
 
   onSetDragOver: (sectionId) ->
     @setState dragOver: sectionId
@@ -75,7 +75,7 @@ module.exports = React.createClass
               dragOver: @state.dragOver
               dragging: @state.dragging
               draggingHeight: @state.draggingHeight
-              dragStart: @state.dragStart
+              dragStartY: @state.dragStartY
             }
             SectionTool { sections: @props.sections, index: i, key: i}
           ]

--- a/client/apps/edit/components/section_list/test/index.coffee
+++ b/client/apps/edit/components/section_list/test/index.coffee
@@ -66,7 +66,12 @@ describe 'SectionList', ->
           }
         ]
       ), (@$el = $ "<div></div>")[0], => setTimeout =>
-        @component.setState = sinon.stub()
+        # @sections.reset = sinon.stub()
+        @component.setState
+          dragging: 0
+          dragOver: 3
+          dragStart: 400
+          draggingHeight: 300
         @component.props.sections.off()
         done()
 
@@ -82,6 +87,7 @@ describe 'SectionList', ->
     @SectionTool.args[2][0].index.should.equal 1
 
   it 'opens editing mode in the last added section', ->
+    @component.setState = sinon.stub()
     @component.onNewSection @component.props.sections.last()
     @component.setState.args[0][0].editingIndex.should.equal 3
 
@@ -94,3 +100,13 @@ describe 'SectionList', ->
     @component.render()
     @SectionContainer.args[0][0].key.should.equal @sections.at(0).cid
     @SectionContainer.args[1][0].key.should.equal @sections.at(1).cid
+
+  it 'onDragEnd resets the section order', ->
+    @component.props.sections.models[3].get('type').should.eql 'artworks'
+    @component.onDragEnd()
+    @component.props.sections.models[3].get('type').should.eql 'text'
+    (@component.state.dragging?).should.not.be.ok
+    (@component.state.dragOver?).should.not.be.ok
+    (@component.state.dragStart?).should.not.be.ok
+    @component.state.draggingHeight.should.eql 0
+

--- a/client/apps/edit/components/section_list/test/index.coffee
+++ b/client/apps/edit/components/section_list/test/index.coffee
@@ -66,7 +66,6 @@ describe 'SectionList', ->
           }
         ]
       ), (@$el = $ "<div></div>")[0], => setTimeout =>
-        # @sections.reset = sinon.stub()
         @component.setState
           dragging: 0
           dragOver: 3

--- a/client/apps/edit/components/section_tool/index.styl
+++ b/client/apps/edit/components/section_tool/index.styl
@@ -16,6 +16,7 @@ section-btn-height = 130px
       fill-color black
   &:last-child
     opacity 1
+    margin-top 15px
   &:hover
     width 100%
     position relative

--- a/client/apps/edit/public/icons/edit_draggable.svg
+++ b/client/apps/edit/public/icons/edit_draggable.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="10px" height="19px" viewBox="0 0 10 19" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 43.2 (39069) - http://www.bohemiancoding.com/sketch -->
+    <title>Combined Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Article" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M6.07148248,3.99730445 L8.60701639,6.53283835 L10.02123,5.11862479 L5.07148248,0.168877324 L0.121735016,5.11862479 L1.53594858,6.53283835 L4.07148248,3.99730445 L4.07148248,14.9576565 L1.53594858,12.4221226 L0.121735016,13.8363361 L5.07148248,18.7860836 L10.02123,13.8363361 L8.60701639,12.4221226 L6.07148248,14.9576565 L6.07148248,3.99730445 Z" id="Combined-Shape" fill="#FFFFFF" fill-rule="nonzero"></path>
+    </g>
+</svg>


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1039
- Adds drag & drop functionality to the sectionContainer and sectionList components
- Does not allow dragging for sectionContainer in the hero section

QA - still seeking a good solution for the 'ghost' image that appears after letting go of the mouse, which would ideally disappear without animated movement on dragEnd.

![drag-drop](https://cloud.githubusercontent.com/assets/1497424/26423131/5e760fbc-409a-11e7-8761-f25991b15635.gif)
