### PR TITLE
@kanaabe => Consolidate section layout controls

### DIFF
--- a/client/apps/edit/components/content2/section_controls/index.coffee
+++ b/client/apps/edit/components/content2/section_controls/index.coffee
@@ -69,6 +69,7 @@ module.exports = React.createClass
   changeLayout: (e) ->
     if @props.section.get('type') is 'image_set'
       @props.section.set 'type', 'image_collection'
+      @forceUpdate()
     e = if e.target then e.target.name else e
     @props.section.set layout: e
     @props.onChange() if @props.onChange
@@ -77,10 +78,7 @@ module.exports = React.createClass
     if @props.section.get('type') is 'image_collection'
       @props.section.unset 'layout'
       @props.section.set 'type', 'image_set'
-    else
-      @props.section.set
-        layout: 'overflow_fillwidth'
-        type: 'image_collection'
+      @forceUpdate()
     @props.onChange() if @props.onChange
 
   renderSectionLayouts: ->

--- a/client/apps/edit/components/content2/section_controls/index.coffee
+++ b/client/apps/edit/components/content2/section_controls/index.coffee
@@ -1,6 +1,6 @@
 React = require 'react'
 _ = require 'underscore'
-{ header } = React.DOM
+{ header, nav, a } = React.DOM
 
 module.exports = React.createClass
   displayName: 'SectionControls'
@@ -66,6 +66,53 @@ module.exports = React.createClass
         insideComponent = true
     insideComponent
 
+  changeLayout: (e) ->
+    if @props.section.get('type') is 'image_set'
+      @props.section.set 'type', 'image_collection'
+    e = if e.target then e.target.name else e
+    @props.section.set layout: e
+    @props.onChange() if @props.onChange
+
+  toggleImageSet: ->
+    if @props.section.get('type') is 'image_collection'
+      @props.section.unset 'layout'
+      @props.section.set 'type', 'image_set'
+    else
+      @props.section.set
+        layout: 'overflow_fillwidth'
+        type: 'image_collection'
+    @props.onChange() if @props.onChange
+
+  renderSectionLayouts: ->
+    nav { className: 'edit-controls__layout' },
+      a {
+        name: 'overflow_fillwidth'
+        className: 'layout'
+        onClick: @changeLayout
+        'data-active': @props.section.get('layout') is 'overflow_fillwidth'
+      }
+      a {
+        name: 'column_width'
+        className: 'layout'
+        onClick: @changeLayout
+        'data-active': @props.section.get('layout') is 'column_width'
+      }
+      if @props.articleLayout is 'feature'
+        a {
+          name: 'fillwidth'
+          className: 'layout'
+          onClick: @changeLayout
+          'data-active': @props.section.get('layout') is 'fillwidth'
+        }
+      if @props.section.get('type') in ['image_set', 'image_collection'] and
+       @props.channel.hasFeature 'image_set'
+        a {
+          name: 'image_set'
+          className: 'layout'
+          onClick: @toggleImageSet
+          'data-active': @props.section.get('type') is 'image_set'
+        }
+
   render: ->
     header {
       className: 'edit-controls' + if @state.insideComponent then ' sticky' else ''
@@ -73,7 +120,9 @@ module.exports = React.createClass
       style:
         position: if @state.insideComponent then 'fixed' else 'absolute'
         bottom: @getPositionBottom()
-        left: @getPositionLeft() if @props.article?.get('layout') is 'classic'
+        left: @getPositionLeft() if @props.articleLayout is 'classic'
     },
+      if @props.sectionLayouts
+        @renderSectionLayouts()
       @props.children
 

--- a/client/apps/edit/components/content2/section_controls/test/index.coffee
+++ b/client/apps/edit/components/content2/section_controls/test/index.coffee
@@ -26,10 +26,11 @@ describe 'SectionControls', ->
           type: 'image_collection'
           layout: 'overflow_fillwidth'
         editing: true
-        channel: { isEditorial: sinon.stub().returns(true) }
+        channel:
+          isEditorial: sinon.stub().returns(true)
+          hasFeature: sinon.stub().returns(true)
         isHero: false
-        article: new Backbone.Model
-          layout: 'classic'
+        articleLayout: 'classic'
       }
 
       @component = ReactDOM.render React.createElement(@SectionControls, @props), (@$el = $ "<div></div>")[0], => setTimeout =>
@@ -95,7 +96,7 @@ describe 'SectionControls', ->
       header.should.eql 95
 
     it 'returns 55 when channel is not editorial', ->
-      @props.channel = { isEditorial: sinon.stub().returns(false) }
+      @props.channel = { isEditorial: sinon.stub().returns(false), hasFeature: sinon.stub().returns(false) }
       component = ReactDOM.render React.createElement(@SectionControls, @props), (@$el = $ "<div></div>")[0], =>
       header = component.getHeaderSize()
       header.should.eql 55

--- a/client/apps/edit/components/content2/sections/image_collection/components/controls.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/components/controls.coffee
@@ -17,23 +17,6 @@ module.exports = React.createClass
   componentWillUnmount: ->
     @autocomplete.remove()
 
-  changeLayout: (e) ->
-    if @props.section.get('type') is 'image_set'
-      @props.section.set 'type', 'image_collection'
-    e = if e.target then e.target.name else e
-    @props.section.set layout: e
-    @props.onChange()
-
-  toggleImageSet: ->
-    if @props.section.get('type') is 'image_collection'
-      @props.section.unset 'layout'
-      @props.section.set 'type', 'image_set'
-    else
-      @props.section.set
-        layout: 'overflow_fillwidth'
-        type: 'image_collection'
-    @props.onChange()
-
   addArtworkFromUrl: (newImages) ->
     @props.section.set images: newImages
     @props.onChange()
@@ -95,32 +78,12 @@ module.exports = React.createClass
 
   render: ->
     SectionControls {
-      editing: @props.editing
       section: @props.section
       channel: @props.channel
-      article: @props.article
+      articleLayout: @props.article.get('layout')
+      onChange: @props.onChange
+      sectionLayouts: true
     },
-      nav { className: 'edit-controls__layout' },
-        a {
-          name: 'overflow_fillwidth'
-          className: 'layout'
-          onClick: @changeLayout
-          'data-active': @props.section.get('layout') is 'overflow_fillwidth'
-        }
-        a {
-          name: 'column_width'
-          className: 'layout'
-          onClick: @changeLayout
-          'data-active': @props.section.get('layout') is 'column_width'
-        }
-        if @props.channel.hasFeature 'image_set'
-          a {
-            name: 'image_set'
-            className: 'layout'
-            onClick: @toggleImageSet
-            'data-active': @props.section.get('type') is 'image_set'
-          }
-
       section { className: 'dashed-file-upload-container' },
         h1 {}, 'Drag & ',
           span { className: 'dashed-file-upload-container-drop' }, 'drop'


### PR DESCRIPTION
Moves layout icon-toggles into section-container component, so we don't have to repeat across components. 