### PR TITLE
Boost name over alternative names, boost index

### DIFF
--- a/api/apps/search/queries.js
+++ b/api/apps/search/queries.js
@@ -5,7 +5,7 @@ export const matchAll = (term) => {
         multi_match: {
           query: term,
           type: 'best_fields',
-          fields: ['name.*', 'alternate_names.*'],
+          fields: ['name.*^4', 'alternate_names.*'],
           fuzziness: 2
         }
       },

--- a/api/apps/search/routes.js
+++ b/api/apps/search/routes.js
@@ -5,7 +5,7 @@ const { NODE_ENV } = process.env
 
 // GET /api/search
 export const index = (req, res, next) => {
-  const env = NODE_ENV === 'production' ? 'production' : 'production'
+  const env = NODE_ENV === 'production' ? 'production' : 'staging'
   let index = ''
   if (req.query.type) {
     index = _.map(req.query.type.split(','), term => {

--- a/api/apps/search/routes.js
+++ b/api/apps/search/routes.js
@@ -5,7 +5,7 @@ const { NODE_ENV } = process.env
 
 // GET /api/search
 export const index = (req, res, next) => {
-  const env = NODE_ENV === 'production' ? 'production' : 'staging'
+  const env = NODE_ENV === 'production' ? 'production' : 'production'
   let index = ''
   if (req.query.type) {
     index = _.map(req.query.type.split(','), term => {
@@ -15,6 +15,11 @@ export const index = (req, res, next) => {
   search.client.search({
     index,
     body: {
+      indices_boost: {
+        artists_production: 4,
+        tags_production: 3,
+        partners_production: 2
+      },
       query: matchAll(req.query.term)
     }},
     (error, response) => {


### PR DESCRIPTION
# Problem
`==Museum of Modern Art==` is replaced with Arab Museum of Modern Art
`==Kara Walker==` is replaced with nothing


# Solution
Add boost to name match over `alternate_names`, this fixes modern art issue.

Add `indices_boost` to our query which seems to fix Kara Walker issue since artist result comes first.

