### PR TITLE
@craigspaeth => Deprecate hero_section fields

### DIFF
--- a/api/apps/articles/components/instant_articles/mixins.jade
+++ b/api/apps/articles/components/instant_articles/mixins.jade
@@ -5,12 +5,12 @@ mixin hero_section(hero)
         img(src=hero.url)/
         figcaption= hero.caption
       when 'fullscreen'
-        if hero.background_url
+        if hero.url && hero.url.indexOf('.mp4') > -1
           figure
             video(loop=true)
-              source(src=hero.background_url type='video/mp4')
+              source(src=hero.url type='video/mp4')
         else
-          img(src= hero.background_image_url)/
+          img(src= hero.url)/
 
 mixin artworks(section)
   if section.artworks

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -39,8 +39,6 @@ fullscreenSection = (->
     title: @string().allow('',null)
     intro: @string().allow('',null)
     url: @string().allow(null)
-    background_url: @string().allow('',null)
-    background_image_url: @string().allow('',null)
 ).call Joi
 
 denormalizedArtwork = (->

--- a/client/apps/edit/components/content/sections/fullscreen/index.coffee
+++ b/client/apps/edit/components/content/sections/fullscreen/index.coffee
@@ -16,8 +16,6 @@ module.exports = React.createClass
 
   getInitialState: ->
     title: @props.section.get('title')
-    background_url: @props.section.get('background_url')
-    background_image_url: @props.section.get('background_image_url')
     url: @props.section.get('url')
     progress: ''
 
@@ -28,11 +26,9 @@ module.exports = React.createClass
     @removeSection() unless @setSection()
 
   setSection: ->
-    return false unless @state.background_url or @state.title or @state.background_image_url
+    return false unless @state.url or @state.title
     @props.section.set
       title: @state.title
-      background_url: @state.background_url
-      background_image_url: @state.background_image_url
       url: @state.url
 
   onEditableKeyup: ->
@@ -51,20 +47,7 @@ module.exports = React.createClass
       add: (src) =>
         @setState progress: 0.1
       done: (src) =>
-        if src.indexOf('.mp4') > 0
-          @setState(
-            background_url: src
-            progress: null
-            background_image_url: null
-            url: src
-          )
-        else
-          @setState(
-            background_image_url: src
-            progress: null
-            background_url: null
-            url: src
-          )
+        @setState progress: null, url: src
         @onClickOff()
 
   render: ->
@@ -76,7 +59,7 @@ module.exports = React.createClass
         div { className: 'esf-right-controls-container' },
           section { className: 'esf-change-background'},
             span {},
-              (if @state.background_url or @state.background_image_url then '+ Change Background' else '+ Add Background'),
+              (if @state.url then '+ Change Background' else '+ Add Background'),
             input { type: 'file', onChange: @upload, accept: 'video/mp4,image/jpg,image/png,image/gif,image/jpeg' }
           button {
             className: 'edit-section-remove button-reset'
@@ -105,20 +88,20 @@ module.exports = React.createClass
             }
       )
       (
-        if @state.background_url
+        if @state.url and @state.url.indexOf('.mp4') > -1
           div { className: 'esf-fullscreen-container' },
             video {
               className: 'esf-fullscreen'
-              src: @state.background_url
+              src: @state.url
               key: 0
               autoPlay: true
               loop: true
             }
-        else if @state.background_image_url
+        else if @state.url
           div {
             className: 'esf-fullscreen-container'
             style:
-              backgroundImage: 'url(' + @state.background_image_url + ')'
+              backgroundImage: 'url(' + @state.url + ')'
           },
             div { className: 'esf-fullscreen'}
         else

--- a/client/apps/edit/components/content/sections/fullscreen/test/index.coffee
+++ b/client/apps/edit/components/content/sections/fullscreen/test/index.coffee
@@ -22,9 +22,8 @@ describe 'SectionFullscreen', ->
       @component = ReactDOM.render React.createElement(SectionFullscreen,
         section: new Backbone.Model
           type: 'fullscreen'
-          title: ''
-          background_url: ''
-          background_image_url: ''
+          title: 'Title Here'
+          url: 'video.mp4'
         editing: false
         setEditing: -> ->
       ), (@$el = $ "<div></div>")[0], => setTimeout =>
@@ -45,7 +44,6 @@ describe 'SectionFullscreen', ->
     @gemup.args[0][0].should.equal 'foo.mp4'
     @gemup.args[0][1].done('fooza.mp4')
     setTimeout =>
-      @component.setState.args[0][0].background_url.should.equal 'fooza.mp4'
       @component.setState.args[0][0].url.should.equal 'fooza.mp4'
       done()
 
@@ -54,7 +52,6 @@ describe 'SectionFullscreen', ->
     @gemup.args[0][0].should.equal 'foo.jpg'
     @gemup.args[0][1].done('fooza.jpg')
     setTimeout =>
-      @component.setState.args[0][0].background_image_url.should.equal 'fooza.jpg'
       @component.setState.args[0][0].url.should.equal 'fooza.jpg'
       done()
 


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1204

Ok last step! Remove the old fields. The `url` is already backfilled and Force is using this new `url` field too. After this, we just need to unset all the old fields in the database.