### PR TITLE
Server side debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@
 
 BIN = node_modules/.bin
 
+# Start the server with inspect
+dev:
+	DEBUG=app,client,api node --inspect ./index.js
+
 # Start the server
 s:
 	DEBUG=app,client,api node ./index.js

--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ make s
 ```
 - Positron should now be running at [http://localhost:3005/](http://localhost:3005/), open a browser and navigate to it. That will redirect you to staging, login as an Artsy administrator and it will redirect you to `http://localhost:3005` logged into Writer with the default partner gallery channel (David Zwirner).
 
+
+Debugging
+---
+
+### Server side
+Start the server using
+```
+make dev
+```
+This will start the server on port `3005` with `inspect` option.
+
+- In your Chrome go to: [Chrome Inspect](chrome://inspect)
+- Under Remote Target now you should see `./index.js`, click on `inspect` link below it which will open a Chrome developer tools.
+
+Now anywhere in your server side code you can put `debugger` and you should be able to debug.
+
+
 Additional docs
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "make s",
+    "dev": "make dev",
     "test": "make test",
     "assets": "sh scripts/assets.sh",
     "deploy": "sh scripts/deploy.sh"


### PR DESCRIPTION
@orta showed me how we can do server side debugging using chrome developer tools which seemed pretty cool! 

I added a new task `make dev` to enable server side debugging and added some docs about how to use it. We could also make that part of `make s` let me know which one makes more sense.
