### PR TITLE
@craigspaeth => Authors API

### DIFF
--- a/api/apps/authors/index.coffee
+++ b/api/apps/authors/index.coffee
@@ -1,0 +1,11 @@
+express = require 'express'
+routes = require './routes'
+{ setUser, authenticated, adminOnly } = require '../users/routes'
+
+app = module.exports = express()
+
+app.get '/authors', routes.index
+app.get '/authors/:id', routes.find, routes.show
+app.post '/authors', setUser, authenticated, adminOnly, routes.save
+app.put '/authors/:id', setUser, authenticated, adminOnly, routes.find, routes.save
+app.delete '/authors/:id', setUser, authenticated, adminOnly, routes.find, routes.delete

--- a/api/apps/authors/model.coffee
+++ b/api/apps/authors/model.coffee
@@ -1,0 +1,80 @@
+#
+# Library of retrieval, persistance, validation, json view, and domain logic for the "authors" resource.
+#
+
+{ extend, omit } = require 'underscore'
+db = require '../../lib/db'
+async = require 'async'
+Joi = require 'joi'
+Joi.objectId = require('joi-objectid') Joi
+{ ObjectId } = require 'mongojs'
+{ API_MAX, API_PAGE_SIZE } = process.env
+
+#
+# Schemas
+#
+@schema = ( ->
+  id: @objectId()
+  name: @string().allow('')
+  bio: @string().allow('')
+  image_url: @string().allow('')
+  twitter_handle: @string().allow('')
+).call Joi
+
+@querySchema = (->
+  q: @string().allow('')
+  limit: @number().max(Number API_MAX).default(Number API_PAGE_SIZE)
+  offset: @number()
+  count: @boolean().default(false)
+).call Joi
+
+#
+# Retrieval
+#
+@find = (id, callback) ->
+  query = if ObjectId.isValid(id) then { _id: ObjectId(id) } else { name: id }
+  db.authors.findOne query, callback
+
+@where = (input, callback) ->
+  Joi.validate input, @querySchema, (err, input) =>
+    return callback err if err
+    cursor = db.authors
+      .find({})
+      .limit(input.limit)
+      .sort($natural: -1)
+      .skip(input.offset or 0)
+    async.parallel [
+      (cb) -> cursor.toArray cb
+      (cb) ->
+        return cb() unless input.count
+        cursor.count cb
+      (cb) ->
+        return cb() unless input.count
+        db.authors.count cb
+    ], (err, [authors, authorCount, total]) =>
+      callback err, {
+        total: total if input.count
+        count: authorCount if input.count
+        results: authors.map(@present)
+      }
+
+#
+# Persistence
+#
+@save = (input, callback) ->
+  Joi.validate input, @schema, (err, input) =>
+    return callback err if err
+    data = extend omit(input, 'id'),
+      _id: ObjectId(input.id)
+    db.authors.save data, callback
+
+@destroy = (id, callback) ->
+  db.authors.remove { _id: ObjectId(id) }, callback
+
+#
+# JSON views
+#
+@present = (author) =>
+  extend
+    id: author?._id?.toString()
+  , omit(author, '_id')

--- a/api/apps/authors/model.coffee
+++ b/api/apps/authors/model.coffee
@@ -5,8 +5,7 @@
 { extend, omit } = require 'underscore'
 db = require '../../lib/db'
 async = require 'async'
-Joi = require 'joi'
-Joi.objectId = require('joi-objectid') Joi
+Joi = require '../../lib/joi'
 { ObjectId } = require 'mongojs'
 { API_MAX, API_PAGE_SIZE } = process.env
 
@@ -14,7 +13,7 @@ Joi.objectId = require('joi-objectid') Joi
 # Schemas
 #
 @schema = ( ->
-  id: @objectId()
+  id: @string().objectid()
   name: @string().allow('')
   bio: @string().allow('')
   image_url: @string().allow('')
@@ -65,7 +64,7 @@ Joi.objectId = require('joi-objectid') Joi
   Joi.validate input, @schema, (err, input) =>
     return callback err if err
     data = extend omit(input, 'id'),
-      _id: ObjectId(input.id)
+      _id: input.id
     db.authors.save data, callback
 
 @destroy = (id, callback) ->

--- a/api/apps/authors/routes.coffee
+++ b/api/apps/authors/routes.coffee
@@ -1,0 +1,31 @@
+{ extend } = require 'underscore'
+{ present } = Author = require './model'
+
+# GET /api/authors
+@index = (req, res, next) ->
+  Author.where req.query, (err, results) ->
+    return next err if err
+    res.send results
+
+# GET /api/authors/:id
+@show = (req, res, next) ->
+  res.send present req.author
+
+# POST /api/authors & PUT /api/authors/:id
+@save = (req, res, next) ->
+  Author.save _.extend(req.body, id: req.params.id), (err, author) ->
+    return next err if err
+    res.send present author
+
+# DELETE /api/authors/:id
+@delete = (req, res, next) ->
+  Author.destroy req.author._id, (err) ->
+    return next err if err
+    res.send present req.author
+
+# Fetch & attach a req.author middleware
+@find = (req, res, next) ->
+  Author.find req.params.id, (err, author) ->
+    return next err if err
+    return res.err 404, 'Author not found.' unless req.author = author
+    next()

--- a/api/apps/authors/test/integration.coffee
+++ b/api/apps/authors/test/integration.coffee
@@ -1,0 +1,43 @@
+_ = require 'underscore'
+{ db, fixtures, fabricate, empty } = require '../../../test/helpers/db'
+app = require '../../../'
+request = require 'superagent'
+{ ObjectId } = require 'mongojs'
+
+describe 'authors endpoints', ->
+
+  beforeEach (done) ->
+    empty =>
+      fabricate 'users', {}, (err, @user) =>
+        @server = app.listen 5000, ->
+          done()
+
+  afterEach ->
+    @server.close()
+
+  it 'gets a list of authors', (done) ->
+    fabricate 'authors', [
+      { name: 'Alex' }
+      { name: 'Molly' }
+      {}
+    ], (err, tags) ->
+      request
+        .get("http://localhost:5000/authors?count=true")
+        .end (err, res) ->
+          res.body.total.should.equal 3
+          res.body.count.should.equal 3
+          res.body.results[2].name.should.equal 'Alex'
+          done()
+
+  it 'gets a single author', (done) ->
+    fabricate 'authors', [
+      {
+        _id: ObjectId('55356a9deca560a0137aa4b7')
+        name: 'Alex'
+      }
+    ], (err, sections) ->
+      request
+        .get("http://localhost:5000/authors/55356a9deca560a0137aa4b7")
+        .end (err, res) ->
+          res.body.name.should.equal 'Alex'
+          done()

--- a/api/apps/authors/test/integration.coffee
+++ b/api/apps/authors/test/integration.coffee
@@ -20,7 +20,7 @@ describe 'authors endpoints', ->
       { name: 'Alex' }
       { name: 'Molly' }
       {}
-    ], (err, tags) ->
+    ], (err, authors) ->
       request
         .get("http://localhost:5000/authors?count=true")
         .end (err, res) ->

--- a/api/apps/authors/test/model.coffee
+++ b/api/apps/authors/test/model.coffee
@@ -1,0 +1,68 @@
+_ = require 'underscore'
+moment = require 'moment'
+{ db, fabricate, empty, fixtures } = require '../../../test/helpers/db'
+Author = require '../model'
+{ ObjectId } = require 'mongojs'
+
+describe 'Author', ->
+
+  beforeEach (done) ->
+    empty ->
+      fabricate 'authors', _.times(10, -> {}), ->
+        done()
+
+  describe '#where', ->
+
+    it 'can return all authors along with total and counts', (done) ->
+      Author.where { count: true }, (err, res) ->
+        { total, count, results } = res
+        total.should.equal 10
+        count.should.equal 10
+        results[0].name.should.equal 'Halley Johnson'
+        done()
+
+  describe '#find', ->
+
+    it 'finds an author by an id string', (done) ->
+      fabricate 'authors', { _id: ObjectId('5086df098523e60002000018') }, ->
+        Author.find '5086df098523e60002000018', (err, author) ->
+          author._id.toString().should.equal '5086df098523e60002000018'
+          done()
+
+    it 'finds the author by name', (done) ->
+      fabricate 'authors', { name: 'Kana Abe' }, ->
+        Author.find 'Kana Abe', (err, author) ->
+          author.name.should.equal 'Kana Abe'
+          done()
+
+  describe '#save', ->
+
+    it 'saves valid author input data', (done) ->
+      Author.save {
+        name: 'Owen Dodd'
+        image_url: 'https://artsy-media/owen.jpg'
+        twitter_handle: '@owendodd'
+        bio: 'Designer based in NYC'
+      }, (err, author) ->
+        author.name.should.equal 'Owen Dodd'
+        author.image_url.should.equal 'https://artsy-media/owen.jpg'
+        author.twitter_handle.should.equal '@owendodd'
+        author.bio.should.equal 'Designer based in NYC'
+        db.authors.count (err, count) ->
+          count.should.equal 11
+          done()
+
+    it 'can return a validation error', (done) ->
+      Author.save {
+        name: 500
+      }, (err, author) ->
+        err.details[0].message.should.containEql '"name" must be a string'
+        done()
+
+  describe '#present', ->
+
+    it 'converts _id to id', (done) ->
+      db.authors.findOne (err, author) ->
+        data = Author.present author
+        (typeof data.id).should.equal 'string'
+        done()

--- a/api/apps/authors/test/model.coffee
+++ b/api/apps/authors/test/model.coffee
@@ -55,6 +55,7 @@ describe 'Author', ->
     it 'can return a validation error', (done) ->
       Author.save {
         name: 500
+        id: '5936f5530fae440cda9ae052'
       }, (err, author) ->
         err.details[0].message.should.containEql '"name" must be a string'
         done()

--- a/api/index.coffee
+++ b/api/index.coffee
@@ -36,6 +36,7 @@ app.use require './apps/curations'
 app.use require './apps/channels'
 app.use require './apps/tags'
 app.use require './apps/verticals'
+app.use require './apps/authors'
 app.use require './apps/graphql'
 
 if SENTRY_PRIVATE_DSN

--- a/api/lib/db.coffee
+++ b/api/lib/db.coffee
@@ -9,7 +9,7 @@ path = require 'path'
 { MONGOHQ_URL } = process.env
 debug = require('debug') 'api'
 
-collections = ['articles', 'users', 'sections', 'artists', 'curations', 'channels', 'tags']
+collections = ['articles', 'users', 'sections', 'artists', 'curations', 'channels', 'tags', 'verticals', 'authors']
 db = mongojs MONGOHQ_URL, collections
 
 exit = (msg) -> (err) ->

--- a/api/lib/joi.coffee
+++ b/api/lib/joi.coffee
@@ -1,0 +1,19 @@
+Joi = require('joi')
+{ ObjectId } = require 'mongojs'
+
+customJoi = Joi.extend(
+  base: Joi.string()
+  name: 'string'
+  language:
+    objectid: 'needs to be a string of 12 bytes or a string of 24 hex characters'
+  rules: [{
+    name: 'objectid'
+    validate: (params, value, state, options) ->
+      if ObjectId.isValid(value)
+        return ObjectId(value)
+      else
+        @createError('string.objectid', { v: value }, state, options)
+  }]
+)
+
+module.exports = customJoi

--- a/api/test/lib/joi.coffee
+++ b/api/test/lib/joi.coffee
@@ -1,0 +1,16 @@
+Joi = require '../../lib/joi'
+
+describe 'custom Joi extension', ->
+
+  it 'returns an error if not a valid objectid', (done) ->
+    schema = Joi.string().objectid()
+    schema.validate '5936f5530fae440cda9ae05', (err, result) ->
+      err.details[0].message.should.containEql '"value" needs to be a string of 12 bytes or a string of 24 hex characters'
+      done()
+
+
+  it 'casts the objectid to the string if valid', (done) ->
+    schema = Joi.string().objectid()
+    schema.validate '5936f5530fae440cda9ae052', (err, result) ->
+      (typeof result).should.equal 'object'
+      done()

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "google-spreadsheet": "^2.0.3",
     "graphql": "^0.7.2",
     "jade": "^1.11.0",
-    "joi": "^9.1.0",
+    "joi": "^10.5.0",
     "joi-objectid": "^2.0.0",
     "joiql": "0.1.0",
     "kerberos": "0.0.21",

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -171,6 +171,12 @@ module.exports = ->
   fixtures.verticals =
     id: '55356a9deca560a0137bb4a7'
     name: 'Culture'
+  fixtures.authors =
+    id: '55356a9deca560a0137bb4a7'
+    name: 'Halley Johnson'
+    bio: 'Writer based in NYC'
+    twitter_handle: '@kanaabe'
+    image_url: 'https://artsy-media.net/halley.jpg'
   fixtures.locals =
     asset: ->
     user: new User fixtures.users

--- a/yarn.lock
+++ b/yarn.lock
@@ -3072,14 +3072,13 @@ joi-objectid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/joi-objectid/-/joi-objectid-2.0.0.tgz#56549573a66ba795dcf6b9e226de5f3b2d36ec3a"
 
-joi@^9.1.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-9.2.0.tgz#3385ac790192130cbe230e802ec02c9215bbfeda"
+joi@^10.5.0:
+  version "10.5.2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-10.5.2.tgz#64f6853b080e9df0cf4cc9e204fa12cc8f792c48"
   dependencies:
     hoek "4.x.x"
     isemail "2.x.x"
     items "2.x.x"
-    moment "2.x.x"
     topo "2.x.x"
 
 joiql@0.1.0:
@@ -3645,7 +3644,7 @@ module-deps@^4.0.8:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment@2.x.x, moment@^2.10.6, moment@^2.11.1:
+moment@^2.10.6, moment@^2.11.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 


### PR DESCRIPTION
API-side of https://github.com/artsy/positron/issues/1080

The first commit is pretty straightforward and similar to other API endpoints we've done. 

The second commit is an attempt to use extensions to validate + typecast mongo objectids from a string. I experimented a bunch with this, and found that adding a validation on `string` was the most straightforward way to achieve both validation + typecasting. I posted [this issue](https://github.com/hapijs/joi/issues/1212) that could be a cleaner solution -- ie being able to say `Joi.objectId()` instead of `Joi.string().objectId()` but it doesn't seem possible.