### PR TITLE
@kanaabe=> Safari caption bug

### DIFF
--- a/client/components/rich_text_caption/index.styl
+++ b/client/components/rich_text_caption/index.styl
@@ -13,8 +13,8 @@
     color gray-dark-color
     left 0
     right 0
-  .bordered-input.has-focus
-    border-color purple-color
+  .public-DraftEditor-content
+    user-select text
   &__actions
     height 40px
     width 85px


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1159

Inputs are blocked from focusing in safari and IE if their parents have `draggable=true`. Adding `user-select` fixes it.
Also removes unused class for focused input. 