### PR TITLE
@kanaabe => no GET /null

### DIFF
--- a/client/apps/articles_list/test/client/client.coffee
+++ b/client/apps/articles_list/test/client/client.coffee
@@ -29,6 +29,10 @@ describe 'ArticlesListView', ->
         ARTICLES: [_.extend fixtures().articles]
       }
       mod.__set__ 'FilterSearch', @FilterSearch = sinon.stub()
+      mod.__set__ 'request', post: (@post = sinon.stub()).returns
+        set: (@set = sinon.stub()).returns
+          send: (@send = sinon.stub()).returns
+            end: sinon.stub().yields(null, body: data: articles: [_.extend fixtures().articles] )
       props = {
           articles: [_.extend fixtures().articles, id: '456']
           published: true
@@ -56,4 +60,6 @@ describe 'ArticlesListView', ->
   it 'updates feed when nav is clicked', ->
     @component.state.published.should.equal true
     r.simulate.click r.find @component, 'drafts'
+    @component.setState.args[0][0].articles.length.should.be > 0
     @component.setState.args[0][0].published.should.equal false
+    @component.setState.args[0][0].offset.should.equal 10


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/942

fetchFeed was having issues with the state being set both inside it's end as well as its callback -- by removing the callbacks and setting state once we see no null requests. 
