### PR TITLE
@kanaabe => Bug pasting from google docs

### DIFF
--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -171,11 +171,11 @@ module.exports = React.createClass
     for span, i in spans
       newSpan = span
       if span?.style.fontStyle is 'italic' and span?.style.fontWeight is '700'
-        newSpan = '<strong><em>' + span.innerHTML + '</em></strong>'
+        newSpan = '<span><strong><em>' + span.innerHTML + '</em></strong></span>'
       else if span?.style.fontStyle is 'italic'
-        newSpan = '<em>' + span.innerHTML + '</em>'
+        newSpan = '<span><em>' + span.innerHTML + '</em></span>'
       else if span?.style.fontWeight is '700'
-        newSpan = '<strong>' + span.innerHTML + '</strong>'
+        newSpan = '<span><strong>' + span.innerHTML + '</strong></span>'
       $(doc.getElementsByTagName('SPAN')[i]).replaceWith(newSpan)
     return doc.innerHTML
 

--- a/client/apps/edit/components/section_text/test/index.coffee
+++ b/client/apps/edit/components/section_text/test/index.coffee
@@ -275,12 +275,17 @@ describe 'SectionText', ->
 
     it 'replaces bold spans with actual b tags', ->
       html = '<p><span style="font-size:11pt;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">B. 1981 in Madrid. Lives and works in Madrid.</span></p>'
-      @component.stripGoogleStyles(html).should.eql '<p><strong>B. 1981 in Madrid. Lives and works in Madrid.</strong></p>'
+      @component.stripGoogleStyles(html).should.eql '<p><span><strong>B. 1981 in Madrid. Lives and works in Madrid.</strong></span></p>'
 
     it 'replaces italic spans with actual em tags', ->
       html = '<p><span style="font-size:11pt;color:#000000;background-color:transparent;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">B. 1981 in Madrid. Lives and works in Madrid.</span></p>'
-      @component.stripGoogleStyles(html).should.eql '<p><em>B. 1981 in Madrid. Lives and works in Madrid.</em></p>'
+      @component.stripGoogleStyles(html).should.eql '<p><span><em>B. 1981 in Madrid. Lives and works in Madrid.</em></span></p>'
 
-    it 'Can replaces spans that are bold and italic', ->
+    it 'replaces spans that are bold and italic', ->
       html = '<p><span style="font-size:11pt;color:#000000;background-color:transparent;font-weight:700;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">B. 1981 in Madrid. Lives and works in Madrid.</span></p>'
-      @component.stripGoogleStyles(html).should.eql '<p><strong><em>B. 1981 in Madrid. Lives and works in Madrid.</em></strong></p>'
+      @component.stripGoogleStyles(html).should.eql '<p><span><strong><em>B. 1981 in Madrid. Lives and works in Madrid.</em></strong></span></p>'
+
+    it 'replaces styled spans that are nested in links', ->
+      html = '<span style="font-size:11pt;color:#000000;background-color:transparent;font-weight:400;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">(via </span><a href="http://theartnewspaper.com/market/dealer-cuts-plea-bargain/" style="text-decoration:none;"><span style="font-size:11pt;color:#1155cc;background-color:transparent;font-weight:400;font-style:italic;font-variant:normal;text-decoration:underline;vertical-align:baseline;white-space:pre-wrap;">The Art Newspaper</span></a><span style="font-size:11pt;color:#000000;background-color:transparent;font-weight:400;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">)</span>'
+      @component.stripGoogleStyles(html).should.eql '<span><em>(via </em></span><a href="http://theartnewspaper.com/market/dealer-cuts-plea-bargain/" style="text-decoration:none;"><span><em>The Art Newspaper</em></span></a><span><em>)</em></span>'
+


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1067

[This line](https://github.com/artsy/positron/compare/master...eessex:link-paste?expand=1#diff-8ac6d971617183b86f1d61823b3f2185R179) was replacing `span` with alternative elements, but it changed the length of the spans array while still iterating through it, losing some indexes before everything was replaced.  By wrapping the line in `<span>` tags, the array stays at its original length.  The tags are later removed when html is converted into an editor state. 