### PR TITLE
@kanaabe => Update captions, Video section mini-refactor

### DIFF
--- a/client/apps/edit/components/hero_section/index.styl
+++ b/client/apps/edit/components/hero_section/index.styl
@@ -35,3 +35,5 @@
       line-height 500px
     iframe
       min-height 590px
+  .esic-img-container
+    padding 20px

--- a/client/apps/edit/components/section_image/index.coffee
+++ b/client/apps/edit/components/section_image/index.coffee
@@ -5,11 +5,12 @@
 _ = require 'underscore'
 gemup = require 'gemup'
 React = require 'react'
-RichTextCaption = React.createFactory require '../../../../components/rich_text_caption/index.coffee'
+DisplayImage = React.createFactory require '../section_image_collection/components/image.coffee'
 sd = require('sharify').data
 icons = -> require('./icons.jade') arguments...
 { div, section, h1, h2, span, img, header, input, nav, a, button, p } = React.DOM
 { crop, resize, fill } = require '../../../../components/resizer/index.coffee'
+
 
 module.exports = React.createClass
   displayName: 'SectionImage'
@@ -17,7 +18,7 @@ module.exports = React.createClass
   getInitialState: ->
     src: @props.section.get('url')
     progress: null
-    caption: @props.section.get('caption')
+    caption: @props.section.get('caption') or ''
     width: @props.section.get('width')
     height: @props.section.get('height')
 
@@ -71,13 +72,6 @@ module.exports = React.createClass
                 if @props.section.get('url') then 'replace' else 'upload')
             h2 {}, 'Up to 30mb'
             input { type: 'file', onChange: @upload }
-          div { className: 'esi-caption-container' },
-            RichTextCaption {
-              item: @state
-              key: 'caption-edit' + @props.section.cid
-              onChange: @onCaptionChange
-            }
-
       (
         if @state.progress
           div { className: 'upload-progress-container' },
@@ -88,18 +82,13 @@ module.exports = React.createClass
       )
       (
         if @state.src
-          div { className: 'esi-preview' },
-            img {
-              className: 'esi-image'
-              src: if @state.progress then @state.src else resize(@state.src, width: 900)
-              style: opacity: if @state.progress then @state.progress else '1'
-              key: 0
-            }
-            div {
-              className: 'esi-inline-caption'
-              dangerouslySetInnerHTML: __html: @state.caption
-              key: 1
-            }
+          image = _.extend {}, url: @state.src, caption: @state.caption
+          console.log image
+          DisplayImage {
+            image: image
+            progress: @state.progress
+            editing:  @props.editing
+          }
         else
           div { className: 'esi-placeholder' }, 'Add an image above'
       )

--- a/client/apps/edit/components/section_image/index.coffee
+++ b/client/apps/edit/components/section_image/index.coffee
@@ -83,7 +83,6 @@ module.exports = React.createClass
       (
         if @state.src
           image = _.extend {}, url: @state.src, caption: @state.caption
-          console.log image
           DisplayImage {
             image: image
             progress: @state.progress

--- a/client/apps/edit/components/section_image/index.styl
+++ b/client/apps/edit/components/section_image/index.styl
@@ -28,48 +28,11 @@
       background #000
       border-top 1px solid #333
 
-.esi-preview
-  padding 20px
-
-.esi-image
+.esic-image
   width 100%
   transition opacity 0.5s
-
-.esi-inline-caption
-  color gray-darker-color
-  garamond l-caption
-  a
-    color gray-darker-color
 
 #edit-thumbnail-upload
   position relative
   .upload-progress-container
     display none
-
-.esi-caption-container
-  .rich-text--caption
-    flex-direction column-reverse
-    &__input
-      width 100%
-      border 1px solid gray-darker-color
-      color white
-      garamond s-body
-      a
-        color white
-        border-bottom 1px solid
-      .public-DraftEditorPlaceholder-root
-        width calc(100% \- 30px)
-        text-align center
-    &__actions
-      width 100%
-      .italic
-        text-align right
-        padding-right 20px
-      .link
-        text-align left
-        margin-left 10px
-  .rich-text--url-input
-    margin-top 40px
-    background-color gray-darkest-color
-    button.add-link::after
-      border-bottom-color gray-darkest-color

--- a/client/apps/edit/components/section_image/test/index.coffee
+++ b/client/apps/edit/components/section_image/test/index.coffee
@@ -75,12 +75,11 @@ describe 'SectionImage', ->
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'foobaz'
 
   it 'renders a caption', ->
+    @component.setState({ src: 'foobaz.jpg' })
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'hello!'
 
-  it 'previews captions on keyup', ->
-    @component.setState({ src: 'foobaz.jpg' })
-    @component.onCaptionChange('<p>foobar</p>')
-    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'foobar'
+  it 'does not render a caption without an image', ->
+    $(ReactDOM.findDOMNode(@component)).html().should.not.containEql '<div class="rich-text--caption">'
 
   it 'saves captions on click off', ->
     @component.state.caption = 'foobar'

--- a/client/apps/edit/components/section_image_collection/components/image.coffee
+++ b/client/apps/edit/components/section_image_collection/components/image.coffee
@@ -16,15 +16,11 @@ module.exports = React.createClass
         src: if @props.progress then image.url else resize image.url, width: 900
         style: opacity: if @props.progress then @props.progress else '1'
       }
-      if @props.editing
-        RichTextCaption {
-          item: image
-        }
-      else
-        div {
-          dangerouslySetInnerHTML: __html: image.caption
-          className: 'esic-caption esic-caption--display'
-        }
+      RichTextCaption {
+        item: image
+        editing: @props.editing
+        placeholder: 'Image Caption'
+      }
       button {
         className: 'edit-section-remove button-reset esic-img-remove'
         onClick: @props.removeItem(image)

--- a/client/apps/edit/components/section_image_collection/components/image.coffee
+++ b/client/apps/edit/components/section_image_collection/components/image.coffee
@@ -21,8 +21,9 @@ module.exports = React.createClass
         editing: @props.editing
         placeholder: 'Image Caption'
       }
-      button {
-        className: 'edit-section-remove button-reset esic-img-remove'
-        onClick: @props.removeItem(image)
-        dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
-      }
+      if @props.removeItem
+        button {
+          className: 'edit-section-remove button-reset esic-img-remove'
+          onClick: @props.removeItem(image)
+          dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
+        }

--- a/client/apps/edit/components/section_image_collection/test/index.coffee
+++ b/client/apps/edit/components/section_image_collection/test/index.coffee
@@ -17,6 +17,7 @@ describe 'ImageCollection', ->
     benv.setup =>
       benv.expose $: benv.require 'jquery'
       $.fn.fillwidthLite = sinon.stub()
+      global.HTMLElement = () => {}
       @ImageCollection = benv.require resolve(__dirname, '../index')
       DisplayArtwork = benv.requireWithJadeify(
         resolve(__dirname, '../components/artwork')
@@ -26,7 +27,11 @@ describe 'ImageCollection', ->
         resolve(__dirname, '../components/image')
         ['icons']
       )
-      DisplayImage.__set__ 'RichTextCaption', sinon.stub()
+      RichTextCaption = benv.requireWithJadeify(
+        resolve(__dirname, '../../../../../components/rich_text_caption/index')
+        ['icons']
+      )
+      DisplayImage.__set__ 'RichTextCaption', React.createFactory RichTextCaption
       Controls = benv.require resolve(__dirname, '../components/controls')
       Controls.__set__ 'Autocomplete', sinon.stub()
       Controls.__set__ 'UrlArtworkInput', sinon.stub()
@@ -66,15 +71,14 @@ describe 'ImageCollection', ->
     benv.teardown()
 
   it 'renders an image collection component with preview', ->
-    rendered = ReactDOMServer.renderToString React.createElement(@ImageCollection, @props)
-    $(rendered).find('img').length.should.eql 2
-    $(rendered).find('.esic-caption--display').css('display').should.equal 'block'
-    $(rendered).find('.esic-caption--display').html().should.containEql '<p>Here is a caption</p>'
+    $(ReactDOM.findDOMNode(@component)).find('img').length.should.eql 2
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Here is a caption'
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'The Four Hedgehogs'
 
   it 'renders a placeholder if no images', ->
-    @props.section.set 'images', []
-    rendered = ReactDOMServer.renderToString React.createElement(@ImageCollection, @props)
-    $(rendered).find('.esic-placeholder').html().should.containEql 'Add images and artworks above'
+    @component.props.section.set 'images', []
+    @component.forceUpdate()
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Add images and artworks above'
 
   it 'renders a progress indicator if progress', ->
     @component.setState progress: .5

--- a/client/apps/edit/components/section_text/index.coffee
+++ b/client/apps/edit/components/section_text/index.coffee
@@ -20,7 +20,7 @@ window.process = {env: {NODE_ENV: sd.NODE_ENV}}
   blockTypes,
   blockRenderMap,
   decorators } = require './draft_config.coffee'
-{ stripGoogleStyles, keyBindingFn } = require '../../../../components/rich_text/utils/index.coffee'
+{ stripGoogleStyles, keyBindingFnFull } = require '../../../../components/rich_text/utils/index.coffee'
 
 editor = (props) -> React.createElement Editor, props
 { div, nav, a, span, p, h3 } = React.DOM
@@ -339,7 +339,7 @@ module.exports = React.createClass
     },
       if @state.showMenu
         nav {
-          className: 'edit-section-text__menu' + hasPlugins
+          className: 'edit-section-text__menu rich-text--nav' + hasPlugins
           style:
             top: @state.selectionTarget?.top
             marginLeft: @state.selectionTarget?.left
@@ -361,7 +361,7 @@ module.exports = React.createClass
           onChange: @onChange
           decorators: decorators
           handleKeyCommand: @handleKeyCommand
-          keyBindingFn: keyBindingFn
+          keyBindingFn: keyBindingFnFull
           handlePastedText: @onPaste
           blockRenderMap: blockRenderMap()
         }

--- a/client/apps/edit/components/section_text/index.styl
+++ b/client/apps/edit/components/section_text/index.styl
@@ -39,71 +39,15 @@
     ul li .public-DraftStyleDefault-ltr,
     li.public-DraftStyleDefault-unorderedListItem .public-DraftStyleDefault-ltr
       list-style disc
+
   nav
-    position absolute
-    top -40px
-    left 0
-    display flex !important
-    flex-wrap wrap
-    background black
-    justify-content center
     width 200px
-    border-radius 5px
-    z-index 6
     &.has-plugins
       width 250px
       button[name='remove-formatting'],
       button[name='header-three']
         border-right none
-    ::after
-      content ''
-      width 0
-      height 0
-      border-left 7px solid transparent
-      border-right 7px solid transparent
-      border-top 7px solid #000
-      position absolute
-      bottom -7px
-      left calc(50% \- 7px)
-    button
-      font-weight 600
-      height 40px
-      width 50px
-      color gray-dark-color
-      line-height 1em !important
-      background none
-      border none
-      border-right 1px solid gray-darkest-color
-      transition color .15s
-      &:hover
-        color gray-color
-      &[name='ITALIC'],
-      &[name='STRIKETHROUGH'],
-      &[name='header-two'],
-      &[name='header-three']
-        garamond l-body
-      &[name='BOLD']
-        font-weight 600
-        avant-garde l-headline
-      &[name='STRIKETHROUGH']
-        text-decoration line-through
-      svg
-        width 18px
-        height 18px
-      .st0, circle, g, path
-        fill gray-dark-color
-        transition color .15s
-      &:hover
-        .st0, circle, g, path
-          fill gray-color
-      &[name='toc']
-        svg
-          width 22px
-          height 22px
-          #Group-2-Copy
-            fill black
-        &:hover g
-          stroke gray-color
+
   &__input
     position relative
     .artist-follow

--- a/client/apps/edit/components/section_video/icons.jade
+++ b/client/apps/edit/components/section_video/icons.jade
@@ -1,0 +1,2 @@
+.remove
+  include ../../public/icons/edit_section_remove.svg

--- a/client/apps/edit/components/section_video/index.coffee
+++ b/client/apps/edit/components/section_video/index.coffee
@@ -62,15 +62,12 @@ module.exports = React.createClass
     @setState coverSrc: null
 
   render: ->
-    coverUrl = if @state.progress then @state.coverSrc \
-          else resize(@state.coverSrc, width: 1100)
-
     coverPreview = div {
       className: 'esv-cover-image-container'
       onClick: @props.setEditing(on)
       key: 'cover' + @props.section.cid
       style:
-        backgroundImage: "url(#{coverUrl})"
+        backgroundImage: "url(#{@state.coverSrc})"
         height: @getVideoHeight()
         opacity: if @state.progress then @state.progress else '1'
     },
@@ -117,7 +114,10 @@ module.exports = React.createClass
               span {}, (' to ' + if @state.cover_image_url then 'replace' else 'upload')
             h2 {}, 'Up to 30mb'
             input { type: 'file', onChange: @uploadCoverImage }
-      div { className: 'esv-video-container' },
+      div {
+        className: 'esv-video-container'
+        onClick: @props.setEditing(on)
+      },
         if @state.progress
           div { className: 'upload-progress-container' },
             div {
@@ -126,12 +126,13 @@ module.exports = React.createClass
             }
         if @state.coverSrc or @state.url
           [
+            if @state.url.length
+              iframe {
+                src: getIframeUrl(@state.url)
+                height: @getVideoHeight()
+                key: 1
+              }
             coverPreview if @state.coverSrc
-            iframe {
-              src: getIframeUrl(@state.url)
-              height: @getVideoHeight()
-              key: 1
-            }
             RichTextCaption {
               item: @state
               key: 'caption-edit' + @props.section.cid

--- a/client/apps/edit/components/section_video/index.styl
+++ b/client/apps/edit/components/section_video/index.styl
@@ -4,16 +4,16 @@ play-button-size = 30px
 short-input-width = 290px
 wide-input-width = 640px
 
-.edit-section-video .esv-controls-container
-  fill-container()
-  display none
-  z-index 3
-  height 384px
-  top -(@height)
-  background black
-
-.esv-nav
-  text-align center
+.edit-section-video
+  .esv-controls-container
+    fill-container()
+    display none
+    z-index 3
+    height 300px
+    top -(@height)
+    background black
+  iframe
+    width 100%
 
 .esv-inputs
   padding controls-padding
@@ -32,37 +32,28 @@ wide-input-width = 640px
     position relative
     top 1px
 
-.esv-nav a
-  display inline-block
-  height 40px
-  width @height + 20px
-  background no-repeat center center
-  transition opacity 0.3s
-  opacity 0.5
-  cursor pointer
-  &:hover
-    opacity 1
-  &:last-of-type
-    border-right 0
-  background-repeat no-repeat !important
-  background-position center !important
-
-.esv-background-color.flat-radio-button
-  margin-top 10px
-  h2
-    avant-garde()
-    font-size 11px
-  label
-    avant-garde()
-    font-size 11px
-    margin-right 10px
-  input
-    width 17px
-    height 17px
-    margin 4px 5px 0 0
-    border-radius 10px
-    z-index 3
-    background-color white
+#edit-content .esv-nav
+  text-align center
+  a
+    display inline-block
+    height 40px
+    width @height + 20px
+    transition opacity 0.3s
+    opacity 0.5
+    cursor pointer
+    color white
+    background-repeat no-repeat !important
+    background-position center !important
+    &:hover
+      opacity 1
+    &:last-of-type
+      border-right 0
+    &.esv-column-width
+      background-image url(/icons/edit_artworks_column_width.svg)
+      background-size 22px
+    &.esv-overflow-fillwidth
+      background-image url(/icons/edit_artworks_overflow_fillwidth.svg)
+      background-size 38px
 
 [data-useragent*=Firefox] .edit-section-video .edit-section-controls input
   width 397px
@@ -78,18 +69,25 @@ wide-input-width = 640px
 .edit-section-container[data-editing=true]
   .esv-controls-container
     display block
+  .rich-text--caption__input
+    z-index 3
   .edit-section-video iframe
     position relative
     z-index 2
 
-.esv-cover-image
-  width 100%
-  min-height 50px
-  background gray-lightest-color
-  max-width 1100px
-
 .esv-cover-image-container
+    position absolute
+    width 100%
+    z-index 5
+    background-size cover
+    background-position 50%
+
+.esv-video-container
   position relative
+  .edit-section-remove svg *
+    fill black
+    &:hover
+      fill red-color
 
 .esv-cover-image-play-container
   background white
@@ -112,22 +110,21 @@ wide-input-width = 640px
 //
 // Varying layouts
 //
-.edit-section-container[data-layout=column_width]
-  nav .esv-column-width
+#edit-content .edit-section-container[data-layout=column_width]
+  .edit-section-controls
+    width 620px
+  nav a.esv-column-width
     opacity 1
   iframe
     width 100%
 
-.edit-section-container[data-layout=overflow_fillwidth][data-type=video]
+#edit-content .edit-section-container[data-layout=overflow_fillwidth][data-type=video]
   width 1100px
   left -240px
   min-height 400px
-  .edit-section-video
-    width calc(100vw - 110px)
-    margin-left calc(1220px + ((100vw - 1270px)/2) - 100vw)
-    img, iframe
-      margin-left calc(100vw - (1220px + ((100vw - 1270px)/2)))
-  nav .esv-overflow-fillwidth
+  .edit-section-controls
+    width 1100px
+  nav a.esv-overflow-fillwidth
     opacity 1
   .esv-inputs
     .bordered-input

--- a/client/apps/edit/components/section_video/index.styl
+++ b/client/apps/edit/components/section_video/index.styl
@@ -76,11 +76,13 @@ wide-input-width = 640px
     z-index 2
 
 .esv-cover-image-container
-    position absolute
-    width 100%
-    z-index 5
-    background-size cover
-    background-position 50%
+  position absolute
+  top 0
+  left 0
+  right 0
+  z-index 3
+  background-size cover
+  background-position 50%
 
 .esv-video-container
   position relative

--- a/client/apps/edit/components/section_video/test/index.coffee
+++ b/client/apps/edit/components/section_video/test/index.coffee
@@ -18,24 +18,40 @@ describe 'SectionVideo', ->
     benv.setup =>
       benv.expose $: benv.require('jquery'), resize: ->
       global.HTMLElement = () => {}
-      SectionVideo = benv.require resolve __dirname, '../index'
-      RichTextCaption = benv.requireWithJadeify(resolve(__dirname, '../../../../../components/rich_text_caption/index'), ['icons'])
+      SectionVideo = benv.requireWithJadeify(
+        resolve __dirname, '../index'
+        ['icons']
+      )
+      RichTextCaption = benv.requireWithJadeify(
+        resolve(__dirname, '../../../../../components/rich_text_caption/index')
+        ['icons']
+      )
       SectionVideo.__set__ 'RichTextCaption', React.createFactory(RichTextCaption)
       SectionVideo.__set__ 'gemup', @gemup = sinon.stub()
+      SectionVideo.__set__ 'resize', @resize = sinon.stub().returns('http://image.jpg')
       props = {
         section: new Backbone.Model
           url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
           caption: '<p>Rick Astley - Never Gonna Give You Up</p>'
-        editing: false
+        editing: true
         setEditing: -> ->
       }
-      @rendered = ReactDOMServer.renderToString React.createElement(SectionVideo, props)
       @component = ReactDOM.render React.createElement(SectionVideo, props), (@$el = $ "<div></div>")[0], => setTimeout =>
         sinon.stub $, 'ajax'
         done()
 
   afterEach ->
     benv.teardown()
+
+  it 'renders the video url', ->
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'dQw4w9WgXcQ'
+
+  it 'renders the cover image', ->
+    @component.setState coverSrc: 'http://image.jpg'
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'http://image.jpg'
+
+  it 'renders the caption', ->
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Never Gonna Give You Up'
 
   it 'removes itself when clicking off & the section is empty', ->
     @component.props.section.destroy = sinon.stub()
@@ -44,30 +60,26 @@ describe 'SectionVideo', ->
     @component.onClickOff()
     @component.props.section.destroy.called.should.be.ok
 
-  it 'saves captions on click off', ->
-    @component.state.caption = 'updated'
-    @component.onClickOff()
-    @component.props.section.get('caption').should.equal 'updated'
-
-  it 'changes the caption when submitting', ->
-    @component.onCaptionChange('<p>updated</p>')
-    $(ReactDOM.findDOMNode(@component)).html().should.containEql '<p>updated</p>'
-
-  it 'changes the video and caption when submitting', ->
+  it 'changes the video when submitting', ->
     $(@component.refs.input).val 'https://youtube/foobar'
     @component.onChangeUrl preventDefault: ->
-    $(ReactDOM.findDOMNode(@component)).html().should.containEql '<iframe src="//www.youtube.com/embed/foobar" width="100%" height="313px">'
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql '<iframe src="//www.youtube.com/embed/foobar" height="600px">'
 
-  it 'renders the video url', ->
-    $(@rendered).html().should.containEql 'dQw4w9WgXcQ'
+  it 'saves captions on click off', ->
+    @component.setState caption: '<p>updated</p>'
+    @component.onClickOff()
+    @component.props.section.get('caption').should.equal '<p>updated</p>'
 
-  it 'renders the caption', ->
-    $(@rendered).html().should.containEql 'Never Gonna Give You Up'
-
-  it 'changes the background when radio button is clicked', ->
-    r.simulate.click r.find @component, "esv-background-black"
-    @component.state.background_color.should.equal 'black'
+  it 'onCaptionChange changes the caption', ->
+    @component.onCaptionChange('<p>updated</p>')
+    @component.state.caption.should.equal '<p>updated</p>'
 
   it 'changes the layout when clicked', ->
     r.simulate.click r.find @component, 'esv-overflow-fillwidth'
-    @component.state.layout.should.equal 'overflow_fillwidth'
+    @component.props.section.get('layout').should.equal 'overflow_fillwidth'
+
+  it 'removes the cover image when remove-button clicked', ->
+    @component.setState coverSrc: 'http://image.jpg'
+    r.simulate.click r.find @component, 'edit-section-remove'
+    $(ReactDOM.findDOMNode(@component)).html().should.not.containEql 'http://image.jpg'
+

--- a/client/components/rich_text/index.styl
+++ b/client/components/rich_text/index.styl
@@ -50,3 +50,63 @@
     position absolute
     top -7px
     left 50%
+
+.rich-text--nav
+  position absolute
+  top -40px
+  left 0
+  display flex !important
+  flex-wrap wrap
+  background black
+  justify-content center
+  border-radius 5px
+  z-index 6
+  ::after
+    content ''
+    width 0
+    height 0
+    border-left 7px solid transparent
+    border-right 7px solid transparent
+    border-top 7px solid #000
+    position absolute
+    bottom -7px
+    left calc(50% \- 7px)
+  button
+    font-weight 600
+    height 40px
+    width 50px
+    color gray-dark-color
+    line-height 1em !important
+    background none
+    border none
+    border-right 1px solid gray-darkest-color
+    transition color .15s
+    &:hover
+      color gray-color
+    &[name='ITALIC'],
+    &[name='STRIKETHROUGH'],
+    &[name='header-two'],
+    &[name='header-three']
+      garamond l-body
+    &[name='BOLD']
+      font-weight 600
+      avant-garde l-headline
+    &[name='STRIKETHROUGH']
+      text-decoration line-through
+    svg
+      width 18px
+      height 18px
+    .st0, circle, g, path
+      fill gray-dark-color
+      transition color .15s
+    &:hover
+      .st0, circle, g, path
+        fill gray-color
+    &[name='toc']
+      svg
+        width 22px
+        height 22px
+        #Group-2-Copy
+          fill black
+      &:hover g
+        stroke gray-color

--- a/client/components/rich_text/test/utils.coffee
+++ b/client/components/rich_text/test/utils.coffee
@@ -49,30 +49,30 @@ describe 'Utils', ->
       @utils.stripGoogleStyles(html).should.eql '<span><em>(via </em></span><a href="http://theartnewspaper.com/market/dealer-cuts-plea-bargain/" style="text-decoration:none;"><span><em>The Art Newspaper</em></span></a><span><em>)</em></span>'
 
 
-  describe '#keyBindingFn', ->
+  describe '#keyBindingFnFull', ->
 
     it 'returns the name of a recognized key binding', ->
       e = { keyCode: 50 }
-      @utils.keyBindingFn(e).should.eql 'header-two'
+      @utils.keyBindingFnFull(e).should.eql 'header-two'
       e = { keyCode: 51 }
-      @utils.keyBindingFn(e).should.eql 'header-three'
+      @utils.keyBindingFnFull(e).should.eql 'header-three'
       e = { keyCode: 191 }
-      @utils.keyBindingFn(e).should.eql 'custom-clear'
+      @utils.keyBindingFnFull(e).should.eql 'custom-clear'
       e = { keyCode: 55 }
-      @utils.keyBindingFn(e).should.eql 'ordered-list-item'
+      @utils.keyBindingFnFull(e).should.eql 'ordered-list-item'
       e = { keyCode: 56 }
-      @utils.keyBindingFn(e).should.eql 'unordered-list-item'
+      @utils.keyBindingFnFull(e).should.eql 'unordered-list-item'
       e = { keyCode: 75 }
-      @utils.keyBindingFn(e).should.eql 'link-prompt'
+      @utils.keyBindingFnFull(e).should.eql 'link-prompt'
       @getDefaultKeyBinding.callCount.should.eql 0
 
     it 'returns the default key binding if no command modifier', ->
       @KeyBindingUtil.hasCommandModifier = sinon.stub().returns(false)
       e = { keyCode: 75 }
-      @utils.keyBindingFn(e)
+      @utils.keyBindingFnFull(e)
       @getDefaultKeyBinding.callCount.should.eql 1
 
     it 'returns the default key binding if no custom setting specified', ->
       e = { keyCode: 45 }
-      @utils.keyBindingFn(e)
+      @utils.keyBindingFnFull(e)
       @getDefaultKeyBinding.callCount.should.eql 1

--- a/client/components/rich_text/test/utils.coffee
+++ b/client/components/rich_text/test/utils.coffee
@@ -76,3 +76,21 @@ describe 'Utils', ->
       e = { keyCode: 45 }
       @utils.keyBindingFnFull(e)
       @getDefaultKeyBinding.callCount.should.eql 1
+
+  describe '#keyBindingFnCaption', ->
+
+    it 'returns the name of a recognized key binding', ->
+      e = { keyCode: 75 }
+      @utils.keyBindingFnCaption(e).should.eql 'link-prompt'
+      @getDefaultKeyBinding.callCount.should.eql 0
+
+    it 'returns the default key binding if no command modifier', ->
+      @KeyBindingUtil.hasCommandModifier = sinon.stub().returns(false)
+      e = { keyCode: 75 }
+      @utils.keyBindingFnCaption(e)
+      @getDefaultKeyBinding.callCount.should.eql 1
+
+    it 'returns the default key binding if no custom setting specified', ->
+      e = { keyCode: 45 }
+      @utils.keyBindingFnCaption(e)
+      @getDefaultKeyBinding.callCount.should.eql 1

--- a/client/components/rich_text/utils/index.coffee
+++ b/client/components/rich_text/utils/index.coffee
@@ -24,7 +24,7 @@ exports.stripGoogleStyles = (html) ->
     $(doc.getElementsByTagName('SPAN')[i]).replaceWith(newSpan)
   return doc.innerHTML
 
-exports.keyBindingFn = (e) ->
+exports.keyBindingFnFull = (e) ->
   if KeyBindingUtil.hasCommandModifier(e)
     if e.keyCode is 50   # command + 2
       return 'header-two'
@@ -36,6 +36,12 @@ exports.keyBindingFn = (e) ->
       return 'ordered-list-item'
     if e.keyCode is 56   # command + 8
       return 'unordered-list-item'
+    if e.keyCode is 75   # command + K
+      return 'link-prompt'
+  return getDefaultKeyBinding(e)
+
+exports.keyBindingFnCaption= (e) ->
+  if KeyBindingUtil.hasCommandModifier(e)
     if e.keyCode is 75   # command + K
       return 'link-prompt'
   return getDefaultKeyBinding(e)

--- a/client/components/rich_text_caption/index.coffee
+++ b/client/components/rich_text_caption/index.coffee
@@ -90,6 +90,7 @@ module.exports = React.createClass
       .replace /(\r\n|\n|\r)/gm, ''
       .replace /<\/p><p>/g, ' '
       .replace(/  /g, ' &nbsp;')
+    html = if html is '<p></p>' then '' else html
     return html
 
   onPaste: (text, html) ->

--- a/client/components/rich_text_caption/index.styl
+++ b/client/components/rich_text_caption/index.styl
@@ -5,12 +5,14 @@
   justify-content flex-start
   position relative
   &__input
-    width calc(100% \- 85px)
     garamond l-caption
-    padding-top 8px
+    width 100%
+    color gray-darker-color
   .public-DraftEditorPlaceholder-root
     position absolute
     color gray-dark-color
+    left 0
+    right 0
   .bordered-input.has-focus
     border-color purple-color
   &__actions

--- a/client/components/rich_text_caption/test/index.coffee
+++ b/client/components/rich_text_caption/test/index.coffee
@@ -13,8 +13,13 @@ describe 'RichTextCaption', ->
         ReactTestUtils: require 'react-addons-test-utils'
         Draft: require 'draft-js'
       window.jQuery = $
+      window.getSelection = sinon.stub().returns(
+        isCollapsed: false, getRangeAt: sinon.stub().returns(
+          getClientRects: sinon.stub().returns([width: 20, top: 20, left: 20])
+        )
+      )
       @r =
-        find: ReactTestUtils.findRenderedDOMComponentWithClass
+        find: ReactTestUtils.scryRenderedDOMComponentsWithClass
         simulate: ReactTestUtils.Simulate
       @d =
         EditorState: Draft.EditorState
@@ -32,7 +37,8 @@ describe 'RichTextCaption', ->
             url: 'https://artsy.net/image.png'
             caption: '<p><a href="http://link.com">A link</a> is  inside a  <em>caption</em>.</p>'
           }
-        }
+        editing: true
+      }
       @component = ReactDOM.render React.createElement(@RichTextCaption, @props), (@$el = $ "<div></div>")[0], => setTimeout =>
         @component.stickyLinkBox = sinon.stub().returns {top: 20, left: 40}
         # a second component with preselected text
@@ -62,22 +68,48 @@ describe 'RichTextCaption', ->
     @component.onChange(@component.state.editorState)
     @component.state.html.should.eql '<p><a href="http://link.com/">A link</a> is &nbsp;inside a &nbsp;<em>caption</em>.</p>'
 
-  it 'Opens a link input popup', ->
-    @r.simulate.mouseDown @r.find @component, 'link'
-    @component.state.showUrlInput.should.eql true
+  it 'Shows a menu if text is selected', ->
+    @r.simulate.mouseUp @r.find(@selectComponent, 'rich-text--caption__input')[0]
+    $(ReactDOM.findDOMNode(@selectComponent)).html().should.containEql 'rich-text--caption__actions'
+    $(ReactDOM.findDOMNode(@selectComponent)).html().should.containEql '<button class="italic">'
+    $(ReactDOM.findDOMNode(@selectComponent)).html().should.containEql '<button class="link">'
+
+  it 'Opens a link input popup on click', ->
+    @r.simulate.mouseUp @r.find(@selectComponent, 'rich-text--caption__input')[0]
+    @r.simulate.mouseDown @r.find(@selectComponent, 'link')[0]
+    $(ReactDOM.findDOMNode(@selectComponent)).html().should.containEql 'rich-text--url-input'
+
+  it 'Opens a link input popup on key command', ->
+    @selectComponent.setState = sinon.stub()
+    @selectComponent.handleKeyCommand('link-prompt')
+    @selectComponent.setState.args[0][0].showUrlInput.should.eql true
 
   it 'Can remove an existing link', ->
-    @r.simulate.mouseDown @r.find @selectComponent, 'link'
+    @r.simulate.mouseUp @r.find(@selectComponent, 'rich-text--caption__input')[0]
+    @r.simulate.mouseDown @r.find(@selectComponent, 'link')[0]
     @selectComponent.state.urlValue.should.eql 'http://link.com/'
-    @r.simulate.mouseDown @r.find @selectComponent, 'remove-link'
+    @r.simulate.mouseDown @r.find(@selectComponent, 'remove-link')[0]
     @selectComponent.state.urlValue.should.eql ''
     @selectComponent.state.showUrlInput.should.eql false
 
-  it 'Can create italic blocks', ->
-    @r.simulate.mouseDown @r.find @selectComponent, 'italic'
+  it 'Can create italic blocks on click', ->
+    @r.simulate.mouseUp @r.find(@selectComponent, 'rich-text--caption__input')[0]
+    @r.simulate.mouseDown @r.find(@selectComponent, 'italic')[0]
     @selectComponent.state.html.should.eql '<p><em><a href="http://link.com/">A link</a></em> is &nbsp;inside a &nbsp;<em>caption</em>.</p>'
+
+  it 'Can create italic blocks on key command', ->
+    @selectComponent.setState = sinon.stub()
+    @selectComponent.handleKeyCommand('italic')
+    @selectComponent.setState.args[0][0].html.should.eql '<p><em><a href="http://link.com/">A link</a></em> is &nbsp;inside a &nbsp;<em>caption</em>.</p>'
 
   it 'Strips unsupported html and linebreaks on paste', ->
     @component.onPaste('Here is a caption about an image yep.', '<p>Here is a</p><ul><li><b>caption</b></li><li>about an image</li></ul><p>yep.</p>')
     @component.state.html.should.eql '<p>Here is a caption about an image yep.<a href="http://link.com/">A link</a> is &nbsp;inside a &nbsp;<em>caption</em>.</p>'
+
+  it 'does not save empty captions', ->
+    @component.props.item.caption = '<p></p>'
+    @component.componentDidMount()
+    @component.onChange(@component.state.editorState)
+    @component.state.html.should.eql ''
+
 


### PR DESCRIPTION
- Converts rich-text-caption input to use same 'popup' menu as text-component
- Adds key command for link to rich-text-caption
- Video and Image section to use same caption style as image-collection (moved out of controls)

In video section- 
- Renders of caption field when cover image present
- Removes background color options (per conversation w @owendodd)
- Adds ability to remove a cover image (before had to delete section or replace)