### PR TITLE
@kanaabe => New article fonts

### DIFF
--- a/client/components/layout/stylesheets/index.styl
+++ b/client/components/layout/stylesheets/index.styl
@@ -2,6 +2,7 @@
 @import './sidebar'
 @import './form_elements'
 @import './simple_modal'
+@import './typography'
 
 global-reset()
 

--- a/client/components/layout/stylesheets/typography.styl
+++ b/client/components/layout/stylesheets/typography.styl
@@ -1,0 +1,62 @@
+Unica(size = 's19', family = 'regular')
+  font-smoothing antialiased
+  if family == 'regular'
+    font-family 'Unica77LLWebRegular', 'Arial', 'serif'
+  else if family == 'italic'
+    font-family 'Unica77LLWebItalic', 'Arial', 'serif'
+  else if family == 'medium'
+    font-family 'Unica77LLWebMedium', 'Arial', 'serif'
+  else if family == 'mediumItalic'
+    font-family 'Unica77LLWebMediumItalic', 'Arial', 'serif'
+  if size == 's130'
+    font-size 130px
+    line-height 1.1em
+  else if size == 's100'
+    font-size 100px
+    line-height 1.1em
+  else if size == 's80'
+    font-size 80px
+    line-height 1.1em
+  else if size == 's69'
+    font-size 69px
+    line-height 1em
+  else if size == 's40'
+    font-size 40px
+    line-height 1.1em
+  else if size == 's19'
+    font-size 19px
+    line-height 1.5em
+  else if size == 's14'
+    font-size 14px
+    line-height 1.1em
+
+AvantGarde(size = 's13')
+  font-family 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif'
+  font-smoothing antialiased
+  text-transform uppercase
+  letter-spacing 1px
+  if size == 's11'
+    font-size 11px
+    line-height 1.1em
+  else if size == 's13'
+    font-size 13px
+    line-height 1.1em
+
+Garamond(size = 's15')
+  font-family 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif'
+  font-smoothing antialiased
+  if size == 's50'
+    font-size 50px
+    line-height 1.1em
+  else if size == 's40'
+    font-size 40px
+    line-height 1.1em
+  else if size == 's23'
+    font-size 23px
+    line-height 1.5em
+  else if size == 's17'
+    font-size 17px
+    line-height 1.1em
+  else if size == 's15'
+    font-size 15px
+    line-height 1.25em

--- a/client/components/layout/templates/index.jade
+++ b/client/components/layout/templates/index.jade
@@ -9,7 +9,8 @@ html( lang="en" data-useragent=sd.USER_AGENT )
     meta( name="apple-mobile-web-app-capable", content="yes" )
     title Artsy Writer
     link( type='text/css' rel='stylesheet' href=asset('/assets/main.css') )
-    link( rel='icon', type='image/png', href=asset('/images/favicon.ico') )
+    link( rel='icon' type='image/png' href=asset('/images/favicon.ico') )
+    link( rel='stylesheet' type='text/css', href=(sd.CDN_URL + '/fonts/unica-stylesheet.css'))
   body
     #layout-content
       unless hideHeader

--- a/client/lib/setup/sharify.coffee
+++ b/client/lib/setup/sharify.coffee
@@ -24,4 +24,5 @@ sharify.data = _.pick process.env,
   'TOPIC_TAG_CURATION',
   'EF_VENICE',
   'SENTRY_PUBLIC_DSN',
-  'NO_INDEX_CHANNELS'
+  'NO_INDEX_CHANNELS',
+  'CDN_URL'


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1156
- Adds typography.styl to components/layout
- Adds stylus mixins for new font-sizes (based on same system as Reaction)
- Loads Unica font-family from CDN

For new fonts, use the same system as before but with font-name capitalized
old: `garamond(l-body)`
new: `Garamond(s19)`