### PR TITLE
@craigspaeth => Admin: Related articles, layout toggle

### DIFF
--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -159,7 +159,7 @@ denormalizedArtwork = (->
       images: @array().items([denormalizedArtwork, imageSection])
   ]).allow(null)
   postscript: @string().allow('', null)
-  related_articles: @array().items(@string().objectid()).allow(null)
+  related_article_ids: @array().items(@string().objectid()).default([])
   primary_featured_artist_ids: @array().items(@string().objectid()).allow(null)
   featured_artist_ids: @array().items(@string().objectid()).allow(null)
   featured_artwork_ids: @array().items(@string().objectid()).allow(null)

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -159,6 +159,7 @@ denormalizedArtwork = (->
       images: @array().items([denormalizedArtwork, imageSection])
   ]).allow(null)
   postscript: @string().allow('', null)
+  related_articles: @array().items(@string().objectid()).allow(null)
   primary_featured_artist_ids: @array().items(@string().objectid()).allow(null)
   featured_artist_ids: @array().items(@string().objectid()).allow(null)
   featured_artwork_ids: @array().items(@string().objectid()).allow(null)

--- a/client/apps/edit/components/admin/article/index.coffee
+++ b/client/apps/edit/components/admin/article/index.coffee
@@ -46,6 +46,9 @@ module.exports = AdminArticle = React.createClass
     @onChange 'featured', featured
 
   onLayoutChange: (e) ->
+    if e.target.name is 'standard' and @props.article.get('layout') is 'feature'
+      canLooseData = confirm 'Some header and section layout data may be lost. Change anyways?'
+      return false unless canLooseData
     @setState layout: e.target.name
     @onChange 'layout', e.target.name
 

--- a/client/apps/edit/components/admin/article/index.coffee
+++ b/client/apps/edit/components/admin/article/index.coffee
@@ -16,7 +16,7 @@ module.exports = AdminArticle = React.createClass
     tier: @props.article.get('tier') or 2
     featured: @props.article?.get('featured') or false
     layout: @setInitialLayout()
-    relatedArticles: @props.article?.get('related_articles') or []
+    relatedArticles: @props.article?.get('related_article_ids') or []
 
   componentWillMount: ->
     @setupPublishDate()
@@ -47,8 +47,8 @@ module.exports = AdminArticle = React.createClass
 
   onLayoutChange: (e) ->
     if e.target.name is 'standard' and @props.article.get('layout') is 'feature'
-      canLooseData = confirm 'Some header and section layout data may be lost. Change anyways?'
-      return false unless canLooseData
+      canLoseData = confirm 'Some header and section layout data may be lost. Change anyways?'
+      return false unless canLoseData
     @setState layout: e.target.name
     @onChange 'layout', e.target.name
 
@@ -248,13 +248,13 @@ module.exports = AdminArticle = React.createClass
                   relatedArticles = @state.relatedArticles
                   relatedArticles = _.pluck items, 'id'
                   @setState relatedArticles: relatedArticles
-                  @props.onChange 'related_articles', relatedArticles
+                  @props.onChange 'related_article_ids', relatedArticles
                 removed: (e, item, items) =>
                   relatedArticles = @state.relatedArticles
                   relatedArticles = _.without(_.pluck(items,'id'),item.id)
                   @setState relatedArticles: relatedArticles
-                  @props.onChange 'related_articles', relatedArticles
-                idsToFetch: @props.article.get('related_articles')
+                  @props.onChange 'related_article_ids', relatedArticles
+                idsToFetch: @props.article.get('related_article_ids')
                 fetchUrl: (id) -> "#{sd.API_URL}/articles/#{id}"
                 resObject: (res) ->
                   id: res.body.id, value: "#{res.body.title}, #{res.body.author?.name}"

--- a/client/apps/edit/components/admin/article/index.coffee
+++ b/client/apps/edit/components/admin/article/index.coffee
@@ -15,12 +15,18 @@ module.exports = AdminArticle = React.createClass
     focus_date: false
     tier: @props.article.get('tier') or 2
     featured: @props.article?.get('featured') or false
+    layout: @setInitialLayout()
+    relatedArticles: @props.article?.get('related_articles') or []
 
   componentWillMount: ->
     @setupPublishDate()
 
   componentDidMount: ->
     ReactDOM.findDOMNode(@refs.container).classList += ' active'
+
+  setInitialLayout: ->
+    return 'classic' unless @props.channel?.isEditorial()
+    return @props.article?.get('layout') or 'standard'
 
   onChange: (key, value)->
     @props.onChange key, value
@@ -38,6 +44,10 @@ module.exports = AdminArticle = React.createClass
     featured = if e.target.name is 'true' then true else false
     @setState featured: featured
     @onChange 'featured', featured
+
+  onLayoutChange: (e) ->
+    @setState layout: e.target.name
+    @onChange 'layout', e.target.name
 
   onCheckboxChange: (e) ->
     key = $(e.currentTarget).attr('name')
@@ -154,6 +164,22 @@ module.exports = AdminArticle = React.createClass
                   className: 'avant-garde-button' + @showActive 'featured', false
                   onClick: @onMagazineChange
                 }, 'No'
+
+          if @props.channel.isEditorial()
+            div {className: 'field-group article-layout'},
+              label {}, 'Article Layout'
+              div {className: 'button-group'},
+                button {
+                  className: 'avant-garde-button' + @showActive('layout', 'standard')
+                  onClick: @onLayoutChange
+                  name: 'standard'
+                }, 'Standard'
+                button {
+                  className: 'avant-garde-button' + @showActive('layout', 'feature')
+                  onClick: @onLayoutChange
+                  name: 'feature'
+                }, 'Feature'
+
           div {
             className: 'field-group--inline flat-checkbox'
             onClick: @onCheckboxChange
@@ -166,6 +192,18 @@ module.exports = AdminArticle = React.createClass
               readOnly: true
             }
             label {}, 'Index for Search'
+          div {
+            className: 'field-group--inline flat-checkbox'
+            onClick: @onCheckboxChange
+            name: 'exclude_google_news'
+          },
+            input {
+              type: 'checkbox'
+              checked: @props.article.get 'exclude_google_news'
+              value: @props.article.get 'exclude_google_news'
+              readOnly: true
+            }
+            label {}, 'Exclude from Google News'
 
         div {className: 'fields-right'},
           div {className: 'field-group publish-time'},
@@ -193,15 +231,28 @@ module.exports = AdminArticle = React.createClass
                 className: 'avant-garde-button date'
                 onClick: @onScheduleChange
               }, @publishButtonText()
-            div {
-              className: 'field-group--inline flat-checkbox'
-              onClick: @onCheckboxChange
-              name: 'exclude_google_news'
-            },
-              input {
-                type: 'checkbox'
-                checked: @props.article.get 'exclude_google_news'
-                value: @props.article.get 'exclude_google_news'
-                readOnly: true
+
+          if @props.channel.isEditorial()
+            div {className: 'field-group'},
+              label {}, 'Related Articles'
+              AutocompleteList {
+                url: "#{sd.API_URL}/articles?published=true&q=%QUERY"
+                placeholder: "Search articles by title..."
+                filter: (articles) ->
+                  for article in articles.results
+                    { id: article.id, value: "#{article.title}, #{article.author?.name}"}
+                selected: (e, item, items) =>
+                  relatedArticles = @state.relatedArticles
+                  relatedArticles = _.pluck items, 'id'
+                  @setState relatedArticles: relatedArticles
+                  @props.onChange 'related_articles', relatedArticles
+                removed: (e, item, items) =>
+                  relatedArticles = @state.relatedArticles
+                  relatedArticles = _.without(_.pluck(items,'id'),item.id)
+                  @setState relatedArticles: relatedArticles
+                  @props.onChange 'related_articles', relatedArticles
+                idsToFetch: @props.article.get('related_articles')
+                fetchUrl: (id) -> "#{sd.API_URL}/articles/#{id}"
+                resObject: (res) ->
+                  id: res.body.id, value: "#{res.body.title}, #{res.body.author?.name}"
               }
-              label {}, 'Exclude from Google News'

--- a/client/apps/edit/components/admin/article/index.styl
+++ b/client/apps/edit/components/admin/article/index.styl
@@ -2,6 +2,9 @@
   flex-direction column
   .flat-checkbox
     width 230px
+    &[name=indexable]
+      margin-top 15px
+      margin-bottom 15px
   .publish-time .field-group--inline
     margin-bottom 30px
     button
@@ -38,7 +41,7 @@
 
   &.edit-admin__fields .tier-feed .field-group
     width 50%
-    margin-bottom 30px
+    margin-bottom 40px
   .button-group
     margin-top 5px
     button

--- a/client/apps/edit/components/admin/test/article.coffee
+++ b/client/apps/edit/components/admin/test/article.coffee
@@ -42,9 +42,11 @@ describe 'AdminArticle', ->
         author: {name: 'Artsy Editorial', id: '123'}
         contributing_authors: [{name: 'Molly Gottschalk', id: '123'}]
         indexable: true
+      @channel = { isEditorial: sinon.stub().returns(false) }
       props = {
         article: @article
         onChange: sinon.stub()
+        channel: @channel
         }
       @component = ReactDOM.render React.createElement(AdminArticle, props), (@$el = $ "<div></div>")[0], =>
         setTimeout =>
@@ -94,6 +96,19 @@ describe 'AdminArticle', ->
       @component.showActive('tier', 2).should.eql ' active'
       @component.showActive('featured', true).should.eql ''
 
+  describe 'Display: Editorial features', ->
+
+    it 'Renders the layout buttons', ->
+      @channel.isEditorial.returns(true)
+      @component.forceUpdate()
+      $(ReactDOM.findDOMNode(@component)).find('.article-layout .button-group').length.should.eql 1
+      $(ReactDOM.findDOMNode(@component)).find('.article-layout .button-group button').length.should.eql 2
+
+    it 'Renders the related article autocomplete', ->
+      @channel.isEditorial.returns(true)
+      @component.forceUpdate()
+      $(ReactDOM.findDOMNode(@component)).text().should.containEql 'Related Articles'
+      $(ReactDOM.findDOMNode(@component)).find('.autocomplete-input').length.should.eql 2
 
   describe 'Publish and scheduled date', ->
 
@@ -189,6 +204,14 @@ describe 'AdminArticle', ->
       r.simulate.click r.findTag(@component, 'button')[4]
       @component.onChange.args[0][0].should.eql 'featured'
       @component.onChange.args[0][1].should.eql false
+
+    it '#onLayoutChange updates the layout', ->
+      @component.onChange = sinon.stub()
+      @channel.isEditorial.returns(true)
+      @component.forceUpdate()
+      r.simulate.click r.findTag(@component, 'button')[5]
+      @component.onChange.args[0][0].should.eql 'layout'
+      @component.onChange.args[0][1].should.eql 'standard'
 
     it '#onCheckboxChange toggles indexable', ->
       @component.onChange = sinon.stub()

--- a/client/apps/edit/components/admin/test/article.coffee
+++ b/client/apps/edit/components/admin/test/article.coffee
@@ -26,6 +26,7 @@ describe 'AdminArticle', ->
           ttAdapter: ->
         )
       $.fn.typeahead = sinon.stub()
+      global.confirm = @confirm = sinon.stub()
       AdminArticle = benv.require resolve __dirname, '../article/index.coffee'
       AdminArticle.__set__ 'sd', {
         API_URL: 'http://localhost:3005/api'
@@ -42,6 +43,7 @@ describe 'AdminArticle', ->
         author: {name: 'Artsy Editorial', id: '123'}
         contributing_authors: [{name: 'Molly Gottschalk', id: '123'}]
         indexable: true
+        layout: 'standard'
       @channel = { isEditorial: sinon.stub().returns(false) }
       props = {
         article: @article
@@ -209,9 +211,17 @@ describe 'AdminArticle', ->
       @component.onChange = sinon.stub()
       @channel.isEditorial.returns(true)
       @component.forceUpdate()
-      r.simulate.click r.findTag(@component, 'button')[5]
+      r.simulate.click r.findTag(@component, 'button')[6]
       @component.onChange.args[0][0].should.eql 'layout'
-      @component.onChange.args[0][1].should.eql 'standard'
+      @component.onChange.args[0][1].should.eql 'feature'
+
+    it '#onLayoutChange warns a user if data will be lost', ->
+      @component.onChange = sinon.stub()
+      @channel.isEditorial.returns(true)
+      @component.props.article.set('layout', 'feature')
+      @component.forceUpdate()
+      r.simulate.click r.findTag(@component, 'button')[5]
+      @confirm.called.should.eql true
 
     it '#onCheckboxChange toggles indexable', ->
       @component.onChange = sinon.stub()


### PR DESCRIPTION
- Adds related_articles field to the Article schema

In Admin panel:
- Adds UI for toggling article layout on editorial channels
- Adds autocomplete for adding related articles in editorial channels
- Adds confirm warning data can be lost when changing from layout to feature


![screen shot 2017-09-20 at 11 13 52 am](https://user-images.githubusercontent.com/1497424/30654191-33e81a24-9dfb-11e7-9e0f-34e28122c3d1.png)
