### PR TITLE
@craigspaeth => Use DragDrop component for SectionList

### DIFF
--- a/client/apps/edit/components/content/section_container/index.coffee
+++ b/client/apps/edit/components/content/section_container/index.coffee
@@ -43,6 +43,7 @@ module.exports = React.createClass
     @props.onDragStart e, dragStartY
 
   onDragOver: (e) ->
+    e.preventDefault()
     mouseY = e.clientY - @props.dragStartY
     $dragOver = $(e.currentTarget).find('.edit-section-container')
     dragOverID = $dragOver.data('id')

--- a/client/apps/edit/components/content/section_container/index.coffee
+++ b/client/apps/edit/components/content/section_container/index.coffee
@@ -78,69 +78,65 @@ module.exports = React.createClass
       }
 
   getContainerProps: ->
-    props = {}
-    unless @props.isHero
-      props = {
-        draggable: !@props.editing
-        onDragStart: @onDragStart
-        onDragEnd: @props.onDragEnd
-        onDragOver: @onDragOver
-        style: {'opacity': .65} if @isDragging() and !@props.editing
-      }
-    return props
+    # props = {}
+    # unless @props.isHero
+    #   props = {
+    #     draggable: !@props.editing
+    #     onDragStart: @onDragStart
+    #     onDragEnd: @props.onDragEnd
+    #     onDragOver: @onDragOver
+    #     style: {'opacity': .65} if @isDragging() and !@props.editing
+    #   }
+    # return props
 
   render: ->
-    div @getContainerProps(),
-      @dropZone() if @state.dropPosition is 'top'
-      div {
-        className: 'edit-section-container'
-        'data-editing': @props.editing
-        'data-type': @props.section.get('type')
-        'data-layout': @props.section.get('layout')
-        'data-id': @props.index
-        'data-dragging': @isDragging() and !@props.editing
-      },
-        unless @props.section.get('type') is 'fullscreen'
-          div {
-            className: 'edit-section-hover-controls'
-            onClick: @setEditing(on)
-          },
-            unless @props.isHero
-              button {
-                className: "edit-section-drag button-reset"
-                dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
-              }
-            button {
-              className: "edit-section-remove button-reset"
-              onClick: @removeSection
-              dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
-            }
-        (switch @props.section.get('type')
-          when 'text' then SectionText
-          when 'video' then SectionVideo
-          when 'slideshow' then SectionSlideshow
-          when 'embed' then SectionEmbed
-          when 'fullscreen' then SectionFullscreen
-          when 'callout' then SectionCallout
-          when 'toc' then SectionToc
-          when 'image_set' then SectionImageCollection
-          when 'image_collection' then SectionImageCollection
-          when 'image' then SectionImage
-        )(
-          section: @props.section
-          editing: @props.editing
-          ref: 'section'
-          onClick: @setEditing(on)
-          setEditing: @setEditing
-          channel: @props.channel
-        )
+    div {
+      className: 'edit-section-container'
+      'data-editing': @props.editing
+      'data-type': @props.section.get('type')
+      'data-layout': @props.section.get('layout')
+      'data-id': @props.index
+      # 'data-dragging': @isDragging() and !@props.editing
+    },
+      unless @props.section.get('type') is 'fullscreen'
         div {
-          className: 'edit-section-container-bg'
-          onClick: @onClickOff
-        }
+          className: 'edit-section-hover-controls'
+          onClick: @setEditing(on)
+        },
+          unless @props.isHero
+            button {
+              className: "edit-section-drag button-reset"
+              dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
+            }
+          button {
+            className: "edit-section-remove button-reset"
+            onClick: @removeSection
+            dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
+          }
+      (switch @props.section.get('type')
+        when 'text' then SectionText
+        when 'video' then SectionVideo
+        when 'slideshow' then SectionSlideshow
+        when 'embed' then SectionEmbed
+        when 'fullscreen' then SectionFullscreen
+        when 'callout' then SectionCallout
+        when 'toc' then SectionToc
+        when 'image_set' then SectionImageCollection
+        when 'image_collection' then SectionImageCollection
+        when 'image' then SectionImage
+      )(
+        section: @props.section
+        editing: @props.editing
+        ref: 'section'
+        onClick: @setEditing(on)
+        setEditing: @setEditing
+        channel: @props.channel
+      )
+      div {
+        className: 'edit-section-container-bg'
+        onClick: @onClickOff
+      }
       (
         if @props.section.get('type') is 'fullscreen'
           div { className: 'edit-section-container-block' }
       )
-      @dropZone() if @state.dropPosition is 'bottom'
-

--- a/client/apps/edit/components/content/section_container/index.coffee
+++ b/client/apps/edit/components/content/section_container/index.coffee
@@ -52,6 +52,11 @@ module.exports = React.createClass
               className: "edit-section-drag button-reset"
               dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
             }
+          button {
+            className: "edit-section-remove button-reset"
+            onClick: @removeSection
+            dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
+          }
       (switch @props.section.get('type')
         when 'text' then SectionText
         when 'video' then SectionVideo

--- a/client/apps/edit/components/content/section_container/index.coffee
+++ b/client/apps/edit/components/content/section_container/index.coffee
@@ -20,9 +20,6 @@ icons = -> require('../../icons.jade') arguments...
 module.exports = React.createClass
   displayName: 'SectionContainer'
 
-  getInitialState: ->
-    dropPosition: 'top'
-
   onClickOff: ->
     @setEditing(off)()
     @refs.section?.onClickOff?()
@@ -38,58 +35,6 @@ module.exports = React.createClass
     e.stopPropagation()
     @props.section.destroy()
 
-  onDragStart: (e) ->
-    dragStartY = e.clientY - ($(e.currentTarget).position().top - window.scrollY)
-    @props.onDragStart e, dragStartY
-
-  onDragOver: (e) ->
-    e.preventDefault()
-    mouseY = e.clientY - @props.dragStartY
-    $dragOver = $(e.currentTarget).find('.edit-section-container')
-    dragOverID = $dragOver.data('id')
-    @setState
-      dropPosition: @getDropZonePosition(mouseY, $dragOver, dragOverID)
-    @props.onSetDragOver dragOverID unless dragOverID is @props.dragOver
-
-  getDropZonePosition: (mouseY, $dragOver, dragOverID) ->
-    dragOverTop = $dragOver.position().top + 20 - window.scrollY
-    dragOverCenter = dragOverTop + ($dragOver.height() / 2)
-    mouseBelowCenter = mouseY > dragOverCenter
-    dragOverIsNext = dragOverID is @props.dragging + 1
-    dragOverNotFirst = dragOverID != 0
-    draggingNotLast = @props.dragging != @props.sections.length - 1
-
-    if (dragOverNotFirst and draggingNotLast and mouseBelowCenter) or dragOverIsNext
-      dropZonePosition = 'bottom'
-    else
-      dropZonePosition = 'top'
-    dropZonePosition
-
-  isDragOver: ->
-    @props.dragOver is @props.index and !@props.isHero
-
-  isDragging: ->
-    @props.dragging is @props.index and !@props.isHero
-
-  dropZone: ->
-    if @isDragOver() and !@isDragging()
-      div {
-        className: 'edit-section-drag-placeholder'
-        style: height: @props.draggingHeight
-      }
-
-  getContainerProps: ->
-    # props = {}
-    # unless @props.isHero
-    #   props = {
-    #     draggable: !@props.editing
-    #     onDragStart: @onDragStart
-    #     onDragEnd: @props.onDragEnd
-    #     onDragOver: @onDragOver
-    #     style: {'opacity': .65} if @isDragging() and !@props.editing
-    #   }
-    # return props
-
   render: ->
     div {
       className: 'edit-section-container'
@@ -97,7 +42,6 @@ module.exports = React.createClass
       'data-type': @props.section.get('type')
       'data-layout': @props.section.get('layout')
       'data-id': @props.index
-      # 'data-dragging': @isDragging() and !@props.editing
     },
       unless @props.section.get('type') is 'fullscreen'
         div {

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -14,10 +14,6 @@ module.exports = React.createClass
 
   getInitialState: ->
     editingIndex: null
-    dragging: null
-    dragOver: null
-    dragStartY: null
-    draggingHeight: 0
 
   componentDidMount: ->
     @props.sections.on 'add', @onNewSection
@@ -33,62 +29,40 @@ module.exports = React.createClass
     if @props.sections.isEmpty()
       @props.article.set 'sections', []
 
-  onDragStart: (e, dragStartY) ->
-    e.dataTransfer.effectAllowed = 'move'
-    e.dataTransfer.setData('text/html', e.currentTarget)
-    $dragged = $(e.currentTarget).find('.edit-section-container')
-    @setState
-      dragStartY: dragStartY
-      dragging: $dragged.data('id')
-      draggingHeight: $dragged.height() - 20
-
-  onDragEnd: ->
-    debugger
-    # newSections = @props.sections.models
-    # removed = newSections.splice @state.dragging, 1
-    # newSections.splice @state.dragOver, 0, removed[0]
-    # @props.sections.reset newSections
-    # @setState
-    #   dragging: null
-    #   dragOver: null
-    #   draggingHeight: 0
-    #   dragStartY: null
-
-  onSetDragOver: (sectionId) ->
-    @setState dragOver: sectionId
+  onDragEnd: (sections) ->
+    @props.sections.reset sections
 
   render: ->
-    div {},
-      div {
-        className: 'edit-section-list' +
-          (if @props.sections.length then ' esl-children' else '')
-        ref: 'sections'
+    div {
+      className: 'edit-section-list' +
+        (if @props.sections.length then ' esl-children' else '')
+      ref: 'sections'
+    },
+      SectionTool { sections: @props.sections, index: -1, key: 1}
+      DragContainer {
+        items: @props.sections.models
+        onDragEnd: @onDragEnd
+        isDraggable: if @state.editingIndex or @state.editingIndex is 0 then false else true
+        layout: 'vertical'
       },
-        SectionTool { sections: @props.sections, index: -1, key: 1}
-        DragContainer {
-          items: @props.sections
-          onDragEnd: @onDragEnd
-          isDraggable: if @state.editingIndex then false else true
-          # dimensions: @state.dimensions
-        },
-          @props.sections.map (section, i) =>
-            [
-              SectionContainer {
-                sections: @props.sections
-                section: section
-                index: i
-                editing: @state.editingIndex is i
-                ref: 'section' + i
-                key: section.cid
-                channel: @props.channel
-                onSetEditing: @onSetEditing
-                onSetDragOver: @onSetDragOver
-                onDragStart: @onDragStart
-                onDragEnd: @onDragEnd
-                dragOver: @state.dragOver
-                dragging: @state.dragging
-                draggingHeight: @state.draggingHeight
-                dragStartY: @state.dragStartY
-              }
-              SectionTool { sections: @props.sections, index: i, key: i}
-            ]
+        @props.sections.map (section, i) =>
+          [
+            SectionContainer {
+              sections: @props.sections
+              section: section
+              index: i
+              editing: @state.editingIndex is i
+              ref: 'section' + i
+              key: section.cid
+              channel: @props.channel
+              onSetEditing: @onSetEditing
+              onSetDragOver: @onSetDragOver
+              onDragStart: @onDragStart
+              onDragEnd: @onDragEnd
+              dragOver: @state.dragOver
+              dragging: @state.dragging
+              draggingHeight: @state.draggingHeight
+              dragStartY: @state.dragStartY
+            }
+            SectionTool { sections: @props.sections, index: i, key: i}
+          ]

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -68,7 +68,7 @@ module.exports = React.createClass
         DragContainer {
           items: @props.sections
           onDragEnd: @onDragEnd
-          isDraggable: true #@props.editing
+          isDraggable: if @state.editingIndex then false else true
           # dimensions: @state.dimensions
         },
           @props.sections.map (section, i) =>

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -30,6 +30,7 @@ module.exports = React.createClass
       @props.article.set 'sections', []
 
   onDragEnd: (sections) ->
+    debugger
     @props.sections.reset sections
 
   render: ->
@@ -39,30 +40,24 @@ module.exports = React.createClass
       ref: 'sections'
     },
       SectionTool { sections: @props.sections, index: -1, key: 1}
-      DragContainer {
-        items: @props.sections.models
-        onDragEnd: @onDragEnd
-        isDraggable: if @state.editingIndex or @state.editingIndex is 0 then false else true
-        layout: 'vertical'
-      },
-        @props.sections.map (section, i) =>
-          [
-            SectionContainer {
-              sections: @props.sections
-              section: section
-              index: i
-              editing: @state.editingIndex is i
-              ref: 'section' + i
-              key: section.cid
-              channel: @props.channel
-              onSetEditing: @onSetEditing
-              onSetDragOver: @onSetDragOver
-              onDragStart: @onDragStart
-              onDragEnd: @onDragEnd
-              dragOver: @state.dragOver
-              dragging: @state.dragging
-              draggingHeight: @state.draggingHeight
-              dragStartY: @state.dragStartY
-            }
-            SectionTool { sections: @props.sections, index: i, key: i}
-          ]
+      if @props.sections.length > 1
+        DragContainer {
+          items: @props.sections.models
+          onDragEnd: @onDragEnd
+          isDraggable: if @state.editingIndex or @state.editingIndex is 0 then false else true
+          layout: 'vertical'
+        },
+          @props.sections.map (section, i) =>
+            [
+              SectionContainer {
+                sections: @props.sections
+                section: section
+                index: i
+                editing: @state.editingIndex is i
+                ref: 'section' + i
+                key: section.cid
+                channel: @props.channel
+                onSetEditing: @onSetEditing
+              }
+              SectionTool { sections: @props.sections, index: i, key: i}
+            ]

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -6,6 +6,7 @@
 React = require 'react'
 SectionContainer = React.createFactory require '../section_container/index.coffee'
 SectionTool = React.createFactory require '../section_tool/index.coffee'
+DragContainer = React.createFactory require '../../../../../components/drag_drop/index.coffee'
 { div } = React.DOM
 
 module.exports = React.createClass
@@ -42,15 +43,16 @@ module.exports = React.createClass
       draggingHeight: $dragged.height() - 20
 
   onDragEnd: ->
-    newSections = @props.sections.models
-    removed = newSections.splice @state.dragging, 1
-    newSections.splice @state.dragOver, 0, removed[0]
-    @props.sections.reset newSections
-    @setState
-      dragging: null
-      dragOver: null
-      draggingHeight: 0
-      dragStartY: null
+    debugger
+    # newSections = @props.sections.models
+    # removed = newSections.splice @state.dragging, 1
+    # newSections.splice @state.dragOver, 0, removed[0]
+    # @props.sections.reset newSections
+    # @setState
+    #   dragging: null
+    #   dragOver: null
+    #   draggingHeight: 0
+    #   dragStartY: null
 
   onSetDragOver: (sectionId) ->
     @setState dragOver: sectionId
@@ -63,24 +65,30 @@ module.exports = React.createClass
         ref: 'sections'
       },
         SectionTool { sections: @props.sections, index: -1, key: 1}
-        @props.sections.map (section, i) =>
-          [
-            SectionContainer {
-              sections: @props.sections
-              section: section
-              index: i
-              editing: @state.editingIndex is i
-              ref: 'section' + i
-              key: section.cid
-              channel: @props.channel
-              onSetEditing: @onSetEditing
-              onSetDragOver: @onSetDragOver
-              onDragStart: @onDragStart
-              onDragEnd: @onDragEnd
-              dragOver: @state.dragOver
-              dragging: @state.dragging
-              draggingHeight: @state.draggingHeight
-              dragStartY: @state.dragStartY
-            }
-            SectionTool { sections: @props.sections, index: i, key: i}
-          ]
+        DragContainer {
+          items: @props.sections
+          onDragEnd: @onDragEnd
+          isDraggable: true #@props.editing
+          # dimensions: @state.dimensions
+        },
+          @props.sections.map (section, i) =>
+            [
+              SectionContainer {
+                sections: @props.sections
+                section: section
+                index: i
+                editing: @state.editingIndex is i
+                ref: 'section' + i
+                key: section.cid
+                channel: @props.channel
+                onSetEditing: @onSetEditing
+                onSetDragOver: @onSetDragOver
+                onDragStart: @onDragStart
+                onDragEnd: @onDragEnd
+                dragOver: @state.dragOver
+                dragging: @state.dragging
+                draggingHeight: @state.draggingHeight
+                dragStartY: @state.dragStartY
+              }
+              SectionTool { sections: @props.sections, index: i, key: i}
+            ]

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -61,5 +61,5 @@ module.exports = React.createClass
                 channel: @props.channel
                 onSetEditing: @onSetEditing
               }
-              SectionTool { sections: @props.sections, index: i, key: i}
+              SectionTool { sections: @props.sections, index: i, key: i }
             ]

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -41,7 +41,7 @@ module.exports = React.createClass
         (if @props.sections.length then ' esl-children' else '')
       ref: 'sections'
     },
-      SectionTool { sections: @props.sections, index: -1, key: 1}
+      SectionTool { sections: @props.sections, index: -1, key: 1 }
       if @props.sections.length > 0
         DragContainer {
           items: @props.sections.models

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -42,7 +42,7 @@ module.exports = React.createClass
       ref: 'sections'
     },
       SectionTool { sections: @props.sections, index: -1, key: 1}
-      if @props.sections.length > 1
+      if @props.sections.length > 0
         DragContainer {
           items: @props.sections.models
           onDragEnd: @onDragEnd

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -30,8 +30,10 @@ module.exports = React.createClass
       @props.article.set 'sections', []
 
   onDragEnd: (sections) ->
-    debugger
     @props.sections.reset sections
+
+  isDraggable: ->
+    if @state.editingIndex or @state.editingIndex is 0 then false else true
 
   render: ->
     div {
@@ -44,7 +46,7 @@ module.exports = React.createClass
         DragContainer {
           items: @props.sections.models
           onDragEnd: @onDragEnd
-          isDraggable: if @state.editingIndex or @state.editingIndex is 0 then false else true
+          isDraggable: @isDraggable()
           layout: 'vertical'
         },
           @props.sections.map (section, i) =>

--- a/client/apps/edit/components/content/section_list/test/index.coffee
+++ b/client/apps/edit/components/content/section_list/test/index.coffee
@@ -18,10 +18,6 @@ describe 'SectionList', ->
       global.HTMLElement = () => {}
       @SectionList = benv.require resolve(__dirname, '../index')
       DragContainer = benv.require resolve(__dirname, '../../../../../../components/drag_drop/index')
-      DragTarget = benv.require resolve(__dirname, '../../../../../../components/drag_drop/drag_target')
-      DragSource = benv.require resolve(__dirname, '../../../../../../components/drag_drop/drag_source')
-      DragContainer.__set__ 'DragTarget', React.createFactory DragTarget
-      DragContainer.__set__ 'DragSource', React.createFactory DragSource
       @SectionList.__set__ 'SectionTool', @SectionTool = sinon.stub()
       @SectionContainer = benv.requireWithJadeify(
         resolve(__dirname, '../../section_container/index'), ['icons']
@@ -56,7 +52,6 @@ describe 'SectionList', ->
             ]
           }
         ]
-        article: new Backbone.Model {sections: @sections.models}
       }
       @component = ReactDOM.render React.createElement(@SectionList, @props ), (@$el = $ "<div></div>")[0], => setTimeout =>
         done()

--- a/client/apps/edit/components/content/sections/image_collection/components/artwork.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/components/artwork.coffee
@@ -8,7 +8,10 @@ module.exports = React.createClass
   displayName: 'ImageCollectionDisplayArtwork'
 
   render: ->
-    div { className: 'esic-img-container'},
+    div {
+      className: 'esic-img-container'
+      style: {width: @props.dimensions?[@props.index]?.width or 'auto'}
+    },
       Artwork {
         artwork: @props.artwork
       }

--- a/client/apps/edit/components/content/sections/image_collection/components/image.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/components/image.coffee
@@ -7,21 +7,18 @@ RichTextCaption = React.createFactory require '../../../../../../../components/r
 module.exports = React.createClass
   displayName: 'ImageCollectionDisplayImage'
 
-  setHeight: ->
-    if @props.dimensions[@props.index]
-      return @props.dimensions[@props.index].height
-    else
-      return 'auto'
-
   render: ->
     image = @props.image
     url = resize image.url, width: 900
 
-    div { className: 'esic-img-container' },
+    div {
+      className: 'esic-img-container'
+      style: {width: @props.dimensions?[@props.index]?.width or 'auto'}
+    },
       img {
         className: 'esic-image'
         src: if @props.progress then image.url else url
-        height: @setHeight()
+        height: @props.dimensions?[@props.index]?.height or 'auto'
         style: opacity: if !@props.imagesLoaded then 0 else 1
       }
       unless @props.progress

--- a/client/apps/edit/components/content/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/index.coffee
@@ -129,6 +129,7 @@ module.exports = React.createClass
                     removeItem: @removeItem
                     editing:  @props.editing
                     imagesLoaded: @state.imagesLoaded
+                    dimensions: @state.dimensions
                   }
                 else
                   Image {

--- a/client/components/drag_drop/drag_source.coffee
+++ b/client/components/drag_drop/drag_source.coffee
@@ -4,9 +4,11 @@ React = require 'react'
 module.exports = React.createClass
   displayName: 'DragSource'
 
-  setDragSource: ->
+  setDragSource: (e) ->
     unless !@props.isDraggable
-      @props.setDragSource(@props.i)
+      dragStartY = e.clientY - ($(e.currentTarget).position().top - window.scrollY)
+      dragHeight = $(e.currentTarget).height()
+      @props.setDragSource(@props.i, dragHeight, dragStartY)
 
   render: ->
     div {

--- a/client/components/drag_drop/drag_source.coffee
+++ b/client/components/drag_drop/drag_source.coffee
@@ -5,7 +5,7 @@ module.exports = React.createClass
   displayName: 'DragSource'
 
   setDragSource: (e) ->
-    unless !@props.isDraggable
+    if @props.isDraggable
       dragStartY = e.clientY - ($(e.currentTarget).position().top - window.scrollY)
       dragHeight = $(e.currentTarget).height()
       @props.setDragSource(@props.i, dragHeight, dragStartY)

--- a/client/components/drag_drop/drag_target.coffee
+++ b/client/components/drag_drop/drag_target.coffee
@@ -6,7 +6,7 @@ module.exports = React.createClass
   displayName: 'DragTarget'
 
   componentWillMount: ->
-    @debouncedDragTarget = _.debounce(((mouseY) =>
+    @debouncedDragTarget = _.debounce((($dragTarget, mouseY) =>
       $dragTarget = $(@refs.target)
       @props.setDragTarget(@props.i, $dragTarget, mouseY)
     ), 3)
@@ -31,6 +31,7 @@ module.exports = React.createClass
       className: 'drag-target'
       onDragOver: @setDragTarget
       'data-target': @props.activeTarget
+      'data-source': @props.activeSource
       style:
         width: @props.width or '100%'
     },

--- a/client/components/drag_drop/drag_target.coffee
+++ b/client/components/drag_drop/drag_target.coffee
@@ -1,21 +1,39 @@
 React = require 'react'
+_ = require 'underscore'
 { div } = React.DOM
 
 module.exports = React.createClass
   displayName: 'DragTarget'
 
+  componentWillMount: ->
+    @debouncedDragTarget = _.debounce(((mouseY) =>
+      $dragTarget = $(@refs.target)
+      @props.setDragTarget(@props.i, $dragTarget, mouseY)
+    ), 3)
+
   setDragTarget: (e) ->
     unless @props.i is @props.activeTarget
-      @props.setDragTarget(@props.i)
+      mouseY = e.clientY - @props.dragStartY
+      @debouncedDragTarget(mouseY)
+
+  renderDropZone: ->
+    verticalClass = if @props.vertical then ' vertical' else ''
+    if @props.activeTarget and @props.isDraggable
+      div {
+        className: 'drag-placeholder' + verticalClass
+        style:
+          height: @props.height or 'auto'
+      }
 
   render: ->
     div {
+      ref: 'target'
       className: 'drag-target'
       onDragOver: @setDragTarget
       'data-target': @props.activeTarget
       style:
         width: @props.width or '100%'
     },
-      if @props.activeTarget and @props.isDraggable
-        div { className: 'drag-placeholder' }
+      @renderDropZone() if @props.dropPosition is 'top'
       @props.children
+      @renderDropZone() if @props.dropPosition is 'bottom'

--- a/client/components/drag_drop/drag_target.coffee
+++ b/client/components/drag_drop/drag_target.coffee
@@ -8,19 +8,13 @@ module.exports = React.createClass
     unless @props.i is @props.activeTarget
       @props.setDragTarget(@props.i)
 
-  setWidth: ->
-    if @props.width and @props.width[@props.i]
-      return @props.width[@props.i].width
-    else
-      return '100%'
-
   render: ->
     div {
       className: 'drag-target'
       onDragOver: @setDragTarget
       'data-target': @props.activeTarget
       style:
-        width: @setWidth()
+        width: @props.width or '100%'
     },
       if @props.activeTarget and @props.isDraggable
         div { className: 'drag-placeholder' }

--- a/client/components/drag_drop/index.coffee
+++ b/client/components/drag_drop/index.coffee
@@ -36,10 +36,8 @@ module.exports = React.createClass
     dragSourceNotLast = @state.dragSource != @props.children.length - 1
 
     if (dragTargetNotFirst and dragSourceNotLast and mouseBelowCenter) or dragTargetIsNext
-      console.log 'bottom'
       dropZonePosition = 'bottom'
     else
-      console.log 'top'
       dropZonePosition = 'top'
     dropZonePosition
 

--- a/client/components/drag_drop/index.coffee
+++ b/client/components/drag_drop/index.coffee
@@ -32,10 +32,10 @@ module.exports = React.createClass
 
     div { className: 'drag-container' },
       children.map (child, i) =>
-        console.log child.props
         if child.type.displayName is 'SectionTool'
           child
         else
+          i = child.props.index or i
           DragTarget {
             key: i
             i: i

--- a/client/components/drag_drop/index.coffee
+++ b/client/components/drag_drop/index.coffee
@@ -32,21 +32,25 @@ module.exports = React.createClass
 
     div { className: 'drag-container' },
       children.map (child, i) =>
-        DragTarget {
-          key: i
-          i: i
-          setDragTarget: @setDragTarget
-          activeSource: @state.dragSource is i
-          activeTarget: @state.dragTarget is i
-          isDraggable: @props.isDraggable
-          width: @props.dimensions
-        },
-          DragSource {
+        console.log child.props
+        if child.type.displayName is 'SectionTool'
+          child
+        else
+          DragTarget {
+            key: i
             i: i
-            setDragSource: @setDragSource
+            setDragTarget: @setDragTarget
             activeSource: @state.dragSource is i
             activeTarget: @state.dragTarget is i
-            onDragEnd: @onDragEnd
             isDraggable: @props.isDraggable
+            width: @props.dimensions
           },
-            child
+            DragSource {
+              i: i
+              setDragSource: @setDragSource
+              activeSource: @state.dragSource is i
+              activeTarget: @state.dragTarget is i
+              onDragEnd: @onDragEnd
+              isDraggable: @props.isDraggable
+            },
+              child

--- a/client/components/drag_drop/index.coffee
+++ b/client/components/drag_drop/index.coffee
@@ -32,7 +32,7 @@ module.exports = React.createClass
 
     div { className: 'drag-container' },
       children.map (child, i) =>
-        if child.type.displayName is 'SectionTool'
+        if child.type.displayName is 'SectionTool' or !@props.isDraggable
           child
         else
           i = child.props.index or i

--- a/client/components/drag_drop/index.coffee
+++ b/client/components/drag_drop/index.coffee
@@ -10,9 +10,14 @@ module.exports = React.createClass
   getInitialState: ->
     dragSource: null
     dragTarget: null
+    dragStartY: null
+    draggingHeight: 0
 
-  setDragSource: (index) ->
-    @setState dragSource: index
+  setDragSource: (index, draggingHeight, clientY) ->
+    @setState
+      dragSource: index
+      dragStartY: clientY
+      draggingHeight: draggingHeight
 
   setDragTarget: (index) ->
     @setState dragTarget: index
@@ -26,6 +31,8 @@ module.exports = React.createClass
     @setState
       dragSource: null
       dragTarget: null
+      dragStartY: null
+      draggingHeight: 0
 
   render: ->
     children = React.Children.toArray(@props.children)
@@ -43,7 +50,7 @@ module.exports = React.createClass
             activeSource: @state.dragSource is i
             activeTarget: @state.dragTarget is i
             isDraggable: @props.isDraggable
-            width: @props.dimensions
+            width: @props.dimensions?[i]?.width
           },
             DragSource {
               i: i

--- a/client/components/drag_drop/index.styl
+++ b/client/components/drag_drop/index.styl
@@ -13,3 +13,5 @@
     left 0
     right 0
     z-index 1
+    &.vertical
+      position relative

--- a/client/components/drag_drop/index.styl
+++ b/client/components/drag_drop/index.styl
@@ -1,17 +1,21 @@
 .drag-container
   width 100%
+
   .drag-target
     position relative
+    .drag-placeholder
+      border 2px dashed gray-color
+      min-height 2em
+      background-color white
+      position absolute
+      top 0
+      bottom 0
+      left 0
+      right 0
+      z-index 1
+      &.vertical
+        position relative
+        margin-bottom 20px
 
-  .drag-placeholder
-    border 2px dashed gray-color
-    min-height 2em
+  .drag-source[data-source='true']
     background-color white
-    position absolute
-    top 0
-    bottom 0
-    left 0
-    right 0
-    z-index 1
-    &.vertical
-      position relative

--- a/client/components/drag_drop/test/index.coffee
+++ b/client/components/drag_drop/test/index.coffee
@@ -1,6 +1,7 @@
 benv = require 'benv'
 sinon = require 'sinon'
 { resolve } = require 'path'
+Backbone = require 'backbone'
 React = require 'react'
 ReactDOM = require 'react-dom'
 ReactDOMServer = require 'react-dom/server'
@@ -9,7 +10,7 @@ r =
   find: ReactTestUtils.scryRenderedDOMComponentsWithClass
   simulate: ReactTestUtils.Simulate
 
-describe 'DragDropContainer', ->
+describe 'DragDropContainer Default', ->
 
   beforeEach (done) ->
     benv.setup =>
@@ -19,7 +20,7 @@ describe 'DragDropContainer', ->
       DragTarget = benv.require resolve __dirname, '../drag_target.coffee'
       DragSource = benv.require resolve __dirname, '../drag_source.coffee'
       ImageDisplay = benv.requireWithJadeify(
-        resolve __dirname, '../../../apps/edit/components/section_image_collection/components/image.coffee'
+        resolve __dirname, '../../../apps/edit/components/content/sections/image_collection/components/image.coffee'
         ['icons']
       )
       @DragDropContainer.__set__ 'DragTarget', React.createFactory DragTarget
@@ -39,7 +40,6 @@ describe 'DragDropContainer', ->
   afterEach ->
     benv.teardown()
 
-
   it 'renders a drag container with children', ->
     @$el.find('.drag-target').length.should.eql 2
     @$el.find('.drag-source').length.should.eql 2
@@ -51,19 +51,29 @@ describe 'DragDropContainer', ->
   it 'sets draggable to false if not props.isDraggable', ->
     @props.isDraggable = false
     rendered = ReactDOMServer.renderToString React.createElement(@DragDropContainer, @props, @children)
-    $(rendered).find('.drag-source[draggable=false]').length.should.eql 2
-    $(rendered).find('.drag-source[draggable=true]').length.should.eql 0
+    $(rendered).find('.drag-source').length.should.eql 0
+    $(rendered).find('[draggable=true]').length.should.eql 0
 
   it 'sets state.dragSource on DragStart', ->
     @component.setState = sinon.stub()
     r.simulate.dragStart r.find(@component, 'drag-source')[1]
     @component.setState.args[0][0].dragSource.should.eql 1
 
-  it 'sets state.dragTarget on DragEnd', ->
+  it 'sets state.dragTarget on DragEnd', (done) ->
+    @component.setState dragSource: 1
     @component.setState = sinon.stub()
     r.simulate.dragOver r.find(@component, 'drag-target')[0]
-    @component.setState.args[0][0].dragTarget.should.eql 0
+    setTimeout( =>
+      @component.setState.args[0][0].dragTarget.should.eql 0
+      done()
+    , 3)
 
+  it 'setDropZonePosition returns top if props.layout is not vertical', ->
+    $dragTarget = sinon.stub()
+    $dragTarget.position = sinon.stub().returns(top: 200)
+    $dragTarget.height = sinon.stub().returns(250)
+    position = @component.setDropZonePosition($dragTarget, 1, 200)
+    position.should.eql 'top'
 
   describe '#DragEnd', ->
 
@@ -79,8 +89,114 @@ describe 'DragDropContainer', ->
       @onDragEnd.args[0][0][0].image.url.should.eql 'image2.com'
       @onDragEnd.args[0][0][1].image.url.should.eql 'image1.com'
 
-    it 'Resets the state dragSource and dragTarget to null', ->
+    it 'Resets the state on DragEnd', ->
       r.simulate.dragStart r.find(@component, 'drag-source')[1]
       r.simulate.dragOver r.find(@component, 'drag-target')[0]
       r.simulate.dragEnd r.find(@component, 'drag-source')[1]
-      @component.state.should.eql { dragSource: null, dragTarget: null }
+      @component.state.should.eql {
+        dragSource: null
+        dragStartY: null
+        dragTarget: null
+        draggingHeight: 0
+        dropPosition: 'top'
+      }
+
+
+describe 'DragDropContainer Vertical', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose
+        $: benv.require 'jquery'
+      @DragDropContainer = benv.require resolve(__dirname, '../index.coffee')
+      DragTarget = benv.require resolve __dirname, '../drag_target.coffee'
+      DragSource = benv.require resolve __dirname, '../drag_source.coffee'
+      SectionContainer = benv.requireWithJadeify(
+        resolve __dirname, '../../../apps/edit/components/content/section_container/index.coffee'
+        ['icons']
+      )
+      SectionTool = benv.requireWithJadeify(
+        resolve __dirname, '../../../apps/edit/components/content/section_tool/index.coffee'
+        ['icons']
+      )
+      ImageCollection = benv.require resolve __dirname, '../../../apps/edit/components/content/sections/image_collection/index.coffee'
+      ImageCollection.__set__ 'Controls', sinon.stub()
+      ImageCollection.__set__ 'imagesLoaded', sinon.stub().returns(true)
+      SectionContainer.__set__ 'SectionImageCollection', React.createFactory ImageCollection
+      @DragDropContainer.__set__ 'DragTarget', React.createFactory DragTarget
+      @DragDropContainer.__set__ 'DragSource', React.createFactory DragSource
+      item1 = new Backbone.Model {
+          type: 'image_collection'
+          images: [{image: {url: 'image1.com'}}]
+      }
+      item2 = new Backbone.Model {
+        type: 'image_collection'
+        images: [{image: {url: 'image2.com'}}]
+      }
+      item3 = new Backbone.Model {
+        type: 'image_collection'
+        images: [{image: {url: 'image3.com'}}]
+      }
+      @props = {
+        isDraggable: true
+        onDragEnd: @onDragEnd = sinon.stub()
+        items: [item1, item2, item3]
+        layout: 'vertical'
+      }
+      @children = [
+        React.createElement(SectionContainer, {key:'child-1', i: 0, section: item1, editing: false, channel: {hasFeature: sinon.stub().returns(true)}})
+        React.createElement(SectionTool, {key:'child-2', i: 1, sections: [item1, item2, item3], channel: {hasFeature: sinon.stub().returns(true)}})
+        React.createElement(SectionContainer, {key:'child-3', i: 2, section: item2, editing: false, channel: {hasFeature: sinon.stub().returns(true)}})
+        React.createElement(SectionContainer, {key:'child-4', i: 3, section: item3, editing: false, channel: {hasFeature: sinon.stub().returns(true)}})
+      ]
+      @component = ReactDOM.render React.createElement(@DragDropContainer, @props, @children), (@$el = $ "<div></div>")[0], =>
+      done()
+
+  afterEach ->
+    benv.teardown()
+
+  it 'renders a drag container with children', ->
+    @$el.find('.drag-target').length.should.eql 3
+    @$el.find('.drag-source').length.should.eql 3
+    @$el.find('img').length.should.eql 3
+
+  it 'does not add draggable properties to sectionTool', ->
+    @$el.find('.edit-section-tool-menu').parent().hasClass('.drag-source').should.not.be.ok
+    @$el.find('.edit-section-tool-menu').parent().hasClass('.drag-container').should.be.ok
+
+  it 'adds a vertical class to active drag-targets', ->
+    @component.setState
+      dragSource: 1
+      dragTarget: 0
+    $(ReactDOM.findDOMNode(@component)).find('.drag-target').html().should.containEql 'drag-placeholder vertical'
+
+
+  describe '#setDropZonePosition', ->
+
+    it 'returns bottom if dragTargetIsNext', ->
+      $dragTarget = sinon.stub()
+      $dragTarget.position = sinon.stub().returns(top: 200)
+      $dragTarget.height = sinon.stub().returns(250)
+      position = @component.setDropZonePosition($dragTarget, 1, 200)
+      position.should.eql 'bottom'
+
+    it 'returns top if dragTarget is first section', ->
+      $dragTarget = sinon.stub()
+      $dragTarget.position = sinon.stub().returns(top: 200)
+      $dragTarget.height = sinon.stub().returns(250)
+      position = @component.setDropZonePosition($dragTarget, 0, 200)
+      position.should.eql 'top'
+
+    it 'returns top if mouse is above center', ->
+      $dragTarget = sinon.stub()
+      $dragTarget.position = sinon.stub().returns(top: 200)
+      $dragTarget.height = sinon.stub().returns(250)
+      position = @component.setDropZonePosition($dragTarget, 2, 200)
+      position.should.eql 'top'
+
+    it 'returns bottom if mouse is below center', ->
+      $dragTarget = sinon.stub()
+      $dragTarget.position = sinon.stub().returns(top: 200)
+      $dragTarget.height = sinon.stub().returns(250)
+      position = @component.setDropZonePosition($dragTarget, 2, 350)
+      position.should.eql 'bottom'


### PR DESCRIPTION
re: https://github.com/artsy/positron/issues/1144
- Moves drag-drop logic out of section list in favor of DragContainer component
- Adds 'vertical' option to DragContainer, which renders drop targets above or below a dragged-over item depending on user's mouse position

![drag-drop](https://user-images.githubusercontent.com/1497424/27961910-46381978-62fe-11e7-8b8f-cb923984ccde.gif)
