### PR TITLE
@craigspaeth => Paste bugs

### DIFF
--- a/client/apps/edit/components/content/sections/text/index.coffee
+++ b/client/apps/edit/components/content/sections/text/index.coffee
@@ -156,8 +156,9 @@ module.exports = React.createClass
       unless unstyled.getType() in ['unstyled', 'LINK', 'header-two', 'header-three', 'unordered-list-item', 'ordered-list-item']
         unstyled = unstyled.set 'type', 'unstyled'
       return unstyled
-    newState = ContentState.createFromBlockArray(convertedHtml, blocksFromHTML.getBlocksAsArray())
-    @onChange(EditorState.push(editorState, newState, 'insert-fragment'))
+    blockMap = ContentState.createFromBlockArray(convertedHtml, blocksFromHTML.getBlocksAsArray()).blockMap
+    newState = Modifier.replaceWithFragment(editorState.getCurrentContent(), editorState.getSelection(), blockMap)
+    @onChange EditorState.push(editorState, newState, 'insert-fragment')
     return true
 
   makePlainText: () ->

--- a/client/apps/edit/components/content/sections/text/test/index.coffee
+++ b/client/apps/edit/components/content/sections/text/test/index.coffee
@@ -456,4 +456,11 @@ describe 'SectionText', ->
 
     it 'strips or converts unsupported html and linebreaks', ->
       @component.onPaste('Here is a caption about an image yep.', '<meta><script>bad.stuff()</script><h1 class="stuff">Here is a</h1><ul><li><b>caption</b></li><li>about an <pre>image</pre></li></ul><p>yep.</p><br>')
+      @component.state.html.should.containEql '<p>Here is a</p><ul><li><strong>caption</strong></li><li>about an image</li></ul>'
+
+    it 'does not overwrite existing content', ->
+      @component.onPaste('Here is a caption about an image yep.', '<meta><script>bad.stuff()</script><h1 class="stuff">Here is a</h1><ul><li><b>caption</b></li><li>about an <pre>image</pre></li></ul><p>yep.</p><br>')
       @component.state.html.should.startWith '<p>Here is a</p><ul><li><strong>caption</strong></li><li>about an image</li></ul>'
+      @component.state.html.should.containEql '<p>yep.01 &nbsp;<a name="here" class="is-jump-link">here is a toc.</a></p><p>In 2016, K mounted a <a'
+
+


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1185

Fixes a bug where pasting content was replacing all editor content with the pasted text.
Adds a modifier to merge current state with new pasted content.