### PR TITLE
@kanaabe => QA - Image Collection

### DIFF
--- a/client/apps/edit/components/content/sections/image/index.coffee
+++ b/client/apps/edit/components/content/sections/image/index.coffee
@@ -6,6 +6,7 @@ _ = require 'underscore'
 gemup = require 'gemup'
 React = require 'react'
 DisplayImage = React.createFactory require '../image_collection/components/image.coffee'
+imagesLoaded = require 'imagesloaded'
 sd = require('sharify').data
 icons = -> require('../../../icons.jade') arguments...
 { div, section, h1, h2, span, img, header, input, nav, a, button, p } = React.DOM
@@ -21,6 +22,12 @@ module.exports = React.createClass
     caption: @props.section.get('caption') or ''
     width: @props.section.get('width')
     height: @props.section.get('height')
+    imagesLoaded: false
+
+  componentWillMount: ->
+    imagesLoaded $(@refs.image), =>
+      @setState
+        imagesLoaded: true
 
   onClickOff: ->
     if @state.src
@@ -87,6 +94,8 @@ module.exports = React.createClass
             image: image
             progress: @state.progress
             editing:  @props.editing
+            imagesLoaded: @state.imagesLoaded
+            ref: 'image'
           }
         else
           div { className: 'esi-placeholder' }, 'Add an image above'

--- a/client/apps/edit/components/content/sections/image_collection/components/artwork.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/components/artwork.coffee
@@ -12,10 +12,9 @@ module.exports = React.createClass
       Artwork {
         artwork: @props.artwork
       }
-      if @props.editing
+      if @props.removeItem and @props.editing
         button {
           className: 'edit-section-remove button-reset esic-img-remove'
           onClick: @props.removeItem(@props.artwork)
           dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
         }
-

--- a/client/apps/edit/components/content/sections/image_collection/components/image.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/components/image.coffee
@@ -8,7 +8,7 @@ module.exports = React.createClass
   displayName: 'ImageCollectionDisplayImage'
 
   setHeight: ->
-    if @props.dimensions[@props.index]
+    if @props.dimensions?[@props.index]
       return @props.dimensions[@props.index].height
     else
       return 'auto'

--- a/client/apps/edit/components/content/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/index.coffee
@@ -43,12 +43,11 @@ module.exports = React.createClass
 
   getFillWidthSizes: ->
     containerSize = 860
-    targetHeight = 450
+    targetHeight = window.innerHeight * .7
     if @props.section.get('type') is 'image_set' and @props.section.get('images').length > 3
-      targetHeight = 300
+      targetHeight = 400
     else if @props.section.get('layout') is 'column_width'
       containerSize = 580
-      targetHeight = 550
     return {containerSize: containerSize, targetHeight: targetHeight}
 
   setProgress: (progress) ->

--- a/client/apps/edit/components/content/sections/image_collection/test/artwork.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/test/artwork.coffee
@@ -14,11 +14,11 @@ describe 'ImageCollectionArtwork', ->
   beforeEach (done) ->
     benv.setup =>
       benv.expose $: benv.require 'jquery'
-      Artwork = benv.requireWithJadeify(
+      @Artwork = benv.requireWithJadeify(
         resolve(__dirname, '../components/artwork')
         ['icons']
       )
-      props = {
+      @props = {
         i: 2
         artwork: {
           type: 'artwork'
@@ -29,8 +29,9 @@ describe 'ImageCollectionArtwork', ->
           artists: [ { name: 'Van Gogh' }, { name: 'Van Dogh' } ]
         }
         removeItem: @removeItem = sinon.stub()
+        editing: true
       }
-      @component = ReactDOM.render React.createElement(Artwork, props), (@$el = $ "<div></div>")[0], =>
+      @component = ReactDOM.render React.createElement(@Artwork, @props), (@$el = $ "<div></div>")[0], =>
       done()
 
   afterEach ->
@@ -45,7 +46,16 @@ describe 'ImageCollectionArtwork', ->
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Van Gogh'
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Van Dogh'
 
+  it 'renders the remove button', ->
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'esic-img-remove'
+
   it 'calls removeItem when clicking remove icon', ->
     r.simulate.click r.find @component, 'esic-img-remove'
     @removeItem.called.should.eql true
     @removeItem.args[0][0].id.should.eql '123'
+
+  it 'hides the remove button when not editing', (done) ->
+    @props.editing = false
+    component = ReactDOM.render React.createElement(@Artwork, @props), (@$el = $ "<div></div>")[0], =>
+    $(ReactDOM.findDOMNode(component)).html().should.not.containEql 'esic-img-remove'
+    done()

--- a/client/apps/edit/components/content/sections/image_collection/test/image.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/test/image.coffee
@@ -48,13 +48,20 @@ describe 'ImageCollectionImage', ->
   it 'renders image caption if not editing', ->
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Here is a caption'
 
-  it 'renders image caption input if editing', (done) ->
+  it 'hides remove button if not editing', ->
+    $(ReactDOM.findDOMNode(@component)).html().should.not.containEql 'esic-img-remove'
+
+  it 'renders image caption input and remove button if editing', (done) ->
     @props.editing = true
     @component = ReactDOM.render React.createElement(@Image, @props), (@$el = $ "<div></div>")[0], =>
     $(ReactDOM.findDOMNode(@component)).html().should.containEql '<div class="rich-text--caption">'
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'esic-img-remove'
     done()
 
-  it 'calls removeItem when clicking remove icon', ->
-    r.simulate.click r.find @component, 'esic-img-remove'
+  it 'calls removeItem when clicking remove icon', (done) ->
+    @props.editing = true
+    component = ReactDOM.render React.createElement(@Image, @props), (@$el = $ "<div></div>")[0], =>
+    r.simulate.click r.find component, 'esic-img-remove'
     @removeItem.called.should.eql true
     @removeItem.args[0][0].url.should.eql 'https://artsy.net/image.png'
+    done()

--- a/client/apps/edit/components/content/sections/image_collection/test/index.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/test/index.coffee
@@ -18,6 +18,7 @@ describe 'ImageCollection', ->
       benv.expose $: benv.require 'jquery'
       $.fn.fillwidthLite = sinon.stub()
       global.HTMLElement = () => {}
+      window = {innerHeight: 800}
       @ImageCollection = benv.require resolve(__dirname, '../index')
       Artwork = benv.requireWithJadeify(
         resolve(__dirname, '../components/artwork')
@@ -155,13 +156,13 @@ describe 'ImageCollection', ->
     it 'returns expected container and target for overflow_fillwidth', ->
       sizes = @component.getFillWidthSizes()
       sizes.containerSize.should.eql 860
-      sizes.targetHeight.should.eql 450
+      sizes.targetHeight.should.eql 537.5999999999999
 
     it 'returns expected container and target for column_width', ->
       @component.props.section.set 'layout', 'column_width'
       sizes = @component.getFillWidthSizes()
       sizes.containerSize.should.eql 580
-      sizes.targetHeight.should.eql 550
+      sizes.targetHeight.should.eql 537.5999999999999
 
     it 'returns expected container and target for image_set with many images', ->
       @component.props.section.unset 'layout'
@@ -169,6 +170,4 @@ describe 'ImageCollection', ->
       @component.props.section.set 'images', ['img', 'img', 'img', 'img']
       sizes = @component.getFillWidthSizes()
       sizes.containerSize.should.eql 860
-      sizes.targetHeight.should.eql 300
-
-
+      sizes.targetHeight.should.eql 400

--- a/client/components/drag_drop/drag_target.coffee
+++ b/client/components/drag_drop/drag_target.coffee
@@ -9,7 +9,7 @@ module.exports = React.createClass
       @props.setDragTarget(@props.i)
 
   setWidth: ->
-    if @props.width and @props.width[@props.i]
+    if @props.width?[@props.i]
       return @props.width[@props.i].width
     else
       return '100%'


### PR DESCRIPTION
1. Fixed target heights lead sometimes to vertical images not filling properly, and square images being too big. 
Fix: Use the window height as a target for scaling

2. Use conditional when searching for fillwidth dimensions (was breaking pages with image headers)

3. Use images loaded in single image component to set opacity

![screen shot 2017-06-27 at 1 17 28 pm](https://user-images.githubusercontent.com/1497424/27600793-10f99068-5b3b-11e7-87c4-d1d7028cfffb.png)

![screen shot 2017-06-27 at 1 17 48 pm](https://user-images.githubusercontent.com/1497424/27600792-10f7a03c-5b3b-11e7-8934-89fa2fa2e7aa.png)
