### PR TITLE
@craigspaeth => Article (singular) GraphQL fetch

### DIFF
--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -206,6 +206,7 @@ denormalizedArtwork = (->
 #
 @querySchema = (->
   id: @string().objectid()
+  slug: @string()
   access_token: @string()
   author_id: @string().objectid()
   published: @boolean()

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -206,7 +206,6 @@ denormalizedArtwork = (->
 #
 @querySchema = (->
   id: @string().objectid()
-  slug: @string()
   access_token: @string()
   author_id: @string().objectid()
   published: @boolean()

--- a/api/apps/graphql/index.coffee
+++ b/api/apps/graphql/index.coffee
@@ -1,7 +1,7 @@
 express = require 'express'
 graphqlHTTP = require 'express-graphql'
 joiql = require 'joiql'
-{ object, array } = require 'joi'
+{ object, array, string } = require 'joi'
 Article = require '../articles/model/schema'
 Curation = require '../curations/model'
 Channel = require '../channels/model'
@@ -20,6 +20,11 @@ schema = joiql
     )).meta(
       args: Article.querySchema
       resolve: resolvers.articles
+    )
+    article: object(Article.inputSchema)
+    .meta(
+      args: id: string()
+      resolve: resolvers.article
     )
     curations: array().items(object(
       Curation.schema

--- a/api/apps/graphql/resolvers.coffee
+++ b/api/apps/graphql/resolvers.coffee
@@ -1,24 +1,38 @@
 _ = require 'underscore'
 User = require '../users/model.coffee'
-{ mongoFetch, presentCollection } = Article = require '../articles/model'
+{ mongoFetch, presentCollection, find, present } = Article = require '../articles/model'
 Curation = require '../curations/model'
 Channel = require '../channels/model'
 Tag = require '../tags/model'
 Author = require '../authors/model'
 
 module.exports.articles = (root, args, req, ast) ->
-  if (not args.published or args.scheduled) and not args.channel_id
+  unpublished = not args.published or args.scheduled
+  if unpublished and not args.channel_id
     throw new Error 'Must pass channel_id to view unpublished articles. Or pass ' +
       'published: true to only view published articles.'
 
-  access = User.hasChannelAccess req.user, args.channel_id
-  if (not args.published or args.scheduled) and not access
+  unauthorized = not User.hasChannelAccess req.user, args.channel_id
+  if unpublished and unauthorized
     throw new Error 'Must be a member of this channel to view unpublished articles. ' +
       'Pass published: true to only view published articles.'
 
   return new Promise (resolve, reject) ->
     mongoFetch args, (err, results) ->
       resolve presentCollection(results).results
+
+module.exports.article = (root, args, req, ast) ->
+  return new Promise (resolve, reject) ->
+    find args.id, (err, results) ->
+      if results
+        unpublished = not results.published or results.scheduled
+        unauthorized = not User.hasChannelAccess req.user, results.channel_id
+        if unpublished and unauthorized
+          reject new Error 'Must be a member of the channel to view an unpublished article.'
+        else
+          resolve present(results)
+      else
+        reject new Error 'Article not found.'
 
 module.exports.curations = (root, args, req, ast) ->
   return new Promise (resolve, reject) ->


### PR DESCRIPTION
Lets us query for a single article by id -- `slug` or `objectid`. This helps us render on the Force side where currently we can only query by `objectid` since Joi expects the `id` field to be of type `objectid`