### PR TITLE
@craigspaeth => Add relatedArticles resolvers

### DIFF
--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -32,6 +32,7 @@ cloneDeep = require 'lodash.clonedeep'
     .skip(offset or 0)
     .sort(sort)
     .limit(limit)
+  console.log(query)
   async.parallel [
     (cb) -> cursor.toArray cb
     (cb) ->

--- a/api/apps/articles/model/index.coffee
+++ b/api/apps/articles/model/index.coffee
@@ -32,7 +32,7 @@ cloneDeep = require 'lodash.clonedeep'
     .skip(offset or 0)
     .sort(sort)
     .limit(limit)
-  console.log(query)
+
   async.parallel [
     (cb) -> cursor.toArray cb
     (cb) ->

--- a/api/apps/articles/model/retrieve.coffee
+++ b/api/apps/articles/model/retrieve.coffee
@@ -84,7 +84,7 @@ moment = require 'moment'
     query.fair_ids = { $elemMatch: { $in: input.fair_ids } }
 
   # Convert query for articles by vertical
-  query.vertical = { $elemMatch: { id: input.vertical } } if input.vertical
+  query["vertical.id"] = input.vertical if input.vertical
 
   # Allow regex searching through the q param
   query.thumbnail_title = { $regex: new RegExp(input.q, 'i') } if input.q and input.q.length

--- a/api/apps/articles/test/model/retrieve.test.coffee
+++ b/api/apps/articles/test/model/retrieve.test.coffee
@@ -40,8 +40,7 @@ describe 'Retrieve', ->
         vertical: '55356a9deca560a0137bb4a7'
         published: true
       }
-      query.vertical['$elemMatch'].should.be.ok()
-      query.vertical['$elemMatch'].id.should.containEql ObjectId '55356a9deca560a0137bb4a7'
+      query['vertical.id'].should.containEql(ObjectId '55356a9deca560a0137bb4a7')
 
     it 'aggregates the query for artist_id', ->
       { query } = Retrieve.toQuery {

--- a/api/apps/graphql/index.js
+++ b/api/apps/graphql/index.js
@@ -13,10 +13,13 @@ import * as resolvers from 'api/apps/graphql/resolvers.js'
 const app = module.exports = express()
 
 const relatedArticles = {
-  relatedArticles: array().items(object(Article.inputSchema)).meta({
-    name: 'RelatedArticles',
-    args: Article.querySchema,
-    resolve: resolvers.articles
+  relatedArticlesCanvas: array().items(object(Article.inputSchema)).meta({
+    name: 'RelatedArticlesCanvas',
+    resolve: resolvers.relatedArticlesCanvas
+  }),
+  relatedArticlesPanel: array().items(object(Article.inputSchema)).meta({
+    name: 'RelatedArticlesPanel',
+    resolve: resolvers.relatedArticlesPanel
   })
 }
 

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -1,9 +1,11 @@
+import _ from 'underscore'
 const User = require('api/apps/users/model.coffee')
 const Curation = require('api/apps/curations/model.coffee')
 const Channel = require('api/apps/channels/model.coffee')
 const Tag = require('api/apps/tags/model.coffee')
 const Author = require('api/apps/authors/model.coffee')
 const { mongoFetch, present, presentCollection, find } = require('api/apps/articles/model/index.coffee')
+const { ObjectId } = require('mongojs')
 
 export const articles = (root, args, req, ast) => {
   const unpublished = !args.published || args.scheduled
@@ -86,6 +88,48 @@ export const tags = (root, args, req, ast) => {
 export const authors = (root, args, req, ast) => {
   return new Promise((resolve, reject) => {
     Author.mongoFetch(args, (err, results) => {
+      if (err) {
+        reject(new Error(err))
+      }
+      resolve(results.results)
+    })
+  })
+}
+
+export const relatedArticlesPanel = (root) => {
+  const tags = root.tags || null
+  const args = {
+    omit: [ObjectId(root.id)],
+    published: true,
+    featured: true,
+    channel_id: ObjectId(root.channel_id),
+    tags: tags,
+    limit: 3,
+    sort: '-published_at'
+  }
+  return new Promise((resolve, reject) => {
+    mongoFetch(_.pick(args, _.identity), (err, results) => {
+      if (err) {
+        reject(new Error(err))
+      }
+      resolve(results.results)
+    })
+  })
+}
+
+export const relatedArticlesCanvas = (root) => {
+  const vertical = root.vertical && root.vertical.id ? ObjectId(root.vertical.id) : null
+  const args = {
+    omit: [ObjectId(root.id)],
+    published: true,
+    featured: true,
+    channel_id: ObjectId(root.channel_id),
+    vertical,
+    limit: 4,
+    sort: '-published_at'
+  }
+  return new Promise((resolve, reject) => {
+    mongoFetch(_.pick(args, _.identity), (err, results) => {
       if (err) {
         reject(new Error(err))
       }

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -25,7 +25,11 @@ describe('resolvers', () => {
       total: 20,
       count: 1,
       results: [
-        _.extend(fixtures().articles, { slugs: ['slug-1'] })
+        _.extend(fixtures().articles, {
+          slugs: ['slug-1'],
+          tags: ['dog'],
+          vertical: { id: '54276766fd4f50996aeca2b3' }
+        })
       ]
     }
     article = _.extend({}, fixtures().articles, {
@@ -144,6 +148,28 @@ describe('resolvers', () => {
       results[0].bio.should.equal('Writer based in NYC')
       results[0].twitter_handle.should.equal('kanaabe')
       results[0].image_url.should.equal('https://artsy-media.net/halley.jpg')
+    })
+  })
+
+  describe('relatedArticlesPanel', () => {
+    it('can find related articles for the panel', async () => {
+      const results = await resolvers.relatedArticlesPanel({
+        id: '54276766fd4f50996aeca2b8',
+        tags: ['dog', 'cat']
+      })
+      results.length.should.equal(1)
+      results[0].tags[0].should.equal('dog')
+    })
+  })
+
+  describe('relatedArticlesCanvas', () => {
+    it('can find related articles for the canvas', async () => {
+      const results = await resolvers.relatedArticlesCanvas({
+        id: '54276766fd4f50996aeca2b8',
+        vertical: { id: '54276766fd4f50996aeca2b3' }
+      })
+      results.length.should.equal(1)
+      results[0].vertical.id.should.equal('54276766fd4f50996aeca2b3')
     })
   })
 })


### PR DESCRIPTION
A follow-up to https://github.com/artsy/positron/pull/1279

I realized the PR above was a bit naive because we need to use the result of the initial articles fetch to query for related articles. We want the query to look like this:
```
{
  articles(published:true, featured: true, limit: 3){
    title
    id
    relatedArticlesCanvas {
      thumbnail_title
    }
    relatedArticlesPanel {
      thumbnail_title
    }
  }
}
```

This allows us to reuse `root` in the `relatedArticlesCanvas` and `relatedArticlesPanel` resolvers which now has the article data. From there we can grab things like `vertical.id` and `tags` and feed it into the subsequent `relatedArticles` queries. 
 
cc @eessex 