### PR TITLE
@kanaabe => Add 'fillwidth' layout to ImageCollections

### DIFF
--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -155,7 +155,7 @@ denormalizedArtwork = (->
       isTypeOf: (data) -> data.type is 'image_collection'
     ).keys
       type: 'image_collection'
-      layout: @string().allow('overflow_fillwidth', 'column_width', null)
+      layout: @string().allow('column_width', 'overflow_fillwidth', 'fillwidth', null)
       images: @array().items([denormalizedArtwork, imageSection])
   ]).allow(null)
   postscript: @string().allow('', null)

--- a/client/apps/edit/components/content2/section_container/index.coffee
+++ b/client/apps/edit/components/content2/section_container/index.coffee
@@ -90,7 +90,7 @@ module.exports = React.createClass
           when 'fullscreen' then Fullscreen
           when 'image_set' then ImageCollection
           when 'image_collection' then ImageCollection
-          when 'image' then ImageCollection
+          when 'image' then Image
         )( @sectionProps() )
       div {
         className: 'edit-section__container-bg'

--- a/client/apps/edit/components/content2/section_container/index.coffee
+++ b/client/apps/edit/components/content2/section_container/index.coffee
@@ -90,7 +90,7 @@ module.exports = React.createClass
           when 'fullscreen' then Fullscreen
           when 'image_set' then ImageCollection
           when 'image_collection' then ImageCollection
-          when 'image' then Image
+          when 'image' then ImageCollection
         )( @sectionProps() )
       div {
         className: 'edit-section__container-bg'

--- a/client/apps/edit/components/content2/section_container/index.styl
+++ b/client/apps/edit/components/content2/section_container/index.styl
@@ -77,6 +77,18 @@
       height 30px
       border-radius 50%
 
+[data-layout='fillwidth']
+  &[data-editing='false']
+     .edit-section__hover-controls
+        z-index 100
+  .edit-section__hover-controls
+    button
+      right 18px
+      &.edit-section__remove
+        top 20px
+      &.edit-section__drag
+        top 60px
+
 .classic
   [data-layout='column_width'], [data-layout='blockquote']
     max-width classic-body-w-margin
@@ -104,4 +116,3 @@
     margin 0 auto
   [data-layout='fillwidth']
     max-width 100%
-

--- a/client/apps/edit/components/content2/section_controls/index.coffee
+++ b/client/apps/edit/components/content2/section_controls/index.coffee
@@ -1,6 +1,8 @@
 React = require 'react'
 _ = require 'underscore'
 { header, nav, div, a } = React.DOM
+components = require('@artsy/reaction-force/dist/components/publishing/index').default
+IconImageFullscreen = React.createFactory components.Icon.ImageFullscreen
 
 module.exports = React.createClass
   displayName: 'SectionControls'
@@ -97,7 +99,10 @@ module.exports = React.createClass
           className: 'layout'
           onClick: @changeLayout
           'data-active': @props.section.get('layout') is 'fillwidth'
-        }
+        },
+          React.createElement(
+            IconImageFullscreen, { fill: 'white' }
+          )
       if @props.section.get('type') in ['image_set', 'image_collection'] and
        @props.channel.hasFeature 'image_set'
         a {

--- a/client/apps/edit/components/content2/section_controls/index.coffee
+++ b/client/apps/edit/components/content2/section_controls/index.coffee
@@ -1,8 +1,6 @@
 React = require 'react'
 _ = require 'underscore'
 { header, nav, div, a } = React.DOM
-components = require('@artsy/reaction-force/dist/components/publishing/index').default
-IconImageFullscreen = React.createFactory components.Icon.ImageFullscreen
 
 module.exports = React.createClass
   displayName: 'SectionControls'
@@ -99,10 +97,7 @@ module.exports = React.createClass
           className: 'layout'
           onClick: @changeLayout
           'data-active': @props.section.get('layout') is 'fillwidth'
-        },
-          React.createElement(
-            IconImageFullscreen, { fill: 'white' }
-          )
+        }
       if @props.section.get('type') in ['image_set', 'image_collection'] and
        @props.channel.hasFeature 'image_set'
         a {

--- a/client/apps/edit/components/content2/section_controls/index.jsx
+++ b/client/apps/edit/components/content2/section_controls/index.jsx
@@ -1,0 +1,179 @@
+import React, { Component } from 'react'
+const _ = require('underscore')
+import components from '@artsy/reaction-force/dist/components/publishing/index'
+const IconImageFullscreen = components.Icon.ImageFullscreen
+
+export default class SectionControls extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      insideComponent: false
+    }
+  }
+
+  componentDidMount() {
+    this.setInsideComponent()
+    return window.addEventListener('scroll', this.setInsideComponent)
+  }
+
+  componentWillUnmount() {
+    return window.removeEventListener('scroll', this.setInsideComponent)
+  }
+
+  setInsideComponent = () => {
+    const insideComponent = this.insideComponent()
+    if (insideComponent !== this.state.insideComponent) {
+      return this.setState({ insideComponent })
+    }
+  }
+
+  getHeaderSize() {
+    return  this.props.channel.isEditorial() ? 95 : 55
+  }
+
+  getControlsWidth() {
+    // used for classic layout only
+    const { section } = this.props
+    if (this.props.isHero) {
+      return 1100
+    } else if (section.get('layout').includes('overflow') ||
+     (section.get('type') === 'image_set')) {
+      return 900
+    } else {
+      return 620
+    }
+  }
+
+  getPositionLeft() {
+    if (this.state.insideComponent) {
+      return ((window.innerWidth / 2) - (this.getControlsWidth() / 2)) + 55
+    } else {
+      if (this.props.articleLayout === 'classic') {
+        return '20px'
+      } else {
+        return 0
+      }
+    }
+  }
+
+  getPositionBottom() {
+    if (this.state.insideComponent) {
+      return window.innerHeight - $(this.refs.controls).height() - this.getHeaderSize()
+    } else {
+      return '100%'
+    }
+  }
+
+  isScrollingOver($section) {
+    const scrollPlusHeader = window.scrollY + this.getHeaderSize()
+    const offsetMinusControls = $section.offset().top - $(this.refs.controls).height()
+    return scrollPlusHeader > offsetMinusControls
+  }
+
+  isScrolledPast($section) {
+    const scrollPlusControls = window.scrollY + $(this.refs.controls).height()
+    const scrollPlusSection = $section.offset().top + $section.height()
+    return scrollPlusControls > scrollPlusSection
+  }
+
+  insideComponent = () => {
+    const $section = $(this.refs.controls) ? $(this.refs.controls).closest('section') : false
+    let insideComponent = false
+    if ($section) {
+      if ((this.isScrollingOver($section) && !this.isScrolledPast($section)) ||
+       (this.props.isHero && !this.isScrolledPast($section))) {
+        insideComponent = true
+      }
+    }
+    return insideComponent
+  }
+
+  changeLayout(layout) {
+    if (this.props.section.get('type') === 'image_set') {
+      this.props.section.set('type', 'image_collection')
+      this.forceUpdate()
+    }
+    this.props.section.set({ layout })
+    if (this.props.onChange) {
+      return this.props.onChange()
+    }
+  }
+
+  toggleImageSet = () => {
+    if (this.props.section.get('type') === 'image_collection') {
+      this.props.section.unset('layout')
+      this.props.section.set('type', 'image_set')
+      this.forceUpdate()
+    }
+    if (this.props.onChange) {
+      return this.props.onChange()
+    }
+  }
+
+  hasImageSet() {
+    const sectionisImage = ['image_set', 'image_collection'].includes(
+      this.props.section.get('type')
+    )
+    return this.props.channel.hasFeature('image_set') && sectionisImage
+  }
+
+  renderSectionLayouts(sectionLayouts, section) {
+    if (sectionLayouts) {
+      return (
+        <nav className='edit-controls__layout'>
+          <a
+            name='overflow_fillwidth'
+            className='layout'
+            onClick={() => this.changeLayout('overflow_fillwidth')}
+            data-active={section.get('layout') === 'overflow_fillwidth'} />
+          <a
+            name='column_width'
+            className='layout'
+            onClick={() => this.changeLayout('column_width')}
+            data-active={section.get('layout') === 'column_width'} />
+          {
+            this.props.articleLayout === 'feature' &&
+            <a
+              name='fillwidth'
+              className='layout'
+              onClick={() => this.changeLayout('fillwidth')}
+              data-active={section.get('layout') === 'fillwidth'}>
+              <IconImageFullscreen fill={'white'} />
+            </a>
+          }
+          { this.hasImageSet() &&
+            <a
+              name='image_set'
+              className='layout'
+              onClick={this.toggleImageSet}
+              data-active={section.get('type') === 'image_set'} />
+          }
+        </nav>
+      )
+    }
+  }
+
+  render() {
+    const { articleLayout, section, sectionLayouts } = this.props
+    const { insideComponent } = this.state
+    const isSticky = insideComponent ? ' sticky' : ''
+
+    return (
+      <div
+        ref='controls'
+        className={'edit-controls' + isSticky}
+        style={{
+          color: 'white',
+          position: insideComponent ? 'fixed' : 'absolute',
+          bottom: this.getPositionBottom(),
+          left: articleLayout === 'classic' ? this.getPositionLeft() : ''
+      }}>
+        {this.renderSectionLayouts(sectionLayouts, section)}
+        <div className='edit-controls__inputs'>
+          {this.props.children}
+        </div>
+      </div>
+    )
+  }
+}

--- a/client/apps/edit/components/content2/section_controls/index.jsx
+++ b/client/apps/edit/components/content2/section_controls/index.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-const _ = require('underscore')
 import components from '@artsy/reaction-force/dist/components/publishing/index'
 const IconImageFullscreen = components.Icon.ImageFullscreen
 
@@ -34,7 +33,8 @@ export default class SectionControls extends Component {
   getControlsWidth() {
     // used for classic layout only
     const { section } = this.props
-    const isOverflow = section.get('layout').includes('overflow') ||
+    const isOverflow = section.get('layout') &&
+     section.get('layout').includes('overflow') ||
      section.get('type') === 'image_set'
 
     if (this.props.isHero) {
@@ -74,7 +74,7 @@ export default class SectionControls extends Component {
 
   insideComponent = () => {
     let insideComponent = false
-    const $section = $(this.refs.controls) ? $(this.refs.controls).closest('section') : false
+    const $section = $(this.refs.controls) && $(this.refs.controls).closest('section')
 
     if ($section) {
       if ((this.isScrollingOver($section) && !this.isScrolledPast($section)) ||
@@ -89,6 +89,9 @@ export default class SectionControls extends Component {
     if (this.props.section.get('type') === 'image_set') {
       this.props.section.set('type', 'image_collection')
       this.forceUpdate()
+    }
+    if (layout === 'fillwidth' && this.props.section.get('images').length > 1) {
+      return this.props.disabledAlert()
     }
     this.props.section.set({ layout })
     this.props.onChange && this.props.onChange()

--- a/client/apps/edit/components/content2/section_controls/index.styl
+++ b/client/apps/edit/components/content2/section_controls/index.styl
@@ -66,6 +66,8 @@
 .feature .edit-section__container
   &[data-layout=column_width] .edit-controls
     max-width feature-body-w-margin
+  &[data-layout=fillwidth] .edit-controls
+    margin-left 0
   &[data-layout=overflow_fillwidth],
   &[data-type=image_set]
     .edit-controls

--- a/client/apps/edit/components/content2/section_controls/index.styl
+++ b/client/apps/edit/components/content2/section_controls/index.styl
@@ -4,6 +4,7 @@
   height auto
   top inherit
   width 100%
+  max-width calc(100vw \- 110px)
   margin-left -20px
   &__layout
     width 100%

--- a/client/apps/edit/components/content2/section_controls/index.styl
+++ b/client/apps/edit/components/content2/section_controls/index.styl
@@ -33,6 +33,9 @@
       opacity 1
   &[data-active=true]
     opacity 1
+  &[name=fillwidth]
+    svg
+      margin-bottom 9px
   &[name=overflow_fillwidth]
     background-image url(/icons/edit_artworks_overflow_fillwidth.svg)
     background-size 38px

--- a/client/apps/edit/components/content2/section_controls/test/index.test.coffee
+++ b/client/apps/edit/components/content2/section_controls/test/index.test.coffee
@@ -11,7 +11,7 @@ r =
   simulate: ReactTestUtils.Simulate
   render: ReactTestUtils.renderIntoDocument
 
-describe 'SectionControls', ->
+describe.skip 'SectionControls', ->
 
   beforeEach (done) ->
     benv.setup =>

--- a/client/apps/edit/components/content2/section_controls/test/index.test.js
+++ b/client/apps/edit/components/content2/section_controls/test/index.test.js
@@ -21,7 +21,8 @@ describe('Section Controls', () => {
     channel: new Channel(),
     section: new Section(StandardArticle.sections[4]),
     articleLayout: 'standard',
-    onChange: sinon.stub()
+    onChange: sinon.stub(),
+    disabledAlert: sinon.stub()
   }
 
   describe('Section Layouts', () => {
@@ -92,6 +93,15 @@ describe('Section Controls', () => {
         <SectionControls {...props} />
       )
       component.find('.layout').at(1).simulate('click')
+      expect(component.instance().props.section.get('layout')).toMatch('column_width')
+    })
+
+    it('when toggling fullscreen, alerts the user if too many images', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.find('.layout').at(2).simulate('click')
+      expect(props.disabledAlert.called).toBe(true)
       expect(component.instance().props.section.get('layout')).toMatch('column_width')
     })
 

--- a/client/apps/edit/components/content2/section_controls/test/index.test.js
+++ b/client/apps/edit/components/content2/section_controls/test/index.test.js
@@ -1,0 +1,273 @@
+import React from 'react'
+import sinon from 'sinon'
+import { mount } from 'enzyme'
+import Channel from '/client/models/channel.coffee'
+import Section from '/client/models/section.coffee'
+import SectionControls from '../index.jsx'
+import components from '@artsy/reaction-force/dist/components/publishing/index'
+const StandardArticle = components.Fixtures.StandardArticle
+
+describe('Section Controls', () => {
+
+  beforeAll(() => {
+    SectionControls.prototype.isScrollingOver = sinon.stub().returns(true)
+    SectionControls.prototype.isScrolledPast = sinon.stub().returns(false)
+    $.fn.offset = sinon.stub().returns({top: 200})
+    $.fn.height = sinon.stub().returns(200)
+    $.fn.closest = sinon.stub().returns(true)
+  })
+
+  const props = {
+    channel: new Channel(),
+    section: new Section(StandardArticle.sections[4]),
+    articleLayout: 'standard',
+    onChange: sinon.stub()
+  }
+
+  describe('Section Layouts', () => {
+
+    it('does not render section layouts unless sectionLayouts', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      expect(component.find('.layout').length).toBe(0)
+    })
+
+    it('renders section layouts if sectionLayouts is true', () => {
+      props.sectionLayouts = true
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      expect(component.html()).toMatch(
+        '<a name="overflow_fillwidth" class="layout" data-active="true">'
+      )
+    })
+
+    it('adds a data-active attr to the current section layout icon', () => {
+      props.sectionLayouts = true
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      expect(component.find('.layout').length).toBe(2)
+    })
+
+    it('does not render image_set icon if channel.hasFeature is false', () => {
+      Channel.prototype.hasFeature = sinon.stub().returns(false)
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      expect(component.html()).not.toMatch('<a name="image_set"')
+    })
+
+    it('renders image_set icon if channel.hasFeature and section is images', () => {
+      Channel.prototype.hasFeature = sinon.stub().returns(true)
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      expect(component.html()).toMatch('<a name="image_set"')
+    })
+
+    it('does not render image_set icon if section is not images', () => {
+      props.section = new Section(StandardArticle.sections[0])
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      expect(component.html()).not.toMatch('<a name="image_set"')
+    })
+
+    it('shows the fullscreen icon if articleLayout is feature', () => {
+      props.section = new Section(StandardArticle.sections[4])
+      props.articleLayout = 'feature'
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      expect(component.html()).toMatch('<a name="fillwidth')
+    })
+  })
+
+  describe('#changeLayout', () => {
+
+    it('changes the layout on click', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.find('.layout').at(1).simulate('click')
+      expect(component.instance().props.section.get('layout')).toMatch('column_width')
+    })
+
+    it('can convert an image_set into an image_collection', () => {
+      props.section.set({ type: 'image_set', layout: 'null' })
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.find('.layout').at(1).simulate('click')
+      expect(component.instance().props.section.get('layout')).toMatch('column_width')
+      expect(component.instance().props.section.get('type')).toMatch('image_collection')
+    })
+  })
+
+  describe('#toggleImageSet', () => {
+
+    it('converts an image_collection to an image_set', () => {
+      props.section = new Section(StandardArticle.sections[4])
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.find('.layout').at(3).simulate('click')
+      expect(component.instance().props.section.get('type')).toMatch('image_set')
+    })
+
+    it('does nothing if section is already an image_set', () => {
+      props.section.set({ type: 'image_set', layout: 'null' })
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.find('.layout').at(3).simulate('click')
+      expect(component.instance().props.section.get('type')).toMatch('image_set')
+    })
+  })
+
+  describe('#setInsideComponent', () => {
+
+    it('returns true if item is scrolled over and not scrolled past', () => {
+      props.section = new Section(StandardArticle.sections[4])
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.instance().setInsideComponent()
+      expect(component.state().insideComponent).toBe(true)
+    })
+
+    it('returns false if item is scrolled past', () => {
+      SectionControls.prototype.isScrolledPast = sinon.stub().returns(true)
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.instance().setInsideComponent()
+      expect(component.state().insideComponent).toBe(false)
+    })
+
+    it('returns true when hero section and not scrolled past', () => {
+      SectionControls.prototype.isScrolledPast = sinon.stub().returns(false)
+      props.isHero = true
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.instance().setInsideComponent()
+      expect(component.state().insideComponent).toBe(true)
+    })
+
+  })
+
+  describe('#getControlsWidth', () => {
+
+    it('returns 1100 if hero section', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      const width = component.instance().getControlsWidth()
+      expect(width).toBe(1100)
+    })
+
+    it('returns 900 if image_set', () => {
+      props.isHero = false
+      props.section.set('type', 'image_set')
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      const width = component.instance().getControlsWidth()
+      expect(width).toBe(900)
+    })
+
+    it('returns 900 for overflow_fillwidth sections', () => {
+      props.section.set({layout: 'overflow_fillwidth', type: 'image_collection'})
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      const width = component.instance().getControlsWidth()
+      expect(width).toBe(900)
+    })
+
+    it('returns 620 for column_width sections', () => {
+      props.section.set('layout', 'column_width')
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      const width = component.instance().getControlsWidth()
+      expect(width).toBe(620)
+    })
+  })
+
+  describe('#getHeaderSize', () => {
+
+    it('returns 55 when channel is not editorial', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      const header = component.instance().getHeaderSize()
+      expect(header).toBe(55)
+    })
+
+    it('returns 95 when channel is editorial', () => {
+      Channel.prototype.isEditorial = sinon.stub().returns(true)
+      Channel.prototype.hasFeature = sinon.stub().returns(true)
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      const header = component.instance().getHeaderSize()
+      expect(header).toBe(95)
+    })
+  })
+
+  describe('#getPositionBottom', () => {
+
+    it('when insideComponent, calculates based on window scroll position', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.instance().setState({insideComponent: true})
+      const bottom = component.instance().getPositionBottom()
+      expect(bottom).toBe(605)
+    })
+
+    it('when outside component, returns 100%', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.instance().setState({insideComponent: false})
+      const bottom = component.instance().getPositionBottom()
+      expect(bottom).toBe('100%')
+    })
+  })
+
+  describe('#getPositionLeft', () => {
+
+    it('when insideComponent, calculates width based on window', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.instance().setState({insideComponent: true})
+      const left = component.instance().getPositionLeft()
+      expect(left).toBe(445)
+    })
+
+    it('returns 0 if outside component and standard/feature layout', () => {
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.instance().setState({insideComponent: false})
+      const left = component.instance().getPositionLeft()
+      expect(left).toBe(0)
+    })
+
+    it('returns 20px if outside component and classic layout', () => {
+      props.articleLayout = 'classic'
+      const component = mount(
+        <SectionControls {...props} />
+      )
+      component.instance().setState({insideComponent: false})
+      const left = component.instance().getPositionLeft()
+      expect(left).toBe('20px')
+    })
+  })
+})

--- a/client/apps/edit/components/content2/sections/image_collection/components/artwork.jsx
+++ b/client/apps/edit/components/content2/sections/image_collection/components/artwork.jsx
@@ -21,7 +21,8 @@ export default class ImageCollectionArtwork extends Component {
   }
 
   getContainerWidth(dimensions) {
-    if (dimensions && dimensions[this.props.index]) {
+    if (dimensions && dimensions[this.props.index] &&
+      this.props.section.get('layout') !== 'fillwidth') {
       return dimensions[this.props.index].width
     } else {
       return 'auto'
@@ -29,13 +30,13 @@ export default class ImageCollectionArtwork extends Component {
   }
 
   render() {
-    const { artwork, article, dimensions } = this.props
+    const { artwork, article, dimensions, imagesLoaded } = this.props
     return (
       <div
         className='image-collection__img-container'
         style={{
           width: this.getContainerWidth(dimensions),
-          opacity: this.props.imagesLoaded ? 1 : 0
+          opacity: imagesLoaded ? 1 : 0
         }} >
         <Artwork
           layout={article.get('layout')}

--- a/client/apps/edit/components/content2/sections/image_collection/components/controls.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/components/controls.coffee
@@ -66,7 +66,14 @@ module.exports = React.createClass
     }]
     @props.section.set images: newImages
 
+  inputsAreDisabled: ->
+    return @props.section.get('layout') is 'fillwidth' and @props.section.get('images').length > 0
+
+  fillwidthAlert: ->
+    return alert('Fullscreen layouts accept one asset, please remove extra images.')
+
   render: ->
+    inputsAreDisabled = @inputsAreDisabled()
     React.createElement(
       SectionControls.default, {
         section: @props.section
@@ -74,20 +81,30 @@ module.exports = React.createClass
         articleLayout: @props.article.get('layout')
         onChange: @props.onChange
         sectionLayouts: true
+        disabledAlert: @fillwidthAlert
       },
-        React.createElement(
-          FileInput.default,
-          { onUpload: @onUpload, onProgress: @props.setProgress }
-        )
-        section { className: 'edit-controls__artwork-inputs' },
+        div { onClick: @fillwidthAlert if inputsAreDisabled },
+          React.createElement(
+            FileInput.default, {
+              onUpload: @onUpload
+              onProgress: @props.setProgress
+              disabled: inputsAreDisabled
+            }
+          )
+        section {
+          className: 'edit-controls__artwork-inputs'
+          onClick: @fillwidthAlert if inputsAreDisabled
+        },
           div { className: 'edit-controls__autocomplete-input' },
             input {
               ref: 'autocomplete'
               className: 'bordered-input bordered-input-dark'
               placeholder: 'Search for artwork by title'
+              disabled: inputsAreDisabled
             }
           UrlArtworkInput {
             images: @props.images
             addArtworkFromUrl: @addArtworkFromUrl
+            disabled: inputsAreDisabled
           }
     )

--- a/client/apps/edit/components/content2/sections/image_collection/components/controls.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/components/controls.coffee
@@ -2,7 +2,7 @@ React = require 'react'
 _ = require 'underscore'
 sd = require('sharify').data
 gemup = require 'gemup'
-SectionControls = React.createFactory require '../../../section_controls/index.coffee'
+SectionControls = require '../../../section_controls/index.jsx'
 UrlArtworkInput = React.createFactory require './url_artwork_input.coffee'
 Autocomplete = require '../../../../../../../components/autocomplete/index.coffee'
 Artwork = require '../../../../../../../models/artwork.coffee'
@@ -67,25 +67,27 @@ module.exports = React.createClass
     @props.section.set images: newImages
 
   render: ->
-    SectionControls {
-      section: @props.section
-      channel: @props.channel
-      articleLayout: @props.article.get('layout')
-      onChange: @props.onChange
-      sectionLayouts: true
-    },
-      React.createElement(
-        FileInput.default,
-        { onUpload: @onUpload, onProgress: @props.setProgress }
-      )
-      section { className: 'edit-controls__artwork-inputs' },
-        div { className: 'edit-controls__autocomplete-input' },
-          input {
-            ref: 'autocomplete'
-            className: 'bordered-input bordered-input-dark'
-            placeholder: 'Search for artwork by title'
+    React.createElement(
+      SectionControls.default, {
+        section: @props.section
+        channel: @props.channel
+        articleLayout: @props.article.get('layout')
+        onChange: @props.onChange
+        sectionLayouts: true
+      },
+        React.createElement(
+          FileInput.default,
+          { onUpload: @onUpload, onProgress: @props.setProgress }
+        )
+        section { className: 'edit-controls__artwork-inputs' },
+          div { className: 'edit-controls__autocomplete-input' },
+            input {
+              ref: 'autocomplete'
+              className: 'bordered-input bordered-input-dark'
+              placeholder: 'Search for artwork by title'
+            }
+          UrlArtworkInput {
+            images: @props.images
+            addArtworkFromUrl: @addArtworkFromUrl
           }
-        UrlArtworkInput {
-          images: @props.images
-          addArtworkFromUrl: @addArtworkFromUrl
-        }
+    )

--- a/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
+++ b/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
@@ -40,7 +40,8 @@ export default class ImageCollectionImage extends Component {
   }
 
   getContainerWidth(dimensions) {
-    if (dimensions && dimensions[this.props.index]) {
+    if (dimensions && dimensions[this.props.index] &&
+      this.props.section.get('layout') !== 'fillwidth') {
       return dimensions[this.props.index].width
     } else {
       return 'auto'
@@ -56,7 +57,7 @@ export default class ImageCollectionImage extends Component {
           width: this.getContainerWidth(dimensions),
           opacity: imagesLoaded ? 1 : 0
         }} >
-        <Image image={image}>
+        <Image image={image} layout={this.props.article.get('layout')}>
           {this.renderCaption(image)}
         </Image>
         {this.renderRemoveButton(image)}

--- a/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
+++ b/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
@@ -57,7 +57,7 @@ export default class ImageCollectionImage extends Component {
           width: this.getContainerWidth(dimensions),
           opacity: imagesLoaded ? 1 : 0
         }} >
-        <Image image={image} layout={this.props.article.get('layout')}>
+        <Image image={image}>
           {this.renderCaption(image)}
         </Image>
         {this.renderRemoveButton(image)}

--- a/client/apps/edit/components/content2/sections/image_collection/components/url_artwork_input.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/components/url_artwork_input.coffee
@@ -48,6 +48,7 @@ module.exports = React.createClass
         placeholder: 'Add artwork url'
         value: @state.url
         onChange: @onChange
+        disabled: @props.disabled
       }
       button {
         className: 'avant-garde-button' + isLoading

--- a/client/apps/edit/components/content2/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/index.coffee
@@ -94,6 +94,7 @@ module.exports = React.createClass
             imagesLoaded: @state.imagesLoaded
             dimensions: @state.dimensions
             article: @props.article
+            section: @props.section
           }
         )
       else

--- a/client/apps/edit/components/content2/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/index.coffee
@@ -81,6 +81,37 @@ module.exports = React.createClass
         imagesetClass = ' imageset-block imageset-block--long'
     imagesetClass
 
+  renderImages: (images) ->
+    images.map (item, i) =>
+      if item.type is 'artwork'
+        React.createElement(
+          Artwork.default, {
+            key: i
+            index: i
+            artwork: item
+            removeItem: @removeItem
+            editing:  @props.editing
+            imagesLoaded: @state.imagesLoaded
+            dimensions: @state.dimensions
+            article: @props.article
+          }
+        )
+      else
+        React.createElement(
+          Image.default, {
+            index: i
+            key: i
+            image: item
+            removeItem: @removeItem
+            editing:  @props.editing
+            dimensions: @state.dimensions
+            imagesLoaded: @state.imagesLoaded
+            article: @props.article
+            section: @props.section
+            onChange: @onChange
+          }
+        )
+
   render: ->
     images = @props.section.get 'images' or []
     hasImages = images.length > 0
@@ -125,40 +156,16 @@ module.exports = React.createClass
                   images: images
                   layout: @props.section.get('layout')
               }
-          else
+          else if images.length > 1
             DragContainer {
               items: images
               onDragEnd: @onDragEnd
               isDraggable: @props.editing
               dimensions: @state.dimensions
             },
-              images.map (item, i) =>
-                if item.type is 'artwork'
-                  React.createElement(
-                    Artwork.default, {
-                      key: i
-                      index: i
-                      artwork: item
-                      removeItem: @removeItem
-                      editing:  @props.editing
-                      imagesLoaded: @state.imagesLoaded
-                      dimensions: @state.dimensions
-                      article: @props.article
-                    }
-                  )
-                else
-                  React.createElement(
-                    Image.default, {
-                      index: i
-                      key: i
-                      image: item
-                      removeItem: @removeItem
-                      editing:  @props.editing
-                      dimensions: @state.dimensions
-                      imagesLoaded: @state.imagesLoaded
-                      article: @props.article
-                      onChange: @onChange
-                    }
-                  )
+              @renderImages(images)
+          else
+            @renderImages(images)
+
         else
           div { className: 'edit-section__placeholder' }, 'Add images and artworks above'

--- a/client/apps/edit/components/content2/sections/image_collection/index.styl
+++ b/client/apps/edit/components/content2/sections/image_collection/index.styl
@@ -111,6 +111,12 @@
     max-width feature-overflow-w-margin
   .edit-section__container[data-type=image_collection][data-layout=fillwidth]
     padding 0 0 20px 0
+    .drag-container
+      flex-direction column
+      .drag-target
+        min-width 100%
+    .image-collection__img-container
+      width 100%
     .edit-section--image-collection .edit-section__remove
       top 20px
       right 20px

--- a/client/apps/edit/components/content2/sections/image_collection/index.styl
+++ b/client/apps/edit/components/content2/sections/image_collection/index.styl
@@ -111,6 +111,13 @@
     max-width feature-overflow-w-margin
   .edit-section__container[data-type=image_collection][data-layout=fillwidth]
     padding 0 0 20px 0
+    .edit-section--image-collection .edit-section__remove
+      top 20px
+      right 20px
+      circle
+        fill gray-color
+      &:hover circle
+        fill red-color
 
 .classic
   .edit-section__container[data-type=image_set][data-editing=true]

--- a/client/apps/edit/components/content2/sections/image_collection/index.styl
+++ b/client/apps/edit/components/content2/sections/image_collection/index.styl
@@ -109,6 +109,8 @@
 .feature
   .edit-section__container[data-type=image_set][data-editing=true]
     max-width feature-overflow-w-margin
+  .edit-section__container[data-type=image_collection][data-layout=fillwidth]
+    padding 0 0 20px 0
 
 .classic
   .edit-section__container[data-type=image_set][data-editing=true]

--- a/client/apps/edit/components/content2/sections/image_collection/test/artwork.test.js
+++ b/client/apps/edit/components/content2/sections/image_collection/test/artwork.test.js
@@ -19,6 +19,7 @@ describe('Artwork', () => {
       width: 2002
     },
     article: new Backbone.Model({layout: 'standard'}),
+    section: new Backbone.Model({layout: 'overflow_fillwidth'}),
     index: 0,
     imagesLoaded: true,
     dimensions: [{width: 200}],

--- a/client/apps/edit/components/content2/sections/image_collection/test/controls.test.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/test/controls.test.coffee
@@ -30,6 +30,13 @@ describe 'ImageCollectionControls', ->
           initialize: ->
           ttAdapter: ->
         )
+      window.matchMedia = sinon.stub().returns(
+        {
+          matches: false
+          addListener: sinon.stub()
+          removeListener: sinon.stub()
+        }
+      )
       $.fn.typeahead = sinon.stub()
       $.fn.offset = sinon.stub().returns(top: 200)
       Backbone.$ = $
@@ -56,6 +63,7 @@ describe 'ImageCollectionControls', ->
         channel: { hasFeature: @hasFeature = sinon.stub().returns(true), isEditorial: sinon.stub().returns(true)}
       }
       @component = ReactDOM.render React.createElement(@Controls, @props), (@$el = $ "<div></div>")[0], =>
+      @component.fillwidthAlert = sinon.stub()
       done()
 
   afterEach ->
@@ -125,3 +133,11 @@ describe 'ImageCollectionControls', ->
     @component.addArtworkFromUrl([{type:'image', url:'image.com'}, {type: 'artwork', image:'artwork.jpg'}])
     @component.props.section.get('images')[0].should.eql {type:'image', url: 'image.com'}
     @component.props.section.get('images')[1].should.eql {type: 'artwork', image:'artwork.jpg'}
+
+  it 'disables inputs and gives an alert on click if fillwidth layout and has image', ->
+    @component.props.section.set 'layout', 'fillwidth'
+    @component.onUpload 'http://image.jpg', 400, 800
+    @component.forceUpdate()
+    r.simulate.click r.find(@component, 'edit-controls__artwork-inputs')[0]
+    @component.fillwidthAlert.called.should.eql true
+

--- a/client/apps/edit/components/content2/sections/image_collection/test/image.test.js
+++ b/client/apps/edit/components/content2/sections/image_collection/test/image.test.js
@@ -14,6 +14,7 @@ describe('Image', () => {
       width: 1200
     },
     article: new Backbone.Model({layout: 'standard'}),
+    section: new Backbone.Model({layout: 'overflow_fillwidth'}),
     index: 0,
     imagesLoaded: true,
     dimensions: [{width: 200}],

--- a/client/components/file_input/index.jsx
+++ b/client/components/file_input/index.jsx
@@ -74,15 +74,19 @@ export default class FileInput extends Component {
   }
 
   render() {
-    const { label, hasImage, sizeLimit, type } = this.props
+    const { label, hasImage, sizeLimit, type, disabled } = this.props
     const typeClass = type ? ' ' + type : ''
+    const disabledClass = disabled ? ' disabled' : ''
     return (
-      <div className={'file-input' + typeClass}>
+      <div className={'file-input' + typeClass + disabledClass}>
         {label && <h2>{label}</h2>}
         <div className='file-input__upload-container'>
           {this.renderUploadPrompt()}
           <h2>Up to {sizeLimit ? sizeLimit.toString() : '30'}MB</h2>
-          <input type='file' onChange={this.uploadFile} accept={this.getAccepted()} />
+          <input
+            type='file'
+            onChange={this.uploadFile}
+            accept={this.getAccepted()} />
         </div>
       </div>
     )

--- a/client/components/file_input/index.styl
+++ b/client/components/file_input/index.styl
@@ -45,5 +45,15 @@
     border none
     background gray-color
 
+.file-input.disabled
+  cursor not-allowed
+  input
+    z-index -1
+  .file-input__upload-container
+    &:hover, &.is-dragover
+      border-color gray-darker-color
+      span
+        color white
+
 .edit-controls__inputs .file-input__upload-container h2
   margin 0

--- a/client/components/file_input/test/index.test.js
+++ b/client/components/file_input/test/index.test.js
@@ -1,7 +1,7 @@
-import FileInput from '../index.jsx';
-import gemup from 'gemup';
-import React from 'react';
-import { mount } from 'enzyme';
+import FileInput from '../index.jsx'
+import gemup from 'gemup'
+import React from 'react'
+import { mount } from 'enzyme'
 
 jest.mock('gemup', () => {
   return jest.fn()
@@ -9,65 +9,69 @@ jest.mock('gemup', () => {
 
 describe('FileInput', () => {
   beforeAll(() => {
-    global.window.$ = jest.fn()
     global.window.$.ajax = jest.fn()
     global.alert = jest.fn()
   })
 
   it('renders drag-drop container', () => {
-    const wrapper = mount(
+    const component = mount(
       <FileInput />
-    );
-    const container = wrapper.find('.file-input')
-    expect(container.text()).toMatch('Drag & Drop or Click to Upload')
+    )
+    expect(component.find('.file-input').text()).toMatch('Drag & Drop or Click to Upload')
   })
 
   it('renders the default size limit', () => {
-    const wrapper = mount(
+    const component = mount(
       <FileInput />
-    );
-    const container = wrapper.find('.file-input')
-    expect(container.text()).toMatch('Up to 30MB')
+    )
+    expect(component.find('.file-input').text()).toMatch('Up to 30MB')
   })
 
   it('renders props.sizeLimit', () => {
-    const wrapper = mount(
+    const component = mount(
       <FileInput sizeLimit={10} />
-    );
-    const container = wrapper.find('.file-input')
-    expect(container.text()).toMatch('Up to 10MB')
+    )
+    expect(component.find('.file-input').text()).toMatch('Up to 10MB')
   })
 
   it('prompts to replace file if hasImage', () => {
-    const wrapper = mount(
+    const component = mount(
       <FileInput hasImage />
-    );
-    const container = wrapper.find('.file-input')
-    expect(container.text()).toMatch('Drag & Drop or Click to Replace')
+    )
+    expect(component.find('.file-input').text()).toMatch('Drag & Drop or Click to Replace')
   })
 
   it('accepts image files by default', () => {
-    const wrapper = mount(
+    const component = mount(
       <FileInput />
-    );
-    const container = wrapper.find('.file-input')
-    expect(container.html()).toMatch('<input type="file" accept=".jpg,.jpeg,.png,.gif">')
+    )
+    expect(component.find('.file-input').html()).toMatch(
+      '<input type="file" accept=".jpg,.jpeg,.png,.gif">'
+    )
   })
 
   it('accepts video files when video prop is passed', () => {
-    const wrapper = mount(
+    const component = mount(
       <FileInput video />
-    );
-    const container = wrapper.find('.file-input')
-    expect(container.html()).toMatch('<input type="file" accept=".jpg,.jpeg,.png,.gif,.mp4">')
+    )
+    expect(component.find('.file-input').html()).toMatch(
+      '<input type="file" accept=".jpg,.jpeg,.png,.gif,.mp4">'
+    )
+  })
+
+  it('disables the input when disabled prop is passed', () => {
+    const component = mount(
+      <FileInput disabled />
+    )
+    expect(component.html()).toMatch('<div class="file-input disabled">')
   })
 
   it('calls upload when a file is selected', () => {
-    const wrapper = mount(
+    const component = mount(
       <FileInput />
-    );
+    )
     const file = new Blob([], {type: 'img/jpg'})
-    wrapper.find('input').simulate('change', {target: {files: [file]}})
+    component.find('input').simulate('change', {target: {files: [file]}})
     expect(gemup).toHaveBeenCalled()
   })
 })

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.0.2",
-    "@artsy/reaction-force": "^0.5.4",
+    "@artsy/reaction-force": "^0.5.5",
     "airtable": "^0.4.5",
     "artsy-backbone-mixins": "git://github.com/artsy/artsy-backbone-mixins.git",
     "artsy-ezel-components": "git://github.com/artsy/artsy-ezel-components.git",

--- a/test/jest-setup.js
+++ b/test/jest-setup.js
@@ -1,3 +1,9 @@
+import $ from 'jquery'
+global.$ = global.jQuery = $
+
+window.innerHeight = 900
+window.innerWidth = 1400
+
 window.matchMedia = window.matchMedia || function() {
   return {
     matches : false,
@@ -5,3 +11,4 @@ window.matchMedia = window.matchMedia || function() {
     removeListener: function() {}
   }
 }
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@^0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.5.4.tgz#d4c2a7d8867f043f8d10698c25f9eb947ec57188"
+"@artsy/reaction-force@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.5.5.tgz#6b967a5020aec4d3ce94d9bdbf03431cd5dfa19c"
   dependencies:
     "@storybook/addon-options" "^3.2.1"
     "@storybook/react" "^3.2.0"


### PR DESCRIPTION
In order to simplify click-events when changing layouts, I've converted the SectionControls to es6. Now the click events pass the layout directly as an arg rather than looking for e.target.name. Using a mix of svg's and background-images made our layout's name attribute complicated to pinpoint. 

For the SectionControls tests I went ahead and used sinon rather than jest.mock() -- this sped up the process of converting existing tests quite a bit!

Image-related:
- Adds fillwidth layout to Image Section schema
- Adds fillwidth icon to Section Controls component
- Adds styling for fillwidth Image sections
- Disables image inputs and adds click alerts if fillwidth sections have images
- Displays an alert if user tries to change layout to fillwidth and section has images
- Does not render drag-drop component if image section has only 1 image

Also:
- Adds an optional 'disabled' prop to the fileInput component
- Adds jQuery and default window size as jest globals
- Updates Reaction to 0.5.5