### PR TITLE
@kanaabe : add freshness boost when indexing for search #migration

### DIFF
--- a/api/apps/articles/model/distribute.coffee
+++ b/api/apps/articles/model/distribute.coffee
@@ -125,6 +125,7 @@ postSailthruAPI = (article, cb) ->
       tags: tags
       body: sections and stripHtmlTags(sections.join(' ')) or ''
       image_url: crop(article.thumbnail_image, { width: 70, height: 70 })
+      search_boost: article.searchBoost
     , (error, response) ->
       console.log('ElasticsearchIndexingError: Article ' + article.id + ' : ' + error) if error
   )

--- a/api/models/article.coffee
+++ b/api/models/article.coffee
@@ -30,6 +30,16 @@ module.exports = class Article extends Backbone.Model
     creator = _.union(creator, _.pluck(@get('contributing_authors'), 'name')) if @get('contributing_authors')?.length
     creator
 
+  # freshness boost as exponential decay on published_at date
+  searchBoost: ->
+    if @get('published')
+      maxBoost = 1000.0
+      meanLifetime = 365 * 3.0
+      decayDays = (new Date().getTime() - moment(@get('published_at')).toDate().getTime())/(1000 * 60 * 60 * 24)
+      maxBoost * Math.exp(-(decayDays/meanLifetime))
+    else
+      0
+
   isEditorial: ->
     @get('featured')
 

--- a/api/test/models/article.coffee
+++ b/api/test/models/article.coffee
@@ -58,6 +58,19 @@ describe "Article", ->
       @article.getAuthorArray()[1].should.equal 'Molly'
       @article.getAuthorArray()[2].should.equal 'Kana'
 
+  describe '#searchBoost', ->
+    it 'creates a freshness score for search with a maximum cap', ->
+      @article.set 'published', true
+      @article.set 'published_at', new Date()
+      @article.searchBoost().should.be.below(1001)
+      @article.searchBoost().should.be.above(999)
+
+    it 'creates a lower score for an older article', ->
+      @article.set 'published', true
+      @article.set 'published_at', new Date(2016, 4, 10)
+      @article.searchBoost().should.be.below(1000)
+      @article.searchBoost().should.be.above(100)
+
   describe '#date', ->
 
     it 'return a moment object with the attribute', ->

--- a/scripts/count.coffee
+++ b/scripts/count.coffee
@@ -1,0 +1,12 @@
+require('node-env-file')(require('path').resolve __dirname, '../.env')
+mongojs = require 'mongojs'
+path = require 'path'
+Article = require '../api/apps/articles/model/index'
+env = require 'node-env-file'
+
+# Connect to database
+db = mongojs(process.env.MONGOHQ_URL, ['articles'])
+
+db.articles.find(indexable: true).toArray (err, articles) ->
+    console.log(articles.length)
+    #console.log(article.thumbnail_image) for article in articles

--- a/scripts/reindex_articles.coffee
+++ b/scripts/reindex_articles.coffee
@@ -1,7 +1,7 @@
 require('node-env-file')(require('path').resolve __dirname, '../.env')
 mongojs = require 'mongojs'
 path = require 'path'
-{ indexForSearch } = Save = require '../api/apps/articles/model/save'
+{ indexForSearch } = Save = require '../api/apps/articles/model/distribute'
 Article = require '../api/apps/articles/model/index'
 search = require '../api/lib/elasticsearch'
 


### PR DESCRIPTION
This uses [exponential decay](https://en.wikipedia.org/wiki/Exponential_decay) on the `published_at` date of the article to produce a freshness boost for articles on artsy.net site search. It should fix the issue of fair booths ranking above articles when searching fair names.

We cap the maximum score at 1000 for a new article and use a 3 year mean lifetime, meaning the exponential curve drops to a score of around 360 in that time period - meaning most articles, even old ones, will be boosted significantly higher than most booths, partners, shows, and artists in search.

This can be merged immediately, but will rely on the follow up 
 to https://github.com/artsy/gravity/pull/11108 in order to function in production.

**Migration**

I will do a full search reindex of articles once this is merged:

```shell
yarn coffee scripts/reindex_articles.coffee
```
