### PR TITLE
Make undefined check safe

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,19 @@
 require('babel-core/register')
 require('coffee-script/register')
-
+const _ = require('underscore')
 const env = require('node-env-file')
 
-if (process.env.NODE_ENV === 'test') {
+const NODE_ENV = process.env.NODE_ENV
+
+if (NODE_ENV === 'test') {
   env('./.env.test')
-} else if (process.env.NODE_ENV === undefined || process.env.NODE_ENV === 'development') {
-  // If NODE_ENV is unset, assume that it's a local setup
+
+  // If NODE_ENV is development or unset, assume that it's a local setup
+} else if (NODE_ENV === 'development' || _.isUndefined(NODE_ENV)) {
   env('./.env')
-} else {
+
   // Other envs: staging, production
+} else {
   env('./.env', { raise: false })
 }
 


### PR DESCRIPTION
Noticed in the previous PR that there was an equality check against `undefined` but JS is super weird and that kind of operation isn't safe. A best practice is do `typeof myVar === 'undefined'`, or use underscore or lodash's `_.isUndefined`.