### PR TITLE
Always use yarn 0.27.x on heroku, stable version as of today

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "engines": {
     "node": "7.10.1",
-    "npm": "4.2.0"
+    "npm": "4.2.0",
+    "yarn": "0.27.x"
   },
   "scripts": {
     "start": "make s",


### PR DESCRIPTION
Heroku picks up ` Downloading and installing yarn (0.28.1)...` which is a nightly build. We should be using a stable version.