### PR TITLE
@kanaabe => Save blockquote as section layout

### DIFF
--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -111,6 +111,7 @@ denormalizedArtwork = (->
     @object().meta(name: 'Text').keys
       type: @string().valid('text')
       body: @string().allow('', null)
+      layout: @string().allow('blockquote', null)
     @object().meta(name: 'Artworks').keys
       type: @string().valid('artworks')
       ids: @array().items(@string().objectid())

--- a/api/apps/articles/test/model/save.coffee
+++ b/api/apps/articles/test/model/save.coffee
@@ -158,6 +158,22 @@ describe 'Save', ->
         ]
       })
 
+    it 'can save layouts on text sections', (done) ->
+      Save.sanitizeAndSave( ->
+        Article.find '5086df098523e60002000011', (err, article) =>
+          article.sections[0].layout.should.eql 'blockquote'
+          done()
+      )(null, {
+        _id: ObjectId '5086df098523e60002000011'
+        sections: [
+          {
+            type: 'text'
+            body: '<blockquote>Viva Art</blockquote>'
+            layout: 'blockquote'
+          }
+        ]
+      })
+
     it 'indexes articles that are indexable', (done) ->
       Save.sanitizeAndSave( =>
         Article.find '5086df098523e60002000011', (err, article) =>

--- a/client/apps/edit/components/content2/section_container/index.coffee
+++ b/client/apps/edit/components/content2/section_container/index.coffee
@@ -46,7 +46,7 @@ module.exports = React.createClass
       className: 'edit-section__container'
       'data-editing': @props.editing
       'data-type': @props.section.get('type')
-      'data-layout': @props.section.getLayout(@props.article.get('layout'))
+      'data-layout': @props.section.get('layout') or 'column_width'
     },
       unless @props.section.get('type') is 'fullscreen'
         div {

--- a/client/apps/edit/components/content2/section_container/index.styl
+++ b/client/apps/edit/components/content2/section_container/index.styl
@@ -71,7 +71,7 @@
       border-radius 50%
 
 .classic
-  [data-layout='column_width']
+  [data-layout='column_width'], [data-layout='blockquote']
     max-width classic-body-w-margin
     margin 0 auto
   [data-layout='overflow_fillwidth']
@@ -82,7 +82,7 @@
   [data-layout='column_width']
     max-width standard-body-w-margin
     margin 0 auto
-  [data-layout='overflow_fillwidth']
+  [data-layout='overflow_fillwidth'], [data-layout='blockquote']
     max-width standard-overflow-w-margin
 
 .feature

--- a/client/apps/edit/components/content2/sections/text/index.coffee
+++ b/client/apps/edit/components/content2/sections/text/index.coffee
@@ -217,7 +217,7 @@ module.exports = React.createClass
       blockquote = blockquote.replace(beforeBlock, '')
       @props.sections.add {type: 'text', body: beforeBlock}, {at: @props.index }
       increment = 1
-    @props.section.set('body', blockquote)
+    @props.section.set({body: blockquote, layout: 'blockquote'})
     @props.onSetEditing @props.index + increment
 
   toggleBlockType: (blockType) ->
@@ -225,7 +225,10 @@ module.exports = React.createClass
       @onChange RichUtils.toggleBlockType(@state.editorState, blockType)
       @setState showMenu: false
       if blockType is 'blockquote'
-        @toggleBlockQuote() if @props.section.get('body').includes('<blockquote>')
+        if @props.section.get('body').includes('<blockquote>')
+          @toggleBlockQuote()
+        else
+          @props.section.set('layout', null)
     return 'handled'
 
   toggleInlineStyle: (inlineStyle) ->

--- a/client/apps/edit/components/content2/sections/text/test/index.coffee
+++ b/client/apps/edit/components/content2/sections/text/test/index.coffee
@@ -275,6 +275,7 @@ describe 'Section Text', ->
       @shortComponent.setState = sinon.stub()
       r.simulate.mouseDown r.find @shortComponent, 'blockquote'
       @shortComponent.setState.args[0][0].html.should.eql '<blockquote>A <em>short</em> piece of <strong>text</strong></blockquote>'
+      @shortComponent.props.section.get('layout').should.eql 'blockquote'
 
     it '#makePlainText Can strip styles', ->
       r.simulate.mouseUp r.find @shortComponent, 'edit-section--text__input'
@@ -336,6 +337,7 @@ describe 'Section Text', ->
       @shortComponent.setState = sinon.stub()
       @shortComponent.handleKeyCommand('blockquote')
       @shortComponent.setState.args[0][0].html.should.eql '<blockquote>A <em>short</em> piece of <strong>text</strong></blockquote>'
+      @shortComponent.props.section.get('layout').should.eql 'blockquote'
 
     it 'Cannot toggle Blockquotes if hasFeatures is false', ->
       @shortComponent.setState hasFeatures: false

--- a/client/components/drag_drop/index.coffee
+++ b/client/components/drag_drop/index.coffee
@@ -64,7 +64,7 @@ module.exports = React.createClass
           i = child.props.index or i
           type = child.props.section?.get('type') or null
           if child.type.displayName is 'SectionContainer'
-            layout = child.props.section.getLayout(@props.article?.get('layout'))
+            layout = child.props.section.get('layout') or 'column_width'
           DragTarget {
             key: i
             i: i

--- a/client/models/section.coffee
+++ b/client/models/section.coffee
@@ -46,11 +46,3 @@ module.exports = class Section extends Backbone.Model
       _.extend super, ids: @artworks.pluck '_id'
     else
       super
-
-   getLayout: (articleLayout) ->
-    layout = 'column_width'
-    if @get('type') is 'text' and @get('body')?.includes('<blockquote>')
-      layout = if articleLayout is 'feature' then 'blockquote' else 'overflow_fillwidth'
-    else if @get('layout')
-      layout = @get('layout')
-    return layout

--- a/client/test/models/section.coffee
+++ b/client/test/models/section.coffee
@@ -64,26 +64,3 @@ describe "Article", ->
     it 'extracts a slug from a Google link', ->
       @section.set body: '<p><a href="https://www.google.com/url?q=https%3A%2F%2Fwww.artsy.net%2Fartist%2Ftrenton-doyle-hancock&sa=D&sntz=1"></p>'
       @section.slugsFromHTML('body','artist')[0].should.equal 'trenton-doyle-hancock'
-
-  describe '#getLayout', ->
-
-    it 'returns column width by default', ->
-      layout = @section.getLayout()
-      layout.should.eql 'column_width'
-
-    it 'can return an existing layout', ->
-      @section.set layout: 'fullscreen'
-      layout = @section.getLayout()
-      layout.should.eql 'fullscreen'
-
-    it 'returns overflow if blockquote', ->
-      @section.set type: 'text'
-      @section.set body: '<blockquote>Cool pullquote</blockquote>'
-      layout = @section.getLayout()
-      layout.should.eql 'overflow_fillwidth'
-
-    it 'returns blockquote if feature article', ->
-      @section.set type: 'text'
-      @section.set body: '<blockquote>Cool pullquote</blockquote>'
-      layout = @section.getLayout('feature')
-      layout.should.eql 'blockquote'


### PR DESCRIPTION
- Removes getLayout from section model
- Adds 'blockquote' to layout schema for text sections
- Toggles blockquote section layout when creating blockquotes
- Adds width support for section container css