### PR TITLE
@eessex => Fix scheduler

### DIFF
--- a/api/apps/articles/model/save.coffee
+++ b/api/apps/articles/model/save.coffee
@@ -15,7 +15,7 @@ Article = require './index'
 artsyXapp = require('artsy-xapp').token or ''
 
 @onPublish = (article, cb) =>
-  unless article.published_at
+  unless article.published_at or article.scheduled_publish_at
     article.published_at = new Date
   @generateSlugs article, cb
 
@@ -59,7 +59,9 @@ removeStopWords = (title) ->
   # Append published_at to slug if that slug already exists
   db.articles.count { slugs: slug }, (err, count) ->
     return cb(err) if err
-    slug = slug + '-' + moment(article.published_at).format('MM-DD-YY') if count
+    if count
+      format = if article.published then 'MM-DD-YY' else 'X'
+      slug = slug + '-' + moment(article.published_at).format(format)
     article.slugs = (article.slugs or []).concat slug
     cb(null, article)
 

--- a/api/apps/articles/test/model/index/persistence.coffee
+++ b/api/apps/articles/test/model/index/persistence.coffee
@@ -139,6 +139,7 @@ describe 'Article Persistence', ->
           thumbnail_title: 'heyo'
           author_id: '5086df098523e60002000018'
           published_at: '01-01-99'
+          published: true
           id: '5086df098523e60002002222'
           author: name: 'Craig Spaeth'
           }, 'foo', {}, (err, article) ->

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -85,7 +85,7 @@ describe 'Save', ->
         slugs: ['molly-clockwork']
       })
 
-    it 'appends unix to the slug if it exists already and it is a draft', ->
+    it 'appends unix to the slug if it exists already and it is a draft', (done) ->
       Save.sanitizeAndSave( =>
         Save.generateSlugs {
           thumbnail_title: 'Clockwork'

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -55,6 +55,50 @@ describe 'Save', ->
           .equal moment().format('MM DD YYYY')
         done()
 
+    it 'does not generate published_at if scheduled', (done) ->
+      Save.onPublish { thumbnail_title: 'a title', scheduled_publish_at: '2017-07-26T17:37:03.065Z', published_at: null }, (err, article) =>
+        (article.published_at is null).should.be.true()
+        done()
+
+  describe '#generateSlugs', ->
+
+    it 'generates a slug', (done) ->
+      Save.generateSlugs {
+        thumbnail_title: 'Clockwork'
+        published: true
+        author: name: 'Molly'
+      }, (err, article) =>
+        article.slugs[0].should.equal 'molly-clockwork'
+        done()
+
+    it 'appends a date to the slug if it exists already', (done) ->
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: true
+          author: name: 'Molly'
+          published_at: '2017-07-26T17:37:03.065Z'
+        }, (err, article) =>
+          article.slugs[0].should.equal 'molly-clockwork-07-26-17'
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
+    it 'appends unix to the slug if it exists already and it is a draft', ->
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: false
+          author: name: 'Molly'
+          published_at: '2017-07-26T17:37:03.065Z'
+        }, (err, article) =>
+          article.slugs[0].should.equal 'molly-clockwork-1501090623'
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
   describe '#onUnpublish', ->
 
     it 'generates slugs and deletes article from sailthru', (done) ->

--- a/client/apps/edit/components/admin/article/index.coffee
+++ b/client/apps/edit/components/admin/article/index.coffee
@@ -72,7 +72,7 @@ module.exports = AdminArticle = React.createClass
 
   onScheduleChange: ->
     published_at = moment(@refs.publish_date.value + ' ' + @refs.publish_time.value).local()
-    if !@props.article.get 'published'
+    unless @props.article.get 'published'
       @onChange 'published_at', null
       if @props.article.get 'scheduled_publish_at'
         # if draft and has scheduled date, unschedule


### PR DESCRIPTION
Not sure if the stuff described in https://artsy.slack.com/archives/C04GGGDCM/p1500985858521608 is entirely solved by this --

In the old iteration of the scheduler, we set both the `scheduled_publish_at` and `published_at` as the same value when someone scheduled and article which meant that the `onPublish` field wouldn't set the `published_at`. Now that that's changed, we should update the API to not set a default `published_at` if it's scheduled. 

Additionally, we won't have to view drafts with the scheduler anymore because it uses the unix timestamp to generate a slug if it is a draft. This ensures that no two drafts created on the same day have the same slug. 

