### PR TITLE
@craigspaeth => QA Edit Content panel

### DIFF
--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -41,7 +41,7 @@ module.exports = class EditLayout extends Backbone.View
   serialize: ->
     {
       author_id: @user.get('id')
-      title: @$('#edit-title textarea').val()
+      title: @article.get 'title'
       thumbnail_title: @$('.edit-title-textarea').val()
       description: @$('.edit-display--magazine .edit-display__description textarea').val()
       social_title: @$('.edit-display--social .edit-display__headline textarea').val()
@@ -96,7 +96,7 @@ module.exports = class EditLayout extends Backbone.View
 
   events:
     'click #edit-tabs > a:not(#edit-publish)': 'toggleTabs'
-    'keyup :input:not(.tt-input,.edit-admin__fields .bordered-input, .edit-display__textarea,#edit-seo__focus-keyword), [contenteditable]:not(.tt-input)': 'onKeyup'
+    'keyup :input:not(.tt-input,.invisible-input, .edit-admin__fields .bordered-input, .edit-display__textarea,#edit-seo__focus-keyword), [contenteditable]:not(.tt-input)': 'onKeyup'
     'keyup .edit-display__textarea, #edit-seo__focus-keyword, [contenteditable]:not(.tt-input)': 'onYoastKeyup'
     'click .edit-section-container *': 'popLockControls'
     'click .edit-section-tool-menu li': -> _.defer => @popLockControls()

--- a/client/apps/edit/components/section_header/index.coffee
+++ b/client/apps/edit/components/section_header/index.coffee
@@ -10,20 +10,14 @@ module.exports = React.createClass
   changeTitle: (e) ->
     if e.key is 'Enter'
       e.preventDefault()
+
+  setTitle: ->
     @props.article.set 'title', this.refs.title.value
     @props.saveArticle()
 
-  changeLeadParagraph: (html) ->
+  setLeadParagraph: (html) ->
     @props.article.setLeadParagraph(html)
     @props.saveArticle()
-
-  getPublishDate: ->
-    date = new Date
-    if @props.article.get('published')
-      date = @props.article.get('published_at')
-    else if @props.article.get('scheduled_publish_at')
-      date = @props.article.get('scheduled_publish_at')
-    return moment(date).format('MMM D, YYYY h:mm a')
 
   render: ->
     div { className: 'edit-header-container' },
@@ -34,6 +28,7 @@ module.exports = React.createClass
           placeholder: 'Type a title'
           defaultValue: @props.article.get 'title'
           onKeyPress: @changeTitle
+          onKeyUp: @setTitle
           ref: 'title'
         }
         unless @props.article.get('title')?.length > 0
@@ -45,7 +40,7 @@ module.exports = React.createClass
       },
         RichTextParagraph {
           text: @props.article.get('lead_paragraph')
-          onChange: @changeLeadParagraph
+          onChange: @setLeadParagraph
           placeholder: 'Lead paragraph (optional)'
         }
 
@@ -53,4 +48,4 @@ module.exports = React.createClass
         if @props.article.get('author')
           p { className: 'article-author' },
             @props.article.get('author').name
-        p { className: 'article-date' }, @getPublishDate()
+        p { className: 'article-date' }, @props.article.getPublishDate()

--- a/client/apps/edit/components/section_header/test/index.coffee
+++ b/client/apps/edit/components/section_header/test/index.coffee
@@ -45,10 +45,10 @@ describe 'SectionHeader', ->
     it 'Can display a saved title', ->
       $(ReactDOM.findDOMNode(@component)).find('#edit-title textarea').val().should.eql 'Top Ten Booths'
 
-    it '#changeTitle sets article title on change', ->
+    it '#setTitle sets article title on change', ->
       input = r.find @component, 'invisible-input'
       input.value = 'Top 8 Booths'
-      r.simulate.keyPress input
+      r.simulate.keyUp input
       @component.props.article.get('title').should.eql 'Top 8 Booths'
 
     it '#changeTitle does not allow linebreaks', ->
@@ -62,7 +62,7 @@ describe 'SectionHeader', ->
     it 'Calls #saveArticle on change', ->
       input = r.find @component, 'invisible-input'
       input.value = 'Top 8 Booths'
-      r.simulate.keyPress input
+      r.simulate.keyUp input
       @component.props.saveArticle.called.should.eql true
 
   describe 'Lead Paragraph', ->
@@ -73,8 +73,8 @@ describe 'SectionHeader', ->
     it 'Can display a saved lead paragraph', ->
       $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Just before the lines start forming...'
 
-    it '#changeLeadParagraph sets and saves article lead paragraph on change', ->
-      @component.changeLeadParagraph('<p>A new paragraph</p>')
+    it '#setLeadParagraph sets and saves article lead paragraph on change', ->
+      @component.setLeadParagraph('<p>A new paragraph</p>')
       @component.props.article.leadParagraph.get('text').should.eql '<p>A new paragraph</p>'
       @component.props.saveArticle.called.should.eql true
 
@@ -88,15 +88,17 @@ describe 'SectionHeader', ->
 
     it '#getPublishDate returns the current date if unpublished and no scheduled_publish_at', ->
       now = moment().format('MMM D, YYYY')
-      @component.getPublishDate().should.containEql now
+      $(ReactDOM.findDOMNode(@component)).find('.article-date').text().should.containEql now
 
     it 'renders scheduled_publish_at if unpublished and scheduled', ->
       scheduled = moment().add(1, 'years')
       @component.props.article.set('scheduled_publish_at', scheduled.toISOString())
-      @component.getPublishDate().should.containEql scheduled.format('MMM D, YYYY')
+      @component.forceUpdate()
+      $(ReactDOM.findDOMNode(@component)).find('.article-date').text().should.containEql scheduled.format('MMM D, YYYY')
 
     it 'renders a published_at if published', ->
       published = moment().subtract(1, 'years')
       @component.props.article.set('published', true)
       @component.props.article.set('published_at', published.toISOString())
-      @component.getPublishDate().should.containEql published.format('MMM D, YYYY')
+      @component.forceUpdate()
+      $(ReactDOM.findDOMNode(@component)).find('.article-date').text().should.containEql published.format('MMM D, YYYY')

--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -50,6 +50,14 @@ module.exports = class Article extends Backbone.Model
     return @get('author').name if @get('author')
     ''
 
+  getPublishDate: ->
+    date = new Date
+    if @get('published')
+      date = @get('published_at')
+    else if @get('scheduled_publish_at')
+      date = @get('scheduled_publish_at')
+    return moment(date).format('MMM D, YYYY h:mm a')
+
   date: (attr) ->
     if @get(attr)
       moment(new Date(@get(attr))).local()

--- a/client/test/models/article.coffee
+++ b/client/test/models/article.coffee
@@ -91,6 +91,25 @@ describe "Article", ->
       @article.trigger 'sync'
       @article.heroSection.get('type').should.equal 'foo'
 
+  describe '#getPublishDate', ->
+
+    it 'returns the current date if unpublished and no scheduled_publish_at', ->
+      @article.set published: false
+      now = moment().format('MMM D, YYYY')
+      @article.getPublishDate().should.containEql now
+
+    it 'returns scheduled_publish_at if unpublished and scheduled', ->
+      @article.set published: false
+      scheduled = moment().add(1, 'years')
+      @article.set('scheduled_publish_at', scheduled.toISOString())
+      @article.getPublishDate().should.containEql scheduled.format('MMM D, YYYY')
+
+    it 'returns published_at if published', ->
+      @article.set published: true
+      published = moment().subtract(1, 'years')
+      @article.set published_at: published.toISOString()
+      @article.getPublishDate().should.containEql published.format('MMM D, YYYY')
+
   describe '#setLeadParagraph', ->
 
     it 'sets @leadParagraph to html contents', ->


### PR DESCRIPTION
Fixes a bug with title on first save - using keypress to trigger save meant the value of the keypress didn't make it into save.  Now using a keypress to detect the enter key, and keyup for save action. 

Also moves published date formatting to article model. 