### PR TITLE
@kanaabe => [WIP] Channels have public flag

### DIFF
--- a/api/apps/channels/model.coffee
+++ b/api/apps/channels/model.coffee
@@ -30,6 +30,7 @@ request = require 'superagent'
     text: @string().allow('',null)
   ]).allow(null).default([])
   slug: @string().allow('',null)
+  public: @boolean().default(true)
   pinned_articles: @array().max(6).items(
     @object().keys
       index: @number()
@@ -41,6 +42,7 @@ request = require 'superagent'
   limit: @number().max(Number API_MAX).default(Number API_PAGE_SIZE)
   offset: @number()
   user_id: @objectId()
+  public: @boolean()
   q: @string()
 ).call Joi
 

--- a/api/apps/channels/test/model.coffee
+++ b/api/apps/channels/test/model.coffee
@@ -3,6 +3,7 @@ moment = require 'moment'
 { db, fabricate, empty, fixtures } = require '../../../test/helpers/db'
 Channel = require '../model'
 { ObjectId } = require 'mongojs'
+request = require 'superagent'
 
 describe 'Channel', ->
 
@@ -48,6 +49,22 @@ describe 'Channel', ->
       fabricate 'channels', { slug: 'life-at-artsy' }, ->
         Channel.find 'life-at-artsy', (err, channel) ->
           channel.slug.should.equal 'life-at-artsy'
+          done()
+
+    it 'finds a channel by a publicity', (done) ->
+      fabricate 'channels', { public: false, slug: 'life-at-artsy' }, ->
+        Channel.where { public: false }, (err, res) ->
+          { total, count, results } = res
+          total.should.equal 11
+          count.should.equal 1
+          results[0].slug.should.equal 'life-at-artsy'
+          results[0].public.should.be.false()
+        Channel.where { public: true }, (err, res) ->
+          { total, count, results } = res
+          total.should.equal 11
+          count.should.equal 10
+          results[0].slug.should.equal 'editorial'
+          results[0].public.should.be.true()
           done()
 
   describe '#save', ->

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -153,6 +153,7 @@ module.exports = ->
     tagline: 'A bunch of cool stuff at Artsy'
     image_url: 'artsy.net/image.jpg'
     slug: 'editorial'
+    public: true
     pinned_articles: [
       {
         id: '5086df098523e60002000015'


### PR DESCRIPTION
Was looking at ways to exclude by 'type' for sitemaps, but I think going with a public flag makes the most sense.  Seems like there may be reason to exclude other channels from the sitemaps. 

Alternatively, would it make sense to tell Cinder only to index channels with slugs, rather than making a new flag?