### PR TITLE
@kanaabe => Scheduled date bug

### DIFF
--- a/client/apps/edit/components/admin/article/index.coffee
+++ b/client/apps/edit/components/admin/article/index.coffee
@@ -49,12 +49,9 @@ module.exports = AdminArticle = React.createClass
       publish_time: @refs.publish_time.value
     published_at = moment(@refs.publish_date.value + ' ' + @refs.publish_time.value)
     if !@props.article.get 'published'
-      # ignore if draft and date is past
-      if published_at < moment()
-        @onChange 'published_at', null
-      # if draft and date is future, set scheduled
-      else
-        @onChange 'scheduled_publish_at', published_at.toISOString()
+      # if draft set scheduled
+      @onChange 'published_at', null
+      @onChange 'scheduled_publish_at', published_at.toISOString()
     else
       # if article is published, reset published date
       @onChange 'published_at', published_at.toISOString()
@@ -64,7 +61,7 @@ module.exports = AdminArticle = React.createClass
       @setState
         publish_date: moment(@props.article.get('scheduled_publish_at')).format('YYYY-MM-DD')
         publish_time: moment(@props.article.get('scheduled_publish_at')).format('HH:mm')
-    if @props.article.get 'published_at'
+    else if @props.article.get 'published_at'
       @setState
         publish_date: moment(@props.article.get('published_at')).format('YYYY-MM-DD')
         publish_time: moment(@props.article.get('published_at')).format('HH:mm')

--- a/client/apps/edit/components/admin/test/article.coffee
+++ b/client/apps/edit/components/admin/test/article.coffee
@@ -121,25 +121,16 @@ describe 'AdminArticle', ->
       r.simulate.change input
       @component.setState.args[0][0].publish_date.should.eql moment().add(1, 'years').format('YYYY-MM-DD')
 
-    it '#onPublishDateChange sets scheduled date if article is draft', ->
+    it '#onPublishDateChange sets scheduled date, and sets published_at to null if article is draft', ->
       @component.setState = sinon.stub()
       @component.onChange = sinon.stub()
       @component.props.article.set('published', false)
       input = ReactDOM.findDOMNode(@component.refs.publish_date)
       input.value = moment().add(1, 'years').format('YYYY-MM-DD')
       r.simulate.change input
-      moment(@component.onChange.args[0][1]).format('YYYY-MM-DD').should.eql moment().add(1, 'years').format('YYYY-MM-DD')
-      @component.onChange.args[0][0].should.eql 'scheduled_publish_at'
-
-    it '#onPublishDateChange published_at is null if input date has passed and article is draft', ->
-      @component.setState = sinon.stub()
-      @component.onChange = sinon.stub()
-      @component.props.article.set('published', false)
-      input = ReactDOM.findDOMNode(@component.refs.publish_date)
-      input.value = moment().subtract(1, 'years').format('YYYY-MM-DD')
-      r.simulate.change input
-      @component.setState.args[0][0].publish_date.should.eql moment().subtract(1, 'years').format('YYYY-MM-DD')
-      @component.onChange.args[0].should.eql [ 'published_at', null ]
+      @component.onChange.args[0].should.eql ['published_at', null]
+      moment(@component.onChange.args[1][1]).format('YYYY-MM-DD').should.eql moment().add(1, 'years').format('YYYY-MM-DD')
+      @component.onChange.args[1][0].should.eql 'scheduled_publish_at'
 
     it '#onPublishDateChange saves a changed published_at date on published article', ->
       @component.setState = sinon.stub()

--- a/client/apps/edit/components/layout/content.jade
+++ b/client/apps/edit/components/layout/content.jade
@@ -1,3 +1,8 @@
+if article.get('published')
+  - date = article.get('published_at')
+else
+  - date = article.get('scheduled_publish_at') ? article.get('scheduled_publish_at') : ''
+
 section#edit-content
   #edit-hero-section
   .edit-header-container
@@ -8,6 +13,6 @@ section#edit-content
     .edit-author-section
       if article.get('author')
         p.article-author= article.get('author').name
-      p.article-date= moment(article.get('published_at') || moment()).format('MMM D, YYYY h:mm a')
+      p.article-date= moment(date).format('MMM D, YYYY h:mm a')
   .edit-body-container
   #edit-sections.edit-body-container


### PR DESCRIPTION
re: https://github.com/artsy/positron/issues/1082
Removes conditional for past dates when setting scheduled publish at. 
Now any date put into the scheduled publish field will be saved as the 'scheduled_publish_at' field. 
Also updates the view side to display 'scheduled_publish_at' if set. 

TODO:  Switch view side to use react when rendering author/publish date, so it reflects dates set in admin panel.