### PR TITLE
[GraphQL] Add script to dump schema.

### DIFF
--- a/api/apps/graphql/index.coffee
+++ b/api/apps/graphql/index.coffee
@@ -51,6 +51,8 @@ schema = joiql
       resolve: resolvers.authors
     )
 
+module.exports.schema = schema
+
 app.use '/graphql', setUser, graphqlHTTP(
   schema: schema
   graphiql: true

--- a/scripts/dump-schema.js
+++ b/scripts/dump-schema.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-console */
+
+const env = require('node-env-file')
+env('.env')
+
+require('coffee-script/register')
+
+const fs = require('fs')
+const path = require('path')
+const { schema } = require('../api/apps/graphql')
+const { graphql } = require('graphql')
+const { introspectionQuery, printSchema } = require('graphql/utilities')
+
+const destination = process.argv[2]
+if (destination === undefined || !fs.existsSync(destination)) {
+  console.error('Usage: dump-schema.js /path/to/output/directory')
+  process.exit(1)
+}
+
+// Save JSON of full schema introspection for Babel Relay Plugin to use
+graphql(schema, introspectionQuery).then(
+  result => {
+    fs.writeFileSync(path.join(destination, 'schema.json'), JSON.stringify(result, null, 2))
+  },
+  error => {
+    console.error('ERROR introspecting schema: ', JSON.stringify(error, null, 2))
+  }
+)
+
+// Save user readable type system shorthand of schema
+fs.writeFileSync(path.join(destination, 'schema.graphql'), printSchema(schema))


### PR DESCRIPTION
Using this script you can do `mkdir schema && ./node_modules/.bin/babel-node scripts/dump-schema.js ./schema` and get a result like [this one](https://gist.github.com/alloy/89cc695e4f746bc6f569c92977d9f4a5).

Dunno if you want to merge this at all or if it’s just useful while cleaning up the schema.