### PR TITLE
@kanaabe => Fix Edit rendering error

### DIFF
--- a/client/apps/edit/components/content/index.coffee
+++ b/client/apps/edit/components/content/index.coffee
@@ -28,10 +28,11 @@ module.exports = React.createClass
   render: ->
     div {className: 'edit-section-layout'},
       if @props.article.get('hero_section') != null or @props.channel.hasFeature 'hero'
-        HeroSection {
-          section: @props.article.heroSection
-          channel: @props.channel
-        }
+        unless @props.article.heroSection.get('type') in ['split', 'text']
+          HeroSection {
+            section: @props.article.heroSection
+            channel: @props.channel
+          }
 
       HeaderSection {
         article: @props.article


### PR DESCRIPTION
Pages with the new hero_section types are causing errors in the old edit page.  This PR adds a conditional to exclude 'text' and 'split' layouts from rendering in the old layout.