### PR TITLE
@eessex => Fix null fetch with background image check

### DIFF
--- a/client/apps/articles_list/client/client.coffee
+++ b/client/apps/articles_list/client/client.coffee
@@ -70,6 +70,7 @@ module.exports.ArticlesListView = ArticlesListView = React.createClass
           searchResults: @setResults
           selected: null
           contentType: 'article'
+          checkable: false
         }
     else
       @showEmptyMessage()

--- a/client/components/article_list/index.coffee
+++ b/client/components/article_list/index.coffee
@@ -17,9 +17,15 @@ module.exports = React.createClass
 
   getDisplayAttrs: (article) ->
     if @props.display is 'email' and article.email_metadata
-      return {headline: article.email_metadata.headline, image: article.email_metadata.image_url}
+      return {
+        headline: article.email_metadata.headline
+        image: article.email_metadata.image_url
+      }
     else
-      return {headline: article.thumbnail_title, image: article.thumbnail_image}
+      return {
+        headline: article.thumbnail_title
+        image: article.thumbnail_image
+      }
 
   publishText: (result) ->
     if result.published_at and result.published
@@ -37,7 +43,10 @@ module.exports = React.createClass
         div { className: 'article-list__no-results' }, "No Results Found"
       (@props.articles.map (result) =>
         attrs = @getDisplayAttrs(result)
-        div { className: 'article-list__result paginated-list-item', key: result.id},
+        div {
+          className: 'article-list__result paginated-list-item'
+          key: result.id
+        },
           if @props.checkable
             div {
               ref: result.id
@@ -45,17 +54,25 @@ module.exports = React.createClass
               dangerouslySetInnerHTML: __html: $(icons()).filter('.check-circle').html()
               onClick: => @props.selected(result)
             }
-          a { className: 'article-list__article', href: "/articles/#{result.id}/edit" },
-            div { className: 'article-list__image paginated-list-img', style: backgroundImage: "url(#{attrs.image})" },
+          a {
+            className: 'article-list__article'
+            href: "/articles/#{result.id}/edit"
+          },
+            div {
+              className: 'article-list__image paginated-list-img'
+              style: if attrs.image then backgroundImage: "url(#{attrs.image})" else {}
+            },
               unless attrs.image
-                div { className: 'missing-img'}, "Missing Thumbnail"
+                div { className: 'missing-img' }, "Missing Thumbnail"
             div { className: 'article-list__title paginated-list-text-container' },
               if attrs.headline
                 h1 {}, attrs.headline
               else
-                h1 { className: 'missing-title'}, 'Missing Title'
+                h1 { className: 'missing-title' }, 'Missing Title'
               h2 {}, @publishText(result)
-          a { className: 'paginated-list-preview avant-garde-button'
-            , href: "#{sd.FORCE_URL}/article/#{result.slug}"
-            , target: '_blank' }, "Preview"
+          a {
+            className: 'paginated-list-preview avant-garde-button'
+            href: "#{sd.FORCE_URL}/article/#{result.slug}"
+            target: '_blank'
+          }, "Preview"
       )

--- a/client/components/article_list/test/index.coffee
+++ b/client/components/article_list/test/index.coffee
@@ -35,6 +35,11 @@ describe 'ArticleList', ->
               thumbnail_image: 'http://artsy.net/thumbnail_image2.jpg'
               email_metadata: {headline: 'Email of Thrones', image_url: 'http://artsy.net/image_url.jpg'}
               slug: 'artsy-editorial-email-of-thrones'
+            },
+            {
+              id: '125'
+              thumbnail_title: '[Draft] Draft Title'
+              slug: 'artsy-editorial-email-of-thrones'
             }
           ]
           selected: sinon.stub()
@@ -62,3 +67,9 @@ describe 'ArticleList', ->
   it 'can render email headlines and images', ->
     $(@rendered).html().should.containEql 'Email of Thrones'
     $(@rendered).html().should.containEql 'image_url.jpg'
+
+  it 'sets the background of the thumbnail image', ->
+    $(@rendered).find('.article-list__image:eq(1)').css('background-image').should.equal 'url(http://artsy.net/image_url.jpg)'
+
+  it 'thumbnail image defaults to not setting background when there is no image', ->
+    $(@rendered).find('.article-list__image:eq(2)').css('background-image').length.should.equal 0


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/942

Turns out it wasn't the SVG but a missing background image instead. The problem was that `background_image: url(undefined)` was doing a GET `/null` on root. For published, this was not a problem because all published articles require a thumbnail_image. Instead, don't try to fetch the background image if there isn't one.