### PR TITLE
@kanaabe => Scroll bug (and a few other bugs)

### DIFF
--- a/client/apps/edit/components/content/sections/hero/index.styl
+++ b/client/apps/edit/components/content/sections/hero/index.styl
@@ -10,26 +10,26 @@
     &:hover
       fill-color black
 
-.edit-section-container[data-type=video], .edit-section-container[data-type=image]
-  width 1100px
-  .esv-controls-container
-    height 243px
-  .esv-nav, .esv-background-color
-    display none
-  .edit-section-video
-    iframe
-      min-height 590px
-  .esic-img-container
-    padding 20px
-  .edit-section-image
-    z-index 1
-  .edit-section-container-bg
-    z-index -1
+  .edit-section-container[data-type=video], .edit-section-container[data-type=image]
+    width 1100px
+    .esv-controls-container
+      height 243px
+    .esv-nav, .esv-background-color
+      display none
+    .edit-section-video
+      iframe
+        min-height 590px
+    .esic-img-container
+      padding 20px
+    .edit-section-image
+      z-index 1
+    .edit-section-container-bg
+      z-index -1
 
-.edit-section-container[data-type=image]
-  left calc(50% - 410px)
-.edit-section-container[data-type=video]
-  left calc(50% - 550px)
+  .edit-section-container[data-type=image]
+    left calc(50% - 410px)
+  .edit-section-container[data-type=video]
+    left calc(50% - 550px)
 
 #edit-hero-section
   .edit-section-tool-menu

--- a/client/apps/edit/components/content/sections/text/index.coffee
+++ b/client/apps/edit/components/content/sections/text/index.coffee
@@ -103,7 +103,7 @@ module.exports = React.createClass
     selection = getSelectionDetails(@state.editorState)
     # only merge a section if cursor is in first character of first block
     if selection.isFirstBlock and selection.anchorOffset is 0 and
-    @props.sections.models[@props.index - 1].get('type') is 'text'
+    @props.sections.models[@props.index - 1]?.get('type') is 'text'
       mergeIntoHTML = @props.sections.models[@props.index - 1].get('body')
       @props.sections.models[@props.index - 1].destroy()
       newHTML = mergeIntoHTML + @state.html

--- a/client/apps/edit/components/content/sections/text/test/index.coffee
+++ b/client/apps/edit/components/content/sections/text/test/index.coffee
@@ -28,9 +28,10 @@ describe 'SectionText', ->
           }])
         )
       )
-      global.Node = () => {}
-      global.HTMLElement = () => {}
-      global.HTMLAnchorElement = () => {}
+      global.Node = window.Node
+      global.Element = window.Element
+      global.HTMLElement = window.HTMLElement
+      global.document = window.document
       @r =
         find: ReactTestUtils.findRenderedDOMComponentWithClass
         simulate: ReactTestUtils.Simulate
@@ -76,6 +77,7 @@ describe 'SectionText', ->
       @artistProps = {
         editing: true
         section: @sections.models[2]
+        sections: @sections
       }
       @component = ReactDOM.render React.createElement(@SectionText, @props), (@$el = $ "<div></div>")[0], => setTimeout =>
         @component.stickyControlsBox = sinon.stub().returns {top: 20, left: 40}

--- a/client/apps/edit/components/content2/sections/text/test/index.test.coffee
+++ b/client/apps/edit/components/content2/sections/text/test/index.test.coffee
@@ -38,9 +38,10 @@ describe 'Section Text', ->
           removeListener: sinon.stub()
         }
       )
-      global.Node = () => {}
-      global.HTMLElement = () => {}
-      global.HTMLAnchorElement = () => {}
+      global.Node = window.Node
+      global.Element = window.Element
+      global.HTMLElement = window.HTMLElement
+      global.document = window.document
       @SectionText = benv.require resolve(__dirname, '../index')
       InputUrl = benv.requireWithJadeify(
         resolve(__dirname, '../../../../../../../components/rich_text2/components/input_url'), ['icons']

--- a/client/components/rich_text/test/input_paragraph.test.coffee
+++ b/client/components/rich_text/test/input_paragraph.test.coffee
@@ -14,6 +14,10 @@ describe 'RichTextParagraph', ->
     benv.setup =>
       benv.expose
         $: benv.require 'jquery'
+        React: require 'react'
+        ReactDOM: require 'react-dom'
+        ReactTestUtils: require 'react-addons-test-utils'
+        ReactDOMServer: require 'react-dom/server'
       window.jQuery = $
       global.Node = () => {}
       global.HTMLElement = () => {}

--- a/client/components/rich_text2/test/input_url.test.coffee
+++ b/client/components/rich_text2/test/input_url.test.coffee
@@ -16,8 +16,10 @@ describe 'RichTextInputUrl', ->
       @r =
         find: ReactTestUtils.findRenderedDOMComponentWithClass
         simulate: ReactTestUtils.Simulate
-      global.HTMLElement = () => {}
-      global.HTMLAnchorElement = () => {}
+      global.Node = window.Node
+      global.Element = window.Element
+      global.HTMLElement = window.HTMLElement
+      global.document = window.document
       DraftInputUrl = benv.requireWithJadeify resolve(__dirname, '../components/input_url'), ['icons']
       props = {
         selectionTarget:

--- a/client/components/rich_text2/test/paragraph.test.coffee
+++ b/client/components/rich_text2/test/paragraph.test.coffee
@@ -19,9 +19,10 @@ describe 'Rich Text: Paragraph', ->
       benv.expose
         $: benv.require 'jquery'
       window.jQuery = $
-      global.Node = () => {}
-      global.HTMLElement = () => {}
-      global.HTMLAnchorElement = () => {}
+      global.Node = window.Node
+      global.Element = window.Element
+      global.HTMLElement = window.HTMLElement
+      global.document = window.document
       window.getSelection = sinon.stub().returns(
         isCollapsed: false
         getRangeAt: sinon.stub().returns(

--- a/client/components/rich_text2/test/plain_text.test.js
+++ b/client/components/rich_text2/test/plain_text.test.js
@@ -13,7 +13,7 @@ describe('PlainText', () => {
       <PlainText {...props} />
     )
     expect(wrapper.html()).toMatch('<div class="plain-text" name="title">')
-    expect(wrapper.html()).toMatch('class="public-DraftEditor-content" contenteditable="true"')
+    expect(wrapper.html()).toMatch('public-DraftEditor-content" contenteditable="true"')
     expect(wrapper.html()).toMatch('Start Typing...')
     expect(wrapper.html()).toMatch('public-DraftEditorPlaceholder-inner')
   })

--- a/client/components/rich_text2/test/utils.test.coffee
+++ b/client/components/rich_text2/test/utils.test.coffee
@@ -23,8 +23,10 @@ describe 'Utils', ->
           }])
         )
       )
-      global.HTMLElement = () => {}
-      global.HTMLAnchorElement = () => {}
+      global.Node = window.Node
+      global.Element = window.Element
+      global.HTMLElement = window.HTMLElement
+      global.document = window.document
       @d =
         EditorState: Draft.EditorState
       copy = '<p>While auction houses will vouch for a piece’s authenticity, issues of title are the responsibility of the consignor.</p><p>Meaning there aren’t other people or organizations with a financial interest in the piece.</p>'

--- a/client/components/rich_text_caption/test/index.test.coffee
+++ b/client/components/rich_text_caption/test/index.test.coffee
@@ -23,8 +23,10 @@ describe 'RichTextCaption', ->
         simulate: ReactTestUtils.Simulate
       @d =
         EditorState: Draft.EditorState
-      global.HTMLElement = () => {}
-      global.HTMLAnchorElement = () => {}
+      global.Node = window.Node
+      global.Element = window.Element
+      global.HTMLElement = window.HTMLElement
+      global.document = window.document
       @RichTextCaption = benv.requireWithJadeify resolve(__dirname, '../../rich_text_caption/index'), ['icons']
       InputUrl = benv.requireWithJadeify(
         resolve(__dirname, '../../rich_text/components/input_url'), ['icons']

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "debug": "^2.2.0",
     "dotenv": "^4.0.0",
     "draft-convert": "^1.4.2",
-    "draft-js": "^0.10.0",
+    "draft-js": "^0.10.3",
     "elasticsearch": "^11.0.0",
     "envify": "^4.1.0",
     "express": "^4.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,11 +3026,12 @@ draft-convert@^1.4.2:
     immutable "~3.7.4"
     invariant "^2.2.1"
 
-draft-js@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.0.tgz#29d16191012b932fdab28a9b37ec1538f421abf6"
+draft-js@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.3.tgz#5f3c3025af9f494c62f00a9066006ccdc1b3c943"
   dependencies:
-    fbjs "^0.8.7"
+    enzyme "^2.9.1"
+    fbjs "^0.8.15"
     immutable "~3.7.4"
     object-assign "^4.1.0"
 
@@ -3719,9 +3720,21 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.7, fbjs@^0.8.8, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.8, fbjs@^0.8.9:
   version "0.8.11"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.11.tgz#340b590b8a2278a01ef7467c07a16da9b753db24"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+fbjs@^0.8.15:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -4919,6 +4932,7 @@ jade@^1.11.0:
     jstransformer "0.0.2"
     mkdirp "~0.5.0"
     transformers "2.1.0"
+    uglify-js "^2.4.19"
     void-elements "~2.0.1"
     with "~4.0.0"
 


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1308

Chrome v61 and 63 were have conflicts with the fbjs library, required by Draft JS.  This caused a bug of scrolling to the top of the page whenever `focus()` is called. Here Draft is updated to 10.3, the fix is in its dependency fbjs, which is required at a higher version in 10.3.  [Context is here](https://github.com/facebook/draft-js/issues/14).

Also fixes some css in the hero-section that was not nested properly, and the [handleBackspace bug](https://sentry.io/artsynet/positron-production/issues/356782374/#) in `content`. (This had already been addressed in `content2`). 

