### PR TITLE
Do not fail when .env is missing in production/staging

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,12 @@ const env = require('node-env-file')
 
 if (process.env.NODE_ENV === 'test') {
   env('./.env.test')
-
-  // Other envs: development, staging, production
-} else {
+} else if (process.env.NODE_ENV === undefined || process.env.NODE_ENV === 'development') {
+  // If NODE_ENV is unset, assume that it's a local setup
   env('./.env')
+} else {
+  // Other envs: staging, production
+  env('./.env', { raise: false })
 }
 
 require('./boot')


### PR DESCRIPTION
It seems like [`node-env-file`](https://github.com/grimen/node-env-file/blob/b0732c5/lib/index.js#L130) has an option to not raise an error even when the `.env` file is missing, which is the case in heroku.