### PR TITLE
@kanaabe => Fix CI tests

### DIFF
--- a/client/apps/settings/test/client/curations.coffee
+++ b/client/apps/settings/test/client/curations.coffee
@@ -15,7 +15,6 @@ describe 'EditCuration', ->
     benv.setup =>
       benv.expose $: benv.require 'jquery'
       Backbone.$ = $
-      sinon.stub Backbone, 'sync'
       @curation = new Curation
         name: 'Artsy Editorial Feature'
         id: '1234'
@@ -23,7 +22,7 @@ describe 'EditCuration', ->
         sections: [{body: 'foo'}]
         carousel: []
         placeholder: ""
-      locals = _.extend(fixtures().locals,
+      locals = _.extend(_.clone(fixtures().locals),
         curation: @curation
       )
       tmpl = resolve __dirname, '../../templates/curations/curation_edit.jade'
@@ -40,13 +39,11 @@ describe 'EditCuration', ->
 
   afterEach ->
     benv.teardown()
-    Backbone.sync.restore()
 
   describe '#initialize', ->
 
     it 'populates the form saved curation data', ->
       $('body textarea').html().should.containEql 'foo'
-
 
   describe '#initMenuState', ->
 

--- a/client/apps/settings/test/client/curations/venice_admin.coffee
+++ b/client/apps/settings/test/client/curations/venice_admin.coffee
@@ -28,7 +28,6 @@ describe 'VeniceAdmin', ->
       $.fn.typeahead = sinon.stub()
       window.jQuery = $
       VeniceAdmin = benv.require resolve __dirname, '../../../client/curations/venice_admin.coffee'
-      # VeniceSection = benv.require resolve __dirname, '../../../client/curations/venice_section.coffee'
       Autocomplete = benv.require resolve __dirname, '../../../../../components/autocomplete_list/index.coffee'
       dropdownHeader = benv.requireWithJadeify(
         resolve(__dirname, '../../../../edit/components/admin/components/dropdown_header.coffee'), ['icons']
@@ -38,10 +37,6 @@ describe 'VeniceAdmin', ->
         ARTSY_URL: 'http://localhost:3005'
         USER: access_token: ''
       }
-      # VeniceSection.__set__ 'sd', {
-      #   ARTSY_URL: 'http://localhost:3005'
-      #   USER: access_token: ''
-      # }
       Autocomplete.__set__ 'request', get: sinon.stub().returns
         set: sinon.stub().returns
           end: sinon.stub().yields(null, body: { id: '123', name: 'An Artist'})
@@ -51,7 +46,6 @@ describe 'VeniceAdmin', ->
       props = curation: @curation
       @component = ReactDOM.render React.createElement(VeniceAdmin, props), (@$el = $ "<div></div>")[0], =>
         setTimeout =>
-          # @component.state.curation.save = sinon.stub()
           done()
 
   afterEach ->

--- a/client/apps/settings/test/client/curations/venice_admin.coffee
+++ b/client/apps/settings/test/client/curations/venice_admin.coffee
@@ -13,7 +13,7 @@ r =
   simulate: ReactTestUtils.Simulate
   findTag: ReactTestUtils.scryRenderedDOMComponentsWithTag
 
-describe 'VeniceSection', ->
+describe 'VeniceAdmin', ->
 
   beforeEach (done) ->
     benv.setup =>
@@ -24,35 +24,39 @@ describe 'VeniceSection', ->
           ttAdapter: ->
         )
         _: benv.require 'underscore'
+      sinon.stub Backbone, 'sync'
       $.fn.typeahead = sinon.stub()
       window.jQuery = $
       VeniceAdmin = benv.require resolve __dirname, '../../../client/curations/venice_admin.coffee'
+      # VeniceSection = benv.require resolve __dirname, '../../../client/curations/venice_section.coffee'
+      Autocomplete = benv.require resolve __dirname, '../../../../../components/autocomplete_list/index.coffee'
       dropdownHeader = benv.requireWithJadeify(
         resolve(__dirname, '../../../../edit/components/admin/components/dropdown_header.coffee'), ['icons']
       )
       VeniceAdmin.__set__ 'dropdownHeader', React.createFactory dropdownHeader
-      VeniceSection = benv.require resolve __dirname, '../../../client/curations/venice_section.coffee'
-      Autocomplete = benv.require resolve __dirname, '../../../../../components/autocomplete_list/index.coffee'
-      VeniceAdmin.__set__ 'AutocompleteList', React.createFactory Autocomplete
-      Autocomplete.__set__ 'request', get: sinon.stub().returns
-        set: sinon.stub().returns
-          end: sinon.stub().yields(null, body: { id: '123', name: 'An Artist'})
-      VeniceSection.__set__ 'sd', {
+      VeniceAdmin.__set__ 'sd', {
         ARTSY_URL: 'http://localhost:3005'
         USER: access_token: ''
       }
-      @curation = new Curation
-      @curation.set 'sections', [{title: 'Searching For Venice'}, {title: 'Dawn Kasper'}]
-      props = {
-        curation: @curation
-      }
+      # VeniceSection.__set__ 'sd', {
+      #   ARTSY_URL: 'http://localhost:3005'
+      #   USER: access_token: ''
+      # }
+      Autocomplete.__set__ 'request', get: sinon.stub().returns
+        set: sinon.stub().returns
+          end: sinon.stub().yields(null, body: { id: '123', name: 'An Artist'})
+      VeniceAdmin.__set__ 'AutocompleteList', React.createFactory Autocomplete
+
+      @curation = new Curation sections: [{title: 'Searching For Venice'}, {title: 'Dawn Kasper'}]
+      props = curation: @curation
       @component = ReactDOM.render React.createElement(VeniceAdmin, props), (@$el = $ "<div></div>")[0], =>
         setTimeout =>
-          @component.state.curation.save = sinon.stub()
+          # @component.state.curation.save = sinon.stub()
           done()
 
   afterEach ->
     benv.teardown()
+    Backbone.sync.restore()
 
   it 'Renders the content', ->
     $(ReactDOM.findDOMNode(@component)).find('button').length.should.eql 1
@@ -81,8 +85,7 @@ describe 'VeniceSection', ->
   it 'Clicking save button saves the curation and removes warnings from save button', ->
     r.simulate.click r.findTag(@component, 'button')[0]
     @component.state.isSaving.should.eql true
-    @component.state.curation.save.callCount.should.eql 1
-    setTimeout( =>
-      @component.state.isSaving.should.eql false
-      @component.state.isChanged.should.eql false
-    , 750)
+    Backbone.sync.args[0][0].should.equal 'create'
+    Backbone.sync.args[0][2].success()
+    @component.state.isSaving.should.eql false
+    @component.state.isChanged.should.eql false

--- a/client/apps/settings/test/client/curations/venice_section.coffee
+++ b/client/apps/settings/test/client/curations/venice_section.coffee
@@ -9,7 +9,7 @@ r =
   find: ReactTestUtils.scryRenderedDOMComponentsWithClass
   simulate: ReactTestUtils.Simulate
 
-xdescribe 'VeniceSection', ->
+describe 'VeniceSection', ->
 
   beforeEach (done) ->
     benv.setup =>


### PR DESCRIPTION
Some new failed tests emerged because of [file ordering](https://circleci.com/docs/1.0/file-ordering/).

When this happens again in the future, a simple way to reproduce a failing test from CI (after you've verified the "whole" test suite passes) is to start with the failing test.

`yarn mocha /Users/kanaabe/Development/Artsy/positron/client/apps/switch_channel/test/index.coffee`
If that works, go backwards and follow the file order that CI is picking up instead of the order your file system decides to. So, the file before this one that Circle decided to run was 

`yarn mocha /Users/kanaabe/Development/Artsy/positron/client/apps/settings/test/routes.coffee /Users/kanaabe/Development/Artsy/positron/client/apps/switch_channel/test/index.coffee`

You'll eventually hit the problematic file when the test fails. Unfortunately this process takes a while, but you'll definitely be able to reproduce the issue. 

In this case, the problematic file was `settings/test/client/curations.coffee` even though the test was failing on `switch_channel/test/index.coffee`. 

