### PR TITLE
Simplify development environment setup via Docker Compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,12 @@ API_URL=http://localhost:3005/api
 FORCE_URL=https://staging.artsy.net
 ARTSY_URL=https://stagingapi.artsy.net
 SESSION_SECRET=p0s1tr0n
-MONGOHQ_URL=mongodb://localhost:27017/positron
+ELASTICSEARCH_PORT=9200
+
+# Local development only for the below; refers to the key in docker-compose.yml
+ELASTICSEARCH_URL=http://elasticsearch:9200
+MONGOHQ_URL=mongodb://mongodb:27017/positron
+
 TECH_SUPPORT=craig@artsymail.com
 DEBUG=api,client,app
 SALT=$2a$10$PJrPMBadu1NPdmnshBgFbe

--- a/.env.test
+++ b/.env.test
@@ -7,6 +7,7 @@ ARTSY_URL=http://localhost:5000/__gravity
 SESSION_SECRET=p0s1tr0n
 MONGOHQ_URL=mongodb://localhost:27017/positron-test
 ELASTICSEARCH_URL=http://localhost:9200
+ELASTICSEARCH_PORT=9200
 SALT=$2a$10$PJrPMBadu1NPdmnshBgFbe
 API_MAX=100
 API_PAGE_SIZE=10

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dump.rdb
 .env.ignore
 node_modules
 .vscode
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:7
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY package.json .
+COPY . .
+RUN yarn install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  elasticsearch:
+    image: elasticsearch:latest
+    ports:
+      - "${ELASTICSEARCH_PORT}:${ELASTICSEARCH_PORT}"
+  mongodb:
+    image: mongo:latest
+  server:
+    build: .
+    command: make s
+    ports:
+      - "${PORT}:${PORT}"
+    depends_on:
+      - elasticsearch
+      - mongodb
+    volumes:
+      - .:/usr/src/app


### PR DESCRIPTION
This is still WIP as I need to test a few things out, but what this PR does is wrap all of our local development environment services (mongo, elasticsearch, node) into one command `docker-compose up`. This allows us to keep things contained when working locally and free of global installs. Future setup is along the lines of 

- Install Docker for Mac (https://docs.docker.com/docker-for-mac/install/)
- `docker-compose up`

Note that this only applies only to local development environments and does not change existing deployment configuration. 