### PR TITLE
@kanaabe => Use regular attrs for lead paragraph

### DIFF
--- a/client/apps/edit/components/content/sections/header/index.coffee
+++ b/client/apps/edit/components/content/sections/header/index.coffee
@@ -16,7 +16,7 @@ module.exports = React.createClass
     @props.saveArticle()
 
   setLeadParagraph: (html) ->
-    @props.article.setLeadParagraph(html)
+    @props.article.set 'lead_paragraph', html
     @props.saveArticle()
 
   render: ->

--- a/client/apps/edit/components/content/sections/header/test/index.coffee
+++ b/client/apps/edit/components/content/sections/header/test/index.coffee
@@ -75,7 +75,7 @@ describe 'SectionHeader', ->
 
     it '#setLeadParagraph sets and saves article lead paragraph on change', ->
       @component.setLeadParagraph('<p>A new paragraph</p>')
-      @component.props.article.leadParagraph.get('text').should.eql '<p>A new paragraph</p>'
+      @component.props.article.get('lead_paragraph').should.eql '<p>A new paragraph</p>'
       @component.props.saveArticle.called.should.eql true
 
   describe 'Author /Date ', ->

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -116,8 +116,8 @@ module.exports = class EditLayout extends Backbone.View
 
   getBodyText: =>
     @fullText = []
-    if $(@article.leadParagraph.get('text')).text().length
-      @fullText.push @article.leadParagraph.get('text')
+    if @article.get('lead_paragraph').length
+      @fullText.push @article.get('lead_paragraph')
     for section in @article.sections.models when section.get('type') is 'text'
       @fullText.push section.get('body')
     @fullText = @fullText.join()

--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -28,7 +28,6 @@ module.exports = class Article extends Backbone.Model
       @mentionedArtists = new Artists
       @featuredArtworks = new Artworks
       @mentionedArtworks = new Artworks
-      @leadParagraph = new Backbone.Model text: @get('lead_paragraph')
       @heroSection = new Backbone.Model @get 'hero_section'
       @on 'change:hero_section', => @heroSection.set @get 'hero_section'
       @heroSection.destroy = @heroSection.clear
@@ -66,9 +65,6 @@ module.exports = class Article extends Backbone.Model
 
   hasContributingAuthors: ->
     @get('contributing_authors')?.length > 0
-
-  setLeadParagraph: (html) =>
-    @leadParagraph.set('text', html)
 
   getDescription: (attr = '') ->
     @get(attr) or @get('description')
@@ -121,6 +117,4 @@ module.exports = class Article extends Backbone.Model
       extended.hero_section = @heroSection.toJSON()
     else if @heroSection
       extended.hero_section = null
-    if @leadParagraph?.get('text')?.length
-      extended.lead_paragraph = @leadParagraph.get('text')
     _.extend super, extended

--- a/client/test/models/article.coffee
+++ b/client/test/models/article.coffee
@@ -42,11 +42,11 @@ describe "Article", ->
       JSON.stringify(@article.toJSON()).should.containEql '"hero_section":null'
 
     it 'serializes the lead paragraph if there is data', ->
-      @article.setLeadParagraph('<p>hello</p>')
+      @article.set('lead_paragraph', '<p>hello</p>')
       @article.toJSON().lead_paragraph.should.eql '<p>hello</p>'
 
     it 'serializes the lead paragraph if there isnt any data', ->
-      @article.setLeadParagraph('<p></p>')
+      @article.set('lead_paragraph', '<p></p>')
       (@article.toJSON().lead_paragraph?).should.not.be.ok
 
   describe '#finishedContent', ->
@@ -109,12 +109,6 @@ describe "Article", ->
       published = moment().subtract(1, 'years')
       @article.set published_at: published.toISOString()
       @article.getPublishDate().should.containEql published.format('MMM D, YYYY')
-
-  describe '#setLeadParagraph', ->
-
-    it 'sets @leadParagraph to html contents', ->
-      @article.setLeadParagraph('<p>hello</p>')
-      @article.leadParagraph.get('text').should.equal '<p>hello</p>'
 
   describe '#getObjectAttribute', ->
 


### PR DESCRIPTION
Tiny step towards lead paragraph changes...
- Removes 'setLeadParagraph' and article.leadParagraph from article model
- Uses regular backbone attrs when setting or reading leadParagraph