### PR TITLE
@eessex => Add section types to Looker export

### DIFF
--- a/scripts/daily_upload_s3.coffee
+++ b/scripts/daily_upload_s3.coffee
@@ -8,7 +8,7 @@ mongojs = require 'mongojs'
 fs = require 'fs'
 path = require 'path'
 moment = require 'moment'
-{ pluck, object } = require 'underscore'
+{ pluck, object, pick } = require 'underscore'
 
 # Setup environment variables
 env = require 'node-env-file'
@@ -53,6 +53,7 @@ attrs = [
   'indexable'
   'is_super_article'
   'description'
+  'sections'
 ]
 projections = object attrs, attrs.map -> 1
 
@@ -68,6 +69,7 @@ db.articles.find({ published: true }, projections).toArray (err, articles) ->
   articles.map (a) ->
     published_at = if a.published_at then moment(a.published_at).format('YYYY-MM-DDThh:mm') + "-05:00" else ''
     contributing_authors = stringify(pluck(a.contributing_authors, 'name'))
+    sections = a.sections.map (section) => pick section, 'type'
     row = [
       a._id
       a.author_id
@@ -97,6 +99,7 @@ db.articles.find({ published: true }, projections).toArray (err, articles) ->
       a.indexable
       a.is_super_article
       stringify a.description
+      stringify(JSON.stringify(sections))
     ].join(',')
     csv.push row
 

--- a/scripts/daily_upload_s3.coffee
+++ b/scripts/daily_upload_s3.coffee
@@ -54,6 +54,7 @@ attrs = [
   'is_super_article'
   'description'
   'sections'
+  'hero_section'
 ]
 projections = object attrs, attrs.map -> 1
 
@@ -70,6 +71,8 @@ db.articles.find({ published: true }, projections).toArray (err, articles) ->
     published_at = if a.published_at then moment(a.published_at).format('YYYY-MM-DDThh:mm') + "-05:00" else ''
     contributing_authors = stringify(pluck(a.contributing_authors, 'name'))
     sections = a.sections.map (section) => pick section, 'type'
+    if a.hero_section
+      hero = stringify(JSON.stringify(pick a.hero_section, 'type'))
     row = [
       a._id
       a.author_id
@@ -100,6 +103,7 @@ db.articles.find({ published: true }, projections).toArray (err, articles) ->
       a.is_super_article
       stringify a.description
       stringify(JSON.stringify(sections))
+      hero
     ].join(',')
     csv.push row
 


### PR DESCRIPTION
Exports a column record like: 
```
"[{'type':'artworks'},{'type':'text'},{'type':'artworks'},{'type':'text'},{'type':'artworks'},{'type':'text'}]"
```
in a `sections` and `hero_section` field so we can query things like, "all articles with a fullscreen header" or "all articles without a text section". 