### PR TITLE
@craigspaeth => Fullscreen header bug / style fixes

### DIFF
--- a/client/apps/edit/components/content/index.coffee
+++ b/client/apps/edit/components/content/index.coffee
@@ -27,13 +27,11 @@ module.exports = React.createClass
 
   render: ->
     div {className: 'edit-section-layout'},
-
       if @props.article.get('hero_section') != null or @props.channel.hasFeature 'hero'
-        div { id: 'edit-hero-section'},
-          HeroSection {
-            section: @props.article.heroSection
-            channel: @props.channel
-          }
+        HeroSection {
+          section: @props.article.heroSection
+          channel: @props.channel
+        }
 
       HeaderSection {
         article: @props.article

--- a/client/apps/edit/components/content/sections/fullscreen/index.coffee
+++ b/client/apps/edit/components/content/sections/fullscreen/index.coffee
@@ -104,11 +104,12 @@ module.exports = React.createClass
               loop: true
             }
         else if @state.background_image_url
-          div { className: 'esf-fullscreen-container' },
-            img {
-              className: 'esf-fullscreen'
-              src: @state.background_image_url
-            }
+          div {
+            className: 'esf-fullscreen-container'
+            style:
+              backgroundImage: 'url(' + @state.background_image_url + ')'
+          },
+            div { className: 'esf-fullscreen'}
         else
           div { className: 'esf-placeholder' }
       )

--- a/client/apps/edit/components/content/sections/fullscreen/index.styl
+++ b/client/apps/edit/components/content/sections/fullscreen/index.styl
@@ -21,27 +21,19 @@
 .edit-section-container[data-type=fullscreen]
   height 800px
   width calc(100vw - 110px)
-  margin-top -55px
   padding 0px
-  left 110px
-  position absolute
   overflow hidden
   &::after
     border 0
-  .edit-section-controls
-    display block
   .edit-author-section
     color white
     border-color white
     margin-top 0px
 
-.edit-section-container[data-type=fullscreen][data-editing=false]
-  .esf-change-background
-    display none
-
-.edit-section-container[data-type=fullscreen][data-editing=true]
-  .esf-change-background
-    display inline-block
+#edit-content .edit-section-container[data-type=fullscreen] .edit-section-controls
+  display block
+  height 100%
+  background transparent
 
 .esf-right-controls-container
   float right
@@ -69,16 +61,21 @@
     cursor pointer
 
 .esf-fullscreen
-  width 100%
-  transition opacity 0.5s
-  opacity 0.5
   position absolute
+  background-color black
+  top 0
+  right 0
+  bottom 0
+  left 0
+  opacity .5
 
 .esf-fullscreen-container
   z-index 3
   background-color black
   width 100%
   height 800px
+  background-size cover
+  background-position 50%
 
 .esf-text-container
   z-index 4

--- a/client/apps/edit/components/content/sections/hero/index.coffee
+++ b/client/apps/edit/components/content/sections/hero/index.coffee
@@ -23,11 +23,12 @@ module.exports = React.createClass
 
   render: ->
     unless @props.section.keys().length
-      SectionTool {
-        sections: @props.sections
-        hero: true
-        setHero: @setHero
-      }
+      div { id: 'edit-hero-section'},
+        SectionTool {
+          sections: @props.sections
+          hero: true
+          setHero: @setHero
+        }
     else
       SectionContainer {
         section: @props.section

--- a/client/apps/edit/components/content/sections/hero/index.styl
+++ b/client/apps/edit/components/content/sections/hero/index.styl
@@ -9,24 +9,13 @@
       display none
     &:hover
       fill-color black
-  .edit-section-container[data-type=video], .edit-section-container[data-type=image]
-    width 1100px
-    .esv-controls-container
-      height 243px
-    .esv-nav, .esv-background-color
-      display none
-  .edit-section-container[data-type=image]
-    left calc(50% - 410px)
-  .edit-section-container[data-type=video]
-    left calc(50% - 550px)
 
-#edit-hero-section
-  .edit-section-tool-menu
-    li
-      width 50%
-    li:first-child:nth-last-child(3),
-    li:first-child:nth-last-child(3) ~ li
-      width 33.3%
+.edit-section-container[data-type=video], .edit-section-container[data-type=image]
+  width 1100px
+  .esv-controls-container
+    height 243px
+  .esv-nav, .esv-background-color
+    display none
   .edit-section-video
     iframe
       min-height 590px
@@ -36,3 +25,16 @@
     z-index 1
   .edit-section-container-bg
     z-index -1
+
+.edit-section-container[data-type=image]
+  left calc(50% - 410px)
+.edit-section-container[data-type=video]
+  left calc(50% - 550px)
+
+#edit-hero-section
+  .edit-section-tool-menu
+    li
+      width 50%
+    li:first-child:nth-last-child(3),
+    li:first-child:nth-last-child(3) ~ li
+      width 33.3%

--- a/client/apps/edit/components/content/sections/image/index.coffee
+++ b/client/apps/edit/components/content/sections/image/index.coffee
@@ -6,6 +6,7 @@ _ = require 'underscore'
 gemup = require 'gemup'
 React = require 'react'
 DisplayImage = React.createFactory require '../image_collection/components/image.coffee'
+SectionControls = React.createFactory require '../../section_controls/index.coffee'
 imagesLoaded = require 'imagesloaded'
 sd = require('sharify').data
 icons = -> require('../../../icons.jade') arguments...
@@ -68,17 +69,23 @@ module.exports = React.createClass
       className: 'edit-section-image'
       onClick: @props.setEditing(true)
     },
-      div { className: 'esi-controls-container edit-section-controls' },
-        div { className: 'esi-inputs' },
-          section { className: 'dashed-file-upload-container' },
-            h1 {}, 'Drag & ',
-              span { className: 'dashed-file-upload-container-drop' }, 'drop'
-              ' or '
-              span { className: 'dashed-file-upload-container-click' }, 'click'
-              span {}, (' to ' +
-                if @props.section.get('url') then 'replace' else 'upload')
-            h2 {}, 'Up to 30mb'
-            input { type: 'file', onChange: @upload }
+      if @props.editing
+        SectionControls {
+          section: @props.section
+          channel: @props.channel
+          isHero: @props.isHero
+        },
+          div { className: 'esi-controls-container edit-section-controls' },
+            div { className: 'esi-inputs' },
+              section { className: 'dashed-file-upload-container' },
+                h1 {}, 'Drag & ',
+                  span { className: 'dashed-file-upload-container-drop' }, 'drop'
+                  ' or '
+                  span { className: 'dashed-file-upload-container-click' }, 'click'
+                  span {}, (' to ' +
+                    if @props.section.get('url') then 'replace' else 'upload')
+                h2 {}, 'Up to 30mb'
+                input { type: 'file', onChange: @upload }
       (
         if @state.progress
           div { className: 'upload-progress-container' },

--- a/client/apps/edit/components/content/test/index.coffee
+++ b/client/apps/edit/components/content/test/index.coffee
@@ -45,7 +45,6 @@ describe 'EditContent', ->
   describe 'Render', ->
 
     it 'renders the hero section if channel hasFeature', ->
-      $(ReactDOM.findDOMNode(@component)).html().should.containEql '<div id="edit-hero-section">'
       @HeroSection.called.should.eql true
 
     it 'does not render the hero section if hasFeature is false', ->


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1162

- Fixes bug where layout sections were appearing over fullscreen header
- Use background image to display fullscreen header background rather than `<img>`
- Use SectionControls component for image section

![screen shot 2017-07-10 at 12 46 49 pm](https://user-images.githubusercontent.com/1497424/28029597-943c2d4a-656e-11e7-931b-8ebde03329c8.png)
