### PR TITLE
@craigspaeth => API bug with viewing draft & expose keywords for graphql

### DIFF
--- a/api/apps/articles/index.coffee
+++ b/api/apps/articles/index.coffee
@@ -5,7 +5,7 @@ routes = require './routes'
 app = module.exports = express()
 
 app.get '/articles', setUser, routes.index
-app.get '/articles/:id', routes.find, routes.show
+app.get '/articles/:id', setUser, routes.find, routes.show
 app.post '/articles', setUser, authenticated, routes.restrictFeature, routes.create
 app.put '/articles/:id', setUser, authenticated, routes.restrictFeature, routes.update
 app.delete '/articles/:id', setUser, authenticated, routes.find, routes.delete

--- a/api/apps/articles/index.coffee
+++ b/api/apps/articles/index.coffee
@@ -5,7 +5,7 @@ routes = require './routes'
 app = module.exports = express()
 
 app.get '/articles', setUser, routes.index
-app.get '/articles/:id', setUser, routes.find, routes.show
+app.get '/articles/:id', routes.find, routes.show
 app.post '/articles', setUser, authenticated, routes.restrictFeature, routes.create
 app.put '/articles/:id', setUser, authenticated, routes.restrictFeature, routes.update
 app.delete '/articles/:id', setUser, authenticated, routes.find, routes.delete

--- a/api/apps/articles/model/retrieve.coffee
+++ b/api/apps/articles/model/retrieve.coffee
@@ -29,6 +29,7 @@ moment = require 'moment'
     'vertical'
     'q'
     'scheduled'
+    'access_token'
   query.fair_ids = input.fair_id if input.fair_id
   if input.fair_programming_id
     query.fair_programming_ids = input.fair_programming_id

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -203,7 +203,7 @@ denormalizedArtwork = (->
   id: @string().objectid()
   access_token: @string()
   author_id: @string().objectid()
-  published: @boolean()
+  published: @boolean().default(true)
   limit: @number().max(Number API_MAX).default(Number API_PAGE_SIZE)
   offset: @number()
   section_id: @string().objectid()

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -194,6 +194,7 @@ denormalizedArtwork = (->
   search_title: @string().allow('', null)
   search_description: @string().allow('', null)
   seo_keyword: @string().allow('', null)
+  keywords: @array().items(@string()).allow(null)
 ).call Joi
 
 #

--- a/api/apps/articles/test/integration.coffee
+++ b/api/apps/articles/test/integration.coffee
@@ -24,12 +24,12 @@ describe 'articles endpoints', ->
         { published: false }
       ], (err, articles) =>
         request
-          .get("http://localhost:5000/articles?published=true&count=true")
+          .get("http://localhost:5000/articles?count=true")
           .end (err, res) ->
-              res.body.total.should.equal 3
-              res.body.count.should.equal 2
-              res.body.results[0].title.should.equal 'Flowers on Flowers The Sequel'
-              done()
+            res.body.total.should.equal 3
+            res.body.count.should.equal 2
+            res.body.results[0].title.should.equal 'Flowers on Flowers The Sequel'
+            done()
 
   describe 'as a non-admin', ->
 
@@ -52,6 +52,21 @@ describe 'articles endpoints', ->
           res.body.message.should.containEql 'must be an admin'
           done()
       return
+
+    it 'does not allow viewing drafts', (done) ->
+      fabricate 'articles', [
+        {
+          title: 'Cows on the prarie'
+          _id: ObjectId '5086df098523e60002000012'
+          partner_channel_id: ObjectId '5086df098523e60002000012'
+          published: false
+        }
+      ], (err, articles) =>
+        request
+          .get("http://localhost:5000/articles/5086df098523e60002000012")
+          .end (err, res) ->
+            err.status.should.equal 404
+            done()
 
   describe 'as a channel member', ->
 

--- a/api/apps/articles/test/model/index/retrieval.coffee
+++ b/api/apps/articles/test/model/index/retrieval.coffee
@@ -429,6 +429,7 @@ describe 'Article Retrieval', ->
         Article.where {
           scheduled: true
           count: true
+          published: false
         }, (err, res) ->
           { total, count, results } = res
           count.should.equal 1


### PR DESCRIPTION
1. Fixes a bug with [this line](https://github.com/artsy/positron/blob/master/api/apps/articles/routes.coffee#L8) where not passing any `published` param will result in skipping the error. Instead of fixing the conditional, we should give the `published` field a default value in the `querySchema` to prevent future mistakes like this.
2. Exposes the `keywords` field in the `inputSchema` (which is normally generated internally) so our GraphQL endpoint can view this field.