### PR TITLE
@craigspaeth => New article QA

### DIFF
--- a/client/apps/edit/components/content2/section_container/index.styl
+++ b/client/apps/edit/components/content2/section_container/index.styl
@@ -77,6 +77,17 @@
       height 30px
       border-radius 50%
 
+#edit-content
+  div[class*="caption__CaptionContainer-"]
+    > div
+      min-width 100%
+    .rich-text--paragraph
+      position relative
+    .public-DraftEditorPlaceholder-root
+      position absolute
+    a
+      background-size 1px 1px
+
 [data-layout='fillwidth']
   &[data-editing='false']
      .edit-section__hover-controls

--- a/client/apps/edit/components/content2/section_list/index.coffee
+++ b/client/apps/edit/components/content2/section_list/index.coffee
@@ -49,7 +49,12 @@ module.exports = React.createClass
         (if @props.sections.length then ' esl-children' else '')
       ref: 'sections'
     },
-      SectionTool { sections: @props.sections, index: -1, key: 1 }
+      SectionTool {
+        sections: @props.sections
+        index: -1
+        key: 1
+        isEditing: @state.editingIndex isnt null
+      }
       if @props.sections.length
         DragContainer {
           items: @props.sections.models
@@ -72,7 +77,12 @@ module.exports = React.createClass
                   onSetEditing: @onSetEditing
                   article: @props.article
                 }
-                SectionTool { sections: @props.sections, index: i, key: i }
+                SectionTool {
+                  sections: @props.sections
+                  index: i
+                  key: i
+                  isEditing: @state.editingIndex isnt null
+                }
               ]
       if @props.channel.isEditorial()
         div {

--- a/client/apps/edit/components/content2/section_list/index.styl
+++ b/client/apps/edit/components/content2/section_list/index.styl
@@ -10,7 +10,7 @@
   .public-DraftEditorPlaceholder-root
     position absolute
     color gray-dark-color
-    top 27px
+    top 0
     Garamond s23
     font-style italic
 

--- a/client/apps/edit/components/content2/section_tool/index.coffee
+++ b/client/apps/edit/components/content2/section_tool/index.coffee
@@ -60,7 +60,11 @@ module.exports = React.createClass
     @setState open: false
 
   render: ->
-    div { className: 'edit-tool', 'data-state-open': @state.open },
+    div {
+      className: 'edit-tool'
+      'data-state-open': @state.open
+      'data-editing': @props.isEditing
+    },
       div { className: 'edit-tool__container'},
         div {
           className: 'edit-tool__icon'

--- a/client/apps/edit/components/content2/section_tool/index.styl
+++ b/client/apps/edit/components/content2/section_tool/index.styl
@@ -10,6 +10,8 @@ section-btn-height = 130px
   margin-left auto
   margin-right auto
   width 100%
+  &[data-editing=true]
+    z-index -1
   &:only-child
     &::after
       opacity 1

--- a/client/apps/edit/components/content2/sections/header/index.styl
+++ b/client/apps/edit/components/content2/sections/header/index.styl
@@ -75,6 +75,7 @@
     color gray-dark-color
 
 .feature .edit-header
+  margin-bottom 30px
   div[class^='feature_header__Vertical'] span
     color gray-dark-color
   [data-type=split]
@@ -82,6 +83,7 @@
     padding-top 20px
     .file-input.simple
       max-height 100%
+      min-height 100%
     .edit-header__image-container
       top 0
       left 0

--- a/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
+++ b/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
@@ -34,6 +34,7 @@ export default class ImageCollectionImage extends Component {
           placeholder='Image Caption'
           html={image.caption || ''}
           onChange={this.onCaptionChange}
+          stripLinebreaks={true}
           layout={this.props.article.get('layout')} />
       )
     }

--- a/client/apps/edit/components/content2/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/index.coffee
@@ -173,7 +173,7 @@ module.exports = React.createClass
               onDragEnd: @onDragEnd
               isDraggable: @props.editing
               dimensions: @state.dimensions
-              isWrapping: @isImageSetWrapping
+              isWrapping: @isImageSetWrapping()
             },
               @renderImages(images)
           else

--- a/client/apps/edit/components/content2/sections/image_collection/index.styl
+++ b/client/apps/edit/components/content2/sections/image_collection/index.styl
@@ -21,6 +21,9 @@
     position relative
     padding-bottom 30px
     max-width 100%
+    margin-right 30px
+    &:last-child
+      margin-right 0
   &.single .image-collection__img-container
     margin 0 auto 30px auto
   &__img
@@ -31,13 +34,18 @@
     z-index 2 !important
     opacity 0
     transition opacity 500ms ease-in
+    display flex
+    justify-content center
     &--placeholder
       opacity 1
     .drag-container
       display flex
-      justify-content space-evenly
+      justify-content center
     .drag-target
       max-width 100%
+      margin-right 30px
+      &:last-child
+        margin-right 0
 
 .edit-section--image-collection
   .edit-controls

--- a/client/apps/edit/components/content2/sections/video/index.jsx
+++ b/client/apps/edit/components/content2/sections/video/index.jsx
@@ -86,6 +86,7 @@ export default class SectionVideo extends Component {
             placeholder='Video Caption (required)'
             html={section.get('caption')}
             onChange={this.onCaptionChange}
+            stripLinebreaks={true}
             layout={article.get('layout')} />
         </Video>
       )

--- a/client/apps/edit/components/content2/sections/video/index.styl
+++ b/client/apps/edit/components/content2/sections/video/index.styl
@@ -16,10 +16,3 @@
     z-index 100
     div[class*="video__VideoContainer-"]
       z-index 1
-  div[class*="caption__CaptionContainer-"]
-    > div
-      min-width 100%
-    .rich-text--paragraph
-      position relative
-    .public-DraftEditorPlaceholder-root
-      position absolute


### PR DESCRIPTION
Addresses a few points raised for QA on the new article layouts [discussed here](https://github.com/artsy/positron/issues/1284).

- Captions do not allow/strip linebreaks
- Caption placeholders are correctly positioned
- Fixes caption link styles
- Images align center if they do not fill their container
- Section tools do not hover when a section is being edited
- Postscript placeholder is correctly positioned
- Feature header upload container does not overflow container
- Fixes bug in imageCollection sizing (was not calling isImageSetWrapping)
