### PR TITLE
@kanaabe => Begin converting Layout to react

### DIFF
--- a/client/apps/edit/components/content/index.coffee
+++ b/client/apps/edit/components/content/index.coffee
@@ -32,6 +32,7 @@ module.exports = React.createClass
         div { id: 'edit-hero-section'},
           HeroSection {
             section: @props.article.heroSection
+            channel: @props.channel
           }
 
       HeaderSection {

--- a/client/apps/edit/components/content/section_container/index.coffee
+++ b/client/apps/edit/components/content/section_container/index.coffee
@@ -133,6 +133,7 @@ module.exports = React.createClass
           onClick: @setEditing(on)
           setEditing: @setEditing
           channel: @props.channel
+          isHero: @props.isHero
         )
         div {
           className: 'edit-section-container-bg'

--- a/client/apps/edit/components/content/section_controls/index.coffee
+++ b/client/apps/edit/components/content/section_controls/index.coffee
@@ -1,0 +1,35 @@
+React = require 'react'
+{ header } = React.DOM
+
+module.exports = React.createClass
+  displayName: 'SectionControls'
+
+  componentDidMount: ->
+    console.log 'mounted'
+    console.log 'size: ' + @refs.controls.offsetWidth
+
+  popLockControls: =>
+    $section = @$('.edit-section-container[data-editing=true]')
+    return unless $section.length
+    $controls = $section.find('.edit-section-controls')
+    $controls.css width: $section.outerWidth(), left: ''
+    insideComponent = @$window.scrollTop() + @$('#edit-header').outerHeight() >
+      ($section.offset().top or 0) - $controls.height()
+    if (@$window.scrollTop() + $controls.outerHeight() >
+        $section.offset().top + $section.height())
+      insideComponent = false
+    left = ($controls.outerWidth() / 2) - ($('#layout-sidebar').width() / 2)
+    type = $section.data('type')
+    unless type is 'fullscreen' or type is 'callout'
+      $controls.css(
+        width: if insideComponent then $controls.outerWidth() else ''
+        left: if insideComponent then "calc(50% - #{left}px)" else ''
+      ).attr('data-fixed', insideComponent)
+
+  render: ->
+    header {
+      className: 'edit-section-controls'
+      ref: 'controls'
+    },
+      @props.children
+

--- a/client/apps/edit/components/content/section_controls/index.coffee
+++ b/client/apps/edit/components/content/section_controls/index.coffee
@@ -1,35 +1,84 @@
 React = require 'react'
+_ = require 'underscore'
 { header } = React.DOM
 
 module.exports = React.createClass
   displayName: 'SectionControls'
 
-  componentDidMount: ->
-    console.log 'mounted'
-    console.log 'size: ' + @refs.controls.offsetWidth
+  getInitialState: ->
+    insideComponent: false
 
-  popLockControls: =>
-    $section = @$('.edit-section-container[data-editing=true]')
-    return unless $section.length
-    $controls = $section.find('.edit-section-controls')
-    $controls.css width: $section.outerWidth(), left: ''
-    insideComponent = @$window.scrollTop() + @$('#edit-header').outerHeight() >
-      ($section.offset().top or 0) - $controls.height()
-    if (@$window.scrollTop() + $controls.outerHeight() >
-        $section.offset().top + $section.height())
-      insideComponent = false
-    left = ($controls.outerWidth() / 2) - ($('#layout-sidebar').width() / 2)
-    type = $section.data('type')
-    unless type is 'fullscreen' or type is 'callout'
-      $controls.css(
-        width: if insideComponent then $controls.outerWidth() else ''
-        left: if insideComponent then "calc(50% - #{left}px)" else ''
-      ).attr('data-fixed', insideComponent)
+  componentDidMount: ->
+    @setInside()
+    window.addEventListener 'scroll', @setInside
+
+  componentWillUnmount: ->
+    window.removeEventListener 'scroll', @setInside
+
+  setInside: ->
+    if @insideComponent() != @state.insideComponent
+      @setState insideComponent: @insideComponent()
+
+  isImages: ->
+    @props.section.get('type') in ['image_set', 'image_collection']
+
+  getHeaderSize: ->
+    height = if @props.channel.isEditorial() then 95 else 55
+    height
+
+  getControlsWidth: ->
+    if @props.section.get('layout')?.includes('overflow') or
+     @props.section.get('type') is 'image_set'
+      width = 900
+    else if @props.section.get('type') is 'embed' or @props.isHero
+        width = 1100
+    else
+      width = 620
+    width
+
+  getPositionLeft: ->
+    if @state.insideComponent
+      left = (window.innerWidth / 2) - (@getControlsWidth() / 2) + 55
+    else if @isImages()
+      left = -20
+    else
+      left = 0
+    left
+
+  getPositionTop: ->
+    if @state.insideComponent
+      top = window.innerHeight - $(@refs.controls).height() - @getHeaderSize()
+      if @isImages()
+        top = top - 20
+    else
+      top = '100%'
+      if @isImages()
+        top = 'calc(100% + 20px)'
+    top
+
+  insideComponent: ->
+    $section = $(@refs.controls).closest('section')
+    insideComponent = false
+    if $section.offset()
+      insideComponent = window.scrollY + @getHeaderSize() >
+        $section.offset().top - $(@refs.controls).height()
+      if (window.scrollY + $(@refs.controls).height() >
+       $section.offset().top + $section.height()) or
+       (@props.section.get('type') in ['fullscreen'])
+        insideComponent = false
+      if @props.isHero
+        insideComponent = true
+    insideComponent
 
   render: ->
     header {
       className: 'edit-section-controls'
       ref: 'controls'
+      style:
+        width: @getControlsWidth()
+        position: if @state.insideComponent then 'fixed' else 'absolute'
+        bottom: @getPositionTop()
+        left: @getPositionLeft()
     },
       @props.children
 

--- a/client/apps/edit/components/content/section_controls/index.styl
+++ b/client/apps/edit/components/content/section_controls/index.styl
@@ -1,0 +1,32 @@
+#edit-content
+  .edit-section-controls
+    background black
+    z-index 5
+    height auto
+    top inherit
+  .es-layout
+    width 100%
+    text-align center
+    height 45px
+    a
+      display inline-block
+      height 40px
+      width @height + 20px
+      background-repeat no-repeat
+      background-position 50%
+      transition opacity 0.3s
+      opacity 0.5
+      cursor pointer
+        &:hover
+          opacity 1
+      &[data-active=true]
+        opacity 1
+      &[name=overflow_fillwidth]
+        background-image url(/icons/edit_artworks_overflow_fillwidth.svg)
+        background-size 38px
+      &[name=column_width]
+        background-image url(/icons/edit_artworks_column_width.svg)
+        background-size 22px
+      &[name=image_set]
+        background-image url(/icons/edit_image_set_slideshow.svg)
+        background-size 22px

--- a/client/apps/edit/components/content/section_controls/test/index.coffee
+++ b/client/apps/edit/components/content/section_controls/test/index.coffee
@@ -1,0 +1,40 @@
+benv = require 'benv'
+sinon = require 'sinon'
+Backbone = require 'backbone'
+{ resolve } = require 'path'
+React = require 'react'
+ReactDOM = require 'react-dom'
+ReactTestUtils = require 'react-addons-test-utils'
+ReactDOMServer = require 'react-dom/server'
+r =
+  find: ReactTestUtils.findRenderedDOMComponentWithClass
+  simulate: ReactTestUtils.Simulate
+  render: ReactTestUtils.renderIntoDocument
+
+describe 'SectionControls', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose $: benv.require 'jquery'
+      @SectionControls = benv.require resolve(__dirname, '../index')
+      @props = {
+        section: new Backbone.Model
+          type: 'image_collection'
+          layout: 'overflow_fillwidth'
+        editing: true
+        channel: { isEditorial: sinon.stub().returns(true) }
+      }
+      @component = ReactDOM.render React.createElement(@SectionControls, @props), (@$el = $ "<div></div>")[0], =>
+      @component.insideComponent = sinon.stub()
+      @$el.append( $section = $
+        "<div class='edit-section-container' data-editing='true' style='height:300px'>
+          <div class='edit-section-controls'></div>
+        </div>"
+      )
+      done()
+
+  afterEach ->
+    benv.teardown()
+
+  it 'sets insideComponent to state on mount', ->
+    console.log $(@$el).html()

--- a/client/apps/edit/components/content/section_controls/test/index.coffee
+++ b/client/apps/edit/components/content/section_controls/test/index.coffee
@@ -16,6 +16,10 @@ describe 'SectionControls', ->
   beforeEach (done) ->
     benv.setup =>
       benv.expose $: benv.require 'jquery'
+      $.fn.offset = sinon.stub().returns(top: 200)
+      $.fn.height = sinon.stub().returns(200)
+      window.innerHeight = 900
+      window.innerWidth = 1400
       @SectionControls = benv.require resolve(__dirname, '../index')
       @props = {
         section: new Backbone.Model
@@ -23,18 +27,116 @@ describe 'SectionControls', ->
           layout: 'overflow_fillwidth'
         editing: true
         channel: { isEditorial: sinon.stub().returns(true) }
+        isHero: false
       }
-      @component = ReactDOM.render React.createElement(@SectionControls, @props), (@$el = $ "<div></div>")[0], =>
-      @component.insideComponent = sinon.stub()
-      @$el.append( $section = $
-        "<div class='edit-section-container' data-editing='true' style='height:300px'>
-          <div class='edit-section-controls'></div>
-        </div>"
+
+      @component = ReactDOM.render React.createElement(@SectionControls, @props), (@$el = $ "<div></div>")[0], => setTimeout =>
+      @component.isScrollingOver = sinon.stub().returns(true)
+      @component.isScrolledPast = sinon.stub().returns(false)
+      $(ReactDOM.findDOMNode(@component)).parent().prepend(
+          "<section class='edit-section-container' data-editing='true' style='height:300px'>
+          </section>"
       )
       done()
 
   afterEach ->
     benv.teardown()
 
-  it 'sets insideComponent to state on mount', ->
-    console.log $(@$el).html()
+  describe '#setInsideComponent', ->
+
+    it 'returns true if item is scrolled over and not scrolled past', ->
+      @component.setInsideComponent()
+      @component.state.insideComponent.should.eql true
+
+    it 'returns false if item is scrolled past', ->
+      @component.isScrolledPast = sinon.stub().returns(true)
+      @component.setInsideComponent()
+      @component.state.insideComponent.should.eql false
+
+    it 'returns true when hero section and not scrolled past', ->
+      @props.isHero = true
+      component = ReactDOM.render React.createElement(@SectionControls, @props), (@$el = $ "<div></div>")[0], =>
+      component.setInsideComponent()
+      component.state.insideComponent.should.eql true
+
+
+  describe '#getControlsWidth', ->
+
+    it 'returns 620 for column_width sections', ->
+      @component.props.section.set 'layout', 'column_width'
+      width = @component.getControlsWidth()
+      width.should.eql 620
+
+    it 'returns 900 if image_set or has overflow layout', ->
+      width = @component.getControlsWidth()
+      width.should.eql 900
+
+      @component.props.section.set 'type', 'image_set'
+      width = @component.getControlsWidth()
+      width.should.eql 900
+
+      @component.props.section.set 'type', 'video'
+      width = @component.getControlsWidth()
+      width.should.eql 900
+
+    it 'returns 1100 if hero section', ->
+      @props.isHero = true
+      component = ReactDOM.render React.createElement(@SectionControls, @props), (@$el = $ "<div></div>")[0], =>
+      width = component.getControlsWidth()
+      width.should.eql 1100
+
+
+  describe '#getHeaderSize', ->
+
+    it 'returns 95 when channel is editorial', ->
+      header = @component.getHeaderSize()
+      header.should.eql 95
+
+    it 'returns 55 when channel is not editorial', ->
+      @props.channel = { isEditorial: sinon.stub().returns(false) }
+      component = ReactDOM.render React.createElement(@SectionControls, @props), (@$el = $ "<div></div>")[0], =>
+      header = component.getHeaderSize()
+      header.should.eql 55
+
+
+  describe '#getPositionBottom', ->
+
+    it 'when inside component, calculates based on window scroll position', ->
+      @component.props.section.set 'type', 'video'
+      @component.setState insideComponent: true
+      bottom = @component.getPositionBottom()
+      bottom.should.eql 605
+
+    it 'when inside component, adds a 20px buffer for images', ->
+      @component.setState insideComponent: true
+      bottom = @component.getPositionBottom()
+      bottom.should.eql 585
+
+    it 'when outside component, returns 100%', ->
+      @component.props.section.set 'type', 'video'
+      @component.setState insideComponent: false
+      bottom = @component.getPositionBottom()
+      bottom.should.eql '100%'
+
+    it 'when outside component, adds a 20px buffer for images', ->
+      @component.setState insideComponent: false
+      bottom = @component.getPositionBottom()
+      bottom.should.eql 'calc(100% + 20px)'
+
+
+  describe '#getPositionLeft', ->
+
+    it 'calculates width based on window when insideComponent', ->
+      left = @component.getPositionLeft()
+      left.should.eql 305
+
+    it 'returns 0 if outside component', ->
+      @component.props.section.set 'type', 'video'
+      @component.setState insideComponent: false
+      left = @component.getPositionLeft()
+      left.should.eql 0
+
+    it 'adds a 20px buffer for images', ->
+      @component.setState insideComponent: false
+      left = @component.getPositionLeft()
+      left.should.eql -20

--- a/client/apps/edit/components/content/section_tool/index.styl
+++ b/client/apps/edit/components/content/section_tool/index.styl
@@ -18,6 +18,7 @@ section-btn-height = 130px
     opacity 1
     margin-top 15px
   &:hover
+    opacity 1
     width 100%
     position relative
     &::after
@@ -144,8 +145,11 @@ section-btn-height = 130px
     max-width 800px
   &::after
     opacity 0
-  .edit-section-tool-icon::after
-    display block
+  .edit-section-tool-icon
+    &::after
+      display block
+    svg
+      fill-color black
   .edit-section-tool-menu
     opacity 1
     max-height (section-btn-height * 2)

--- a/client/apps/edit/components/content/sections/callout/index.coffee
+++ b/client/apps/edit/components/content/sections/callout/index.coffee
@@ -13,6 +13,7 @@ Autocomplete = require '../../../../../../components/autocomplete/index.coffee'
 { div, section, input, a, h1, h2, button, img, p, strong, span } = React.DOM
 { crop } = require '../../../../../../components/resizer/index.coffee'
 Article = require '../../../../../../models/article.coffee'
+SectionControls = React.createFactory require '../../section_controls/index.coffee'
 
 module.exports = React.createClass
   displayName: 'SectionCallout'
@@ -135,53 +136,57 @@ module.exports = React.createClass
         @setState error: 'Article Not Found'
 
   render: ->
-    div {
+    section {
       className: 'edit-section-callout-container'
       onClick: @props.setEditing(on)
     },
-      div { className: 'esc-controls-container edit-section-controls' },
-        section { className: 'esc-inputs' },
-          h1 {}, 'Article (optional)'
-          div { className: 'esc-autocomplete-input' },
-            input {
-              ref: 'autocomplete'
-              className: 'bordered-input bordered-input-dark'
-              placeholder: 'Search for an Article by name'
-            }
-          h1 {}, 'Text'
-          div { className: 'esc-text-input' },
-            input {
-              ref: 'textInput'
-              className: 'bordered-input bordered-input-dark'
-              placeholder: 'Enter Text Here...'
-              onBlur: @setText
-            }
-          h1 {}, 'Thumbnail Image (optional)'
-          section { className: 'dashed-file-upload-container' },
-            h1 {}, 'Drag & ',
-              span { className: 'dashed-file-upload-container-drop' }, 'drop'
-              ' or '
-              span { className: 'dashed-file-upload-container-click' }, 'click'
-              span {}, (' to ' +
-                if @props.section.get('thumbnail_url') then 'replace' else 'upload')
-            h2 {}, 'Up to 30mb'
-            input { type: 'file', onChange: @upload }
-          div { className: 'esc-hide-thumbnail' },
-            h1 {}, 'Hide Thumbnail?'
-            input {
-              type: 'checkbox'
-              ref: 'checkInput'
-              value: @state.hide_image?
-              onChange: @setHideImage
-            }
-          div { className: 'esc-top-stories' },
-            h1 {}, 'Top Stories on Artsy'
-            input {
-              type: 'checkbox'
-              ref: 'topStories'
-              value: @state.top_stories?
-              onChange: @setTopStories
-            }
+      if @props.editing
+        SectionControls {
+          section: @props.section
+          channel: @props.channel
+        },
+          div { className: 'esc-inputs' },
+            h1 {}, 'Article (optional)'
+            div { className: 'esc-autocomplete-input' },
+              input {
+                ref: 'autocomplete'
+                className: 'bordered-input bordered-input-dark'
+                placeholder: 'Search for an Article by name'
+              }
+            h1 {}, 'Text'
+            div { className: 'esc-text-input' },
+              input {
+                ref: 'textInput'
+                className: 'bordered-input bordered-input-dark'
+                placeholder: 'Enter Text Here...'
+                onBlur: @setText
+              }
+            h1 {}, 'Thumbnail Image (optional)'
+            div { className: 'dashed-file-upload-container' },
+              h1 {}, 'Drag & ',
+                span { className: 'dashed-file-upload-container-drop' }, 'drop'
+                ' or '
+                span { className: 'dashed-file-upload-container-click' }, 'click'
+                span {}, (' to ' +
+                  if @props.section.get('thumbnail_url') then 'replace' else 'upload')
+              h2 {}, 'Up to 30mb'
+              input { type: 'file', onChange: @upload }
+            div { className: 'esc-hide-thumbnail' },
+              h1 {}, 'Hide Thumbnail?'
+              input {
+                type: 'checkbox'
+                ref: 'checkInput'
+                value: @state.hide_image?
+                onChange: @setHideImage
+              }
+            div { className: 'esc-top-stories' },
+              h1 {}, 'Top Stories on Artsy'
+              input {
+                type: 'checkbox'
+                ref: 'topStories'
+                value: @state.top_stories?
+                onChange: @setTopStories
+              }
       (
         if @state.progress
           div { className: 'upload-progress-container' },

--- a/client/apps/edit/components/content/sections/embed/index.coffee
+++ b/client/apps/edit/components/content/sections/embed/index.coffee
@@ -5,6 +5,7 @@
 _ = require 'underscore'
 React = require 'react'
 sd = require('sharify').data
+SectionControls = React.createFactory require '../../section_controls/index.coffee'
 { div, section, label, nav, input, a, h1, p, strong, span, form, button, iframe } = React.DOM
 
 module.exports = React.createClass
@@ -47,71 +48,62 @@ module.exports = React.createClass
     if @props.section.get('layout') is 'overflow' then 1060 else 500
 
   render: ->
-    div {
+    section {
       className: 'edit-section-embed-container'
       onClick: @props.setEditing(on)
     },
-      div { className: 'ese-controls-container edit-section-controls' },
-        nav {},
-          a {
-            style: {
-              'backgroundImage': 'url(/icons/edit_artworks_overflow_fillwidth.svg)'
-              'backgroundSize': '38px'
+      if @props.editing
+        SectionControls {
+          section: @props.section
+          channel: @props.channel
+        },
+          nav { className: 'es-layout' },
+            a {
+              name: 'overflow_fillwidth'
+              className: 'layout'
+              onClick: @changeLayout('overflow')
+              'data-active': @props.section.get('layout') is 'overflow'
             }
-            className: 'ese-overflow'
-            onClick: @changeLayout('overflow')
-          }
-          a {
-            style: {
-              'backgroundImage': 'url(/icons/edit_artworks_column_width.svg)'
-              'backgroundSize': '22px'
+            a {
+              name: 'column_width'
+              className: 'layout'
+              onClick: @changeLayout('column_width')
+              'data-active': @props.section.get('layout') is 'column_width'
             }
-            className: 'ese-column-width'
-            onClick: @changeLayout('column_width')
-          }
-          a {
-            style: {
-              'backgroundImage': 'url(/icons/edit_artworks_overflow_fillwidth.svg)'
-              'backgroundSize': '22px'
+          section { className: 'ese-inputs' },
+            div {
+              className: 'ese-iframe-error'
+              dangerouslySetInnerHTML: __html: @state.errorMessage
             }
-            className: 'ese-overflow-fillwidth'
-            onClick: @changeLayout('overflow_fillwidth')
-          }
-        section { className: 'ese-inputs' },
-          h1 {}, 'Add embedded content to this section'
-          div {
-            className: 'ese-iframe-error'
-            dangerouslySetInnerHTML: __html: @state.errorMessage
-          }
-          form {
-            className: 'ese-input-form-container'
-            onSubmit: @submitUrl
-          },
-            div { className: 'ese-input' }, "URL",
-              input {
-                placeholder: 'https://files.artsy.net'
-                className: 'bordered-input bordered-input-dark'
-                ref: 'url'
-                defaultValue: @props.section.get('url')
-              },
-            div { className: 'ese-input ese-input-height' }, "Height (optional)",
-              input {
-                placeholder: '400'
-                className: 'bordered-input bordered-input-dark'
-                ref: 'height'
-                defaultValue: @props.section.get('height')
+            form {
+              className: 'ese-input-form-container'
+              onSubmit: @submitUrl
+            },
+              div { className: 'ese-input' }, "URL",
+                input {
+                  placeholder: 'https://files.artsy.net'
+                  className: 'bordered-input bordered-input-dark'
+                  ref: 'url'
+                  defaultValue: @props.section.get('url')
+                },
+              div { className: 'ese-input ese-input-height' }, "Height (optional)",
+                input {
+                  placeholder: '400'
+                  className: 'bordered-input bordered-input-dark'
+                  ref: 'height'
+                  defaultValue: @props.section.get('height')
+                }
+              div { className: 'ese-input ese-input-height' }, "Mobile Height (optional)",
+                input {
+                  placeholder: '300'
+                  className: 'bordered-input bordered-input-dark'
+                  ref: 'mobileHeight'
+                  defaultValue: @props.section.get('mobile_height')
               }
-            div { className: 'ese-input ese-input-height' }, "Mobile Height (optional)",
-              input {
-                placeholder: '300'
-                className: 'bordered-input bordered-input-dark'
-                ref: 'mobileHeight'
-                defaultValue: @props.section.get('mobile_height')
-            }
-            button {
-              className: 'avant-garde-button avant-garde-button-dark'
-              'data-state': if @state.loading then 'loading' else ''
-            }, 'Add URL'
+              button {
+                className: 'avant-garde-button avant-garde-button-dark'
+                'data-state': if @state.loading then 'loading' else ''
+              }, 'Add URL'
       div {
         className: 'embed-container'
         ref: 'embed'

--- a/client/apps/edit/components/content/sections/hero/index.coffee
+++ b/client/apps/edit/components/content/sections/hero/index.coffee
@@ -34,4 +34,5 @@ module.exports = React.createClass
         editing: @state.editing
         onSetEditing: @onSetEditing
         isHero: true
+        channel: @props.channel
       }

--- a/client/apps/edit/components/content/sections/hero/index.styl
+++ b/client/apps/edit/components/content/sections/hero/index.styl
@@ -10,14 +10,11 @@
     &:hover
       fill-color black
   .edit-section-container[data-type=video], .edit-section-container[data-type=image]
-    min-height 400px
     width 1100px
     .esv-controls-container
       height 243px
     .esv-nav, .esv-background-color
       display none
-  .esi-placeholder
-    line-height 480px
   .edit-section-container[data-type=image]
     left calc(50% - 410px)
   .edit-section-container[data-type=video]
@@ -31,8 +28,6 @@
     li:first-child:nth-last-child(3) ~ li
       width 33.3%
   .edit-section-video
-    .esv-placeholder
-      line-height 500px
     iframe
       min-height 590px
   .esic-img-container

--- a/client/apps/edit/components/content/sections/image_collection/components/controls.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/components/controls.coffee
@@ -2,6 +2,7 @@ React = require 'react'
 _ = require 'underscore'
 sd = require('sharify').data
 gemup = require 'gemup'
+SectionControls = React.createFactory require '../../../section_controls/index.coffee'
 UrlArtworkInput = React.createFactory require './url_artwork_input.coffee'
 Autocomplete = require '../../../../../../../components/autocomplete/index.coffee'
 Artwork = require '../../../../../../../models/artwork.coffee'
@@ -93,7 +94,10 @@ module.exports = React.createClass
           @props.setProgress null
 
   render: ->
-    header { className: 'edit-section-controls' },
+    SectionControls {
+      editing: @props.editing
+      section: @props.section
+    },
       nav { className: 'es-layout' },
         a {
           name: 'overflow_fillwidth'

--- a/client/apps/edit/components/content/sections/image_collection/components/controls.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/components/controls.coffee
@@ -97,6 +97,7 @@ module.exports = React.createClass
     SectionControls {
       editing: @props.editing
       section: @props.section
+      channel: @props.channel
     },
       nav { className: 'es-layout' },
         a {
@@ -119,23 +120,23 @@ module.exports = React.createClass
             'data-active': @props.section.get('type') is 'image_set'
           }
 
-        section { className: 'dashed-file-upload-container' },
-          h1 {}, 'Drag & ',
-            span { className: 'dashed-file-upload-container-drop' }, 'drop'
-            ' or '
-            span { className: 'dashed-file-upload-container-click' }, 'click'
-            span {}, ' to upload'
-          h2 {}, 'Up to 30mb'
-          input { type: 'file', onChange: @upload }
+      section { className: 'dashed-file-upload-container' },
+        h1 {}, 'Drag & ',
+          span { className: 'dashed-file-upload-container-drop' }, 'drop'
+          ' or '
+          span { className: 'dashed-file-upload-container-click' }, 'click'
+          span {}, ' to upload'
+        h2 {}, 'Up to 30mb'
+        input { type: 'file', onChange: @upload }
 
-        section { className: 'esic-artwork-inputs' },
-          div { className: 'esis-autocomplete-input' },
-            input {
-              ref: 'autocomplete'
-              className: 'bordered-input bordered-input-dark'
-              placeholder: 'Search for artwork by title'
-            }
-          UrlArtworkInput {
-            images: @props.images
-            addArtworkFromUrl: @addArtworkFromUrl
+      section { className: 'esic-artwork-inputs' },
+        div { className: 'esis-autocomplete-input' },
+          input {
+            ref: 'autocomplete'
+            className: 'bordered-input bordered-input-dark'
+            placeholder: 'Search for artwork by title'
           }
+        UrlArtworkInput {
+          images: @props.images
+          addArtworkFromUrl: @addArtworkFromUrl
+        }

--- a/client/apps/edit/components/content/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/index.coffee
@@ -95,6 +95,7 @@ module.exports = React.createClass
         setProgress: @setProgress
         onChange: @onChange
         channel: @props.channel
+        editing: @props.editing
       }
       if @state.progress
         div { className: 'upload-progress-container' },

--- a/client/apps/edit/components/content/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/index.coffee
@@ -89,14 +89,15 @@ module.exports = React.createClass
       className: 'edit-section-image-collection edit-section-image-container' + @largeImagesetClass()
       onClick: @props.setEditing(true)
     },
-      Controls {
-        section: @props.section
-        images: images
-        setProgress: @setProgress
-        onChange: @onChange
-        channel: @props.channel
-        editing: @props.editing
-      }
+      if @props.editing
+        Controls {
+          section: @props.section
+          images: images
+          setProgress: @setProgress
+          onChange: @onChange
+          channel: @props.channel
+          editing: @props.editing
+        }
       if @state.progress
         div { className: 'upload-progress-container' },
           div {

--- a/client/apps/edit/components/content/sections/image_collection/index.styl
+++ b/client/apps/edit/components/content/sections/image_collection/index.styl
@@ -2,55 +2,13 @@
 
 .edit-section-image-collection
   position relative
-
-.edit-section-image-collection .edit-section-controls
-  fill-container()
-  background black
-  height 225px
-  top -(@height + controls-padding)
-  left -(controls-padding)
-  padding 5px 20px 20px 20px
-  display none
-  z-index 3
-  min-width 620px
-  nav
-    width 100%
-    text-align center
-    a
-      display inline-block
-      height 40px
-      width @height + 20px
-      background-repeat no-repeat !important
-      background-position center !important
-      transition opacity 0.3s
-      opacity 0.5
-      cursor pointer
-      &:hover
-        opacity 1
-      &:last-of-type
-        border-right 0
-    &.esi-nav
-      margin-top -10px
-      margin-bottom 5px
-
-#edit-content .edit-section-image-collection .es-layout
-  a
-    &[data-active=true]
-      opacity 1
-    &[name=overflow_fillwidth]
-      background-image url(/icons/edit_artworks_overflow_fillwidth.svg)
-      background-size 38px
-    &[name=column_width]
-      background-image url(/icons/edit_artworks_column_width.svg)
-      background-size 22px
-    &[name=image_set]
-      background-image url(/icons/edit_image_set_slideshow.svg)
-      background-size 22px
+  .edit-section-controls
+    padding 5px 20px 20px 20px
 
 .esic-artwork-inputs
   clearfix()
   color white
-  padding controls-padding 0px
+  padding-top controls-padding
   text-align left
   border-top 1px solid gray-darkest-color
   input
@@ -139,15 +97,11 @@
 .edit-section-container[data-editing=false][data-type=image_set]
   .edit-section-remove
     display block
-  .edit-section-controls, .esic-controls-container
-    display none
 
 .edit-section-container[data-editing=true][data-type=image_collection],
 .edit-section-container[data-editing=true][data-type=image_set]
   .esic-caption--display
     display none
-  .edit-section-controls, .esic-controls-container
-    display block
   .drag-target[data-target=true]
     .esic-img-remove,
     .rich-text--caption
@@ -159,8 +113,6 @@
 
 .edit-section-container[data-layout=overflow_fillwidth],
 .edit-section-container[data-editing=true][data-type=image_set]
-  .edit-section-controls
-    width 900px
   .esic-images-list
     .drag-container
       display flex

--- a/client/apps/edit/components/content/sections/toc/index.coffee
+++ b/client/apps/edit/components/content/sections/toc/index.coffee
@@ -18,7 +18,6 @@ module.exports = React.createClass
   render: ->
     div {
       className: 'edit-section-toc-container'
-      onClick: @props.setEditing(on)
     },
       div { className: 'es-toc-headline' }, "Table Of Contents"
       ul { className: 'es-toc-list', ref: 'links' },

--- a/client/apps/edit/components/content/sections/video/index.coffee
+++ b/client/apps/edit/components/content/sections/video/index.coffee
@@ -6,6 +6,7 @@ _ = require 'underscore'
 gemup = require 'gemup'
 React = require 'react'
 RichTextCaption = React.createFactory require '../../../../../../components/rich_text_caption/index.coffee'
+SectionControls = React.createFactory require '../../section_controls/index.coffee'
 icons = -> require('../../../icons.jade') arguments...
 { getIframeUrl } = require '../../../../../../models/section.coffee'
 sd = require('sharify').data
@@ -85,35 +86,45 @@ module.exports = React.createClass
     section {
       className: 'edit-section-video'
     },
-      div { className: 'esv-controls-container edit-section-controls' },
-        nav { className: 'esv-nav' },
-          a {
-            className: 'esv-overflow-fillwidth'
-            onClick: @changeLayout('overflow_fillwidth')
-          }
-          a {
-            className: 'esv-column-width'
-            onClick: @changeLayout('column_width')
-          }
-        div { className: 'esv-inputs' },
-          h2 {}, 'Video'
-          input {
-            className: 'bordered-input bordered-input-dark'
-            placeholder: 'Paste a youtube or vimeo url ' +
-              '(e.g. http://youtube.com/watch?v=id)'
-            ref: 'input'
-            defaultValue: @state.url
-            onKeyDown: _.debounce(_.bind(@onChangeUrl, this), 500)
-          }
-          h2 {}, "Cover image"
-          section { className: 'dashed-file-upload-container' },
-            h1 {}, 'Drag & ',
-              span { className: 'dashed-file-upload-container-drop' }, 'drop'
-              ' or '
-              span { className: 'dashed-file-upload-container-click' }, 'click'
-              span {}, (' to ' + if @state.cover_image_url then 'replace' else 'upload')
-            h2 {}, 'Up to 30mb'
-            input { type: 'file', onChange: @uploadCoverImage }
+      if @props.editing
+        SectionControls {
+          section: @props.section
+          channel: @props.channel
+          isHero: @props.isHero
+        },
+          unless @props.isHero
+            nav { className: 'es-layout' },
+              a {
+                name: 'overflow_fillwidth'
+                className: 'layout'
+                onClick: @changeLayout('overflow_fillwidth')
+                'data-active': @props.section.get('layout') is 'overflow_fillwidth'
+              }
+              a {
+                name: 'column_width'
+                className: 'layout'
+                onClick: @changeLayout('column_width')
+                'data-active': @props.section.get('layout') is 'column_width'
+              }
+          div { className: 'esv-inputs' },
+            h2 {}, 'Video'
+            input {
+              className: 'bordered-input bordered-input-dark'
+              placeholder: 'Paste a youtube or vimeo url ' +
+                '(e.g. http://youtube.com/watch?v=id)'
+              ref: 'input'
+              defaultValue: @state.url
+              onKeyDown: _.debounce(_.bind(@onChangeUrl, this), 500)
+            }
+            h2 {}, "Cover image"
+            section { className: 'dashed-file-upload-container' },
+              h1 {}, 'Drag & ',
+                span { className: 'dashed-file-upload-container-drop' }, 'drop'
+                ' or '
+                span { className: 'dashed-file-upload-container-click' }, 'click'
+                span {}, (' to ' + if @state.cover_image_url then 'replace' else 'upload')
+              h2 {}, 'Up to 30mb'
+              input { type: 'file', onChange: @uploadCoverImage }
       div {
         className: 'esv-video-container'
         onClick: @props.setEditing(on)

--- a/client/apps/edit/components/content/sections/video/index.styl
+++ b/client/apps/edit/components/content/sections/video/index.styl
@@ -32,29 +32,6 @@ wide-input-width = 640px
     position relative
     top 1px
 
-#edit-content .esv-nav
-  text-align center
-  a
-    display inline-block
-    height 40px
-    width @height + 20px
-    transition opacity 0.3s
-    opacity 0.5
-    cursor pointer
-    color white
-    background-repeat no-repeat !important
-    background-position center !important
-    &:hover
-      opacity 1
-    &:last-of-type
-      border-right 0
-    &.esv-column-width
-      background-image url(/icons/edit_artworks_column_width.svg)
-      background-size 22px
-    &.esv-overflow-fillwidth
-      background-image url(/icons/edit_artworks_overflow_fillwidth.svg)
-      background-size 38px
-
 [data-useragent*=Firefox] .edit-section-video .edit-section-controls input
   width 397px
 
@@ -121,11 +98,9 @@ wide-input-width = 640px
     width 100%
 
 #edit-content .edit-section-container[data-layout=overflow_fillwidth][data-type=video]
-  width 1100px
-  left -240px
+  width 900px
+  left -140px
   min-height 400px
-  .edit-section-controls
-    width 1100px
   nav a.esv-overflow-fillwidth
     opacity 1
   .esv-inputs

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -103,11 +103,6 @@ module.exports = class EditLayout extends Backbone.View
     'dragenter .dashed-file-upload-container': 'toggleDragover'
     'dragleave .dashed-file-upload-container': 'toggleDragover'
     'change .dashed-file-upload-container input[type=file]': 'toggleDragover'
-    'mouseenter .edit-section-tool': 'toggleSectionTool'
-    'mouseleave .edit-section-tool': 'toggleSectionTool'
-    'mouseenter .edit-section-container:not([data-editing=true])': 'toggleSectionTools'
-    'mouseleave .edit-section-container:not([data-editing=true])': 'hideSectionTools'
-    'click .edit-section-container, .edit-section-tool-menu > li': 'hideSectionTools'
     'blur #edit-title': 'prefillThumbnailTitle'
 
   toggleTabs: (e) ->
@@ -140,36 +135,23 @@ module.exports = class EditLayout extends Backbone.View
     @toggleAstericks()
 
   popLockControls: =>
-    $section = @$('.edit-section-container[data-editing=true]')
-    return unless $section.length
-    $controls = $section.find('.edit-section-controls')
-    $controls.css width: $section.outerWidth(), left: ''
-    insideComponent = @$window.scrollTop() + @$('#edit-header').outerHeight() >
-      ($section.offset().top or 0) - $controls.height()
-    if (@$window.scrollTop() + $controls.outerHeight() >
-        $section.offset().top + $section.height())
-      insideComponent = false
-    left = ($controls.outerWidth() / 2) - ($('#layout-sidebar').width() / 2)
-    type = $section.data('type')
-    unless type is 'fullscreen' or type is 'callout'
-      $controls.css(
-        width: if insideComponent then $controls.outerWidth() else ''
-        left: if insideComponent then "calc(50% - #{left}px)" else ''
-      ).attr('data-fixed', insideComponent)
+    # $section = @$('.edit-section-container[data-editing=true]')
+    # return unless $section.length
+    # $controls = $section.find('.edit-section-controls')
+    # $controls.css width: $section.outerWidth(), left: ''
+    # insideComponent = @$window.scrollTop() + @$('#edit-header').outerHeight() >
+    #   ($section.offset().top or 0) - $controls.height()
+    # if (@$window.scrollTop() + $controls.outerHeight() >
+    #     $section.offset().top + $section.height())
+    #   insideComponent = false
+    # left = ($controls.outerWidth() / 2) - ($('#layout-sidebar').width() / 2)
+    # type = $section.data('type')
+    # unless type is 'fullscreen' or type is 'callout'
+    #   $controls.css(
+    #     width: if insideComponent then $controls.outerWidth() else ''
+    #     left: if insideComponent then "calc(50% - #{left}px)" else ''
+    #   ).attr('data-fixed', insideComponent)
 
   toggleDragover: (e) ->
     $(e.currentTarget).closest('.dashed-file-upload-container')
       .toggleClass 'is-dragover'
-
-  toggleSectionTool: (e) ->
-    $t = $(e.currentTarget)
-    return if $t.siblings().find('.edit-section-container').is('[data-editing=true]')
-    $t.toggleClass 'is-active'
-
-  toggleSectionTools: (e) ->
-    @hideSectionTools()
-    $(e.currentTarget).prev('.edit-section-tool').addClass 'is-active'
-    $(e.currentTarget).next('.edit-section-tool').addClass 'is-active'
-
-  hideSectionTools: ->
-    @$('.edit-section-tool').removeClass 'is-active'

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -18,9 +18,7 @@ module.exports = class EditLayout extends Backbone.View
     @article.on 'finished', @onFinished
     @article.on 'loading', @showSpinner
     @article.once 'sync', @onFirstSave if @article.isNew()
-    @article.sections.on 'change:layout', => _.defer => @popLockControls()
     @article.on 'savePublished', @savePublished
-    @$window.on 'scroll', @popLockControls
     @setupOnBeforeUnload()
     @toggleAstericks()
     @setupYoast() if @channel.isEditorial()
@@ -98,8 +96,6 @@ module.exports = class EditLayout extends Backbone.View
     'click #edit-tabs > a:not(#edit-publish)': 'toggleTabs'
     'keyup :input:not(.tt-input,.invisible-input, .edit-admin__fields .bordered-input,#edit-seo__focus-keyword), [contenteditable]:not(.tt-input)': 'onKeyup'
     'keyup .edit-display__textarea, #edit-seo__focus-keyword, [contenteditable]:not(.tt-input)': 'onYoastKeyup'
-    'click .edit-section-container *': 'popLockControls'
-    'click .edit-section-tool-menu li': -> _.defer => @popLockControls()
     'dragenter .dashed-file-upload-container': 'toggleDragover'
     'dragleave .dashed-file-upload-container': 'toggleDragover'
     'change .dashed-file-upload-container input[type=file]': 'toggleDragover'
@@ -133,24 +129,6 @@ module.exports = class EditLayout extends Backbone.View
     else
       @article.save @serialize()
     @toggleAstericks()
-
-  popLockControls: =>
-    # $section = @$('.edit-section-container[data-editing=true]')
-    # return unless $section.length
-    # $controls = $section.find('.edit-section-controls')
-    # $controls.css width: $section.outerWidth(), left: ''
-    # insideComponent = @$window.scrollTop() + @$('#edit-header').outerHeight() >
-    #   ($section.offset().top or 0) - $controls.height()
-    # if (@$window.scrollTop() + $controls.outerHeight() >
-    #     $section.offset().top + $section.height())
-    #   insideComponent = false
-    # left = ($controls.outerWidth() / 2) - ($('#layout-sidebar').width() / 2)
-    # type = $section.data('type')
-    # unless type is 'fullscreen' or type is 'callout'
-    #   $controls.css(
-    #     width: if insideComponent then $controls.outerWidth() else ''
-    #     left: if insideComponent then "calc(50% - #{left}px)" else ''
-    #   ).attr('data-fixed', insideComponent)
 
   toggleDragover: (e) ->
     $(e.currentTarget).closest('.dashed-file-upload-container')

--- a/client/apps/edit/components/layout/test/index.coffee
+++ b/client/apps/edit/components/layout/test/index.coffee
@@ -77,7 +77,7 @@ describe 'EditLayout', ->
       @view.user.set id: 'foo'
       @view.serialize().author_id.should.equal 'foo'
 
-  describe '#popLockControls', ->
+  xdescribe '#popLockControls', ->
 
     it 'locks the controls to the top when you scroll', ->
       @view.$el.append( $section = $

--- a/client/apps/edit/components/layout/test/index.coffee
+++ b/client/apps/edit/components/layout/test/index.coffee
@@ -77,19 +77,6 @@ describe 'EditLayout', ->
       @view.user.set id: 'foo'
       @view.serialize().author_id.should.equal 'foo'
 
-  xdescribe '#popLockControls', ->
-
-    it 'locks the controls to the top when you scroll', ->
-      @view.$el.append( $section = $
-        "<div class='edit-section-container' data-editing='true' style='height:300px'>
-          <div class='edit-section-controls'></div>
-        </div>"
-      )
-      @view.$window = scrollTop: -> 100
-      @view.popLockControls()
-      $($section.find('.edit-section-controls')).attr('data-fixed')
-        .should.equal 'true'
-
   describe '#onFinished', ->
 
     it 'redirects to the list if the articles is saved', ->

--- a/client/apps/edit/index.styl
+++ b/client/apps/edit/index.styl
@@ -3,6 +3,7 @@
 @import './components/header'
 @import './components/display'
 @import './components/content/section_container'
+@import './components/content/section_controls'
 @import './components/content/section_list'
 @import './components/content/section_tool'
 @import './components/content/sections/embed'


### PR DESCRIPTION
First steps toward eliminating layout Backbone view, with the goal of having 'one true state' for the article in the 'content' component.

1. Removes dependency on classes for section-tool styles
2. Adds 'Section Controls' component, which houses logic for 'pop-lock' controls
3. Controls are now shown based on react props rather than classes added via jquery