### PR TITLE
@craigspaeth => DragDrop QA

### DIFF
--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -31,6 +31,7 @@ module.exports = React.createClass
 
   onDragEnd: (sections) ->
     @props.sections.reset sections
+    @forceUpdate() if @props.article.get 'published'
 
   isDraggable: ->
     if @state.editingIndex or @state.editingIndex is 0 then false else true


### PR DESCRIPTION
Published articles were not re-rendering the list on drag-end, this adds a forceupdate to the section list if article is published
