### PR TITLE
@kanaabe: Article type drop down

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ To shut down the process, press `ctrl+c` or execute `docker-compose down`.
 - Install Node 6
 
 ```
-nvm install 6
-nvm alias default 6
+nvm install 8
+nvm alias default 8
 ```
 
 - Fork Positron to your Github account in the Github UI.

--- a/client/apps/edit/components/layout/components/yoast/yoast.styl
+++ b/client/apps/edit/components/layout/components/yoast/yoast.styl
@@ -2,7 +2,7 @@
   position fixed
   width calc(100% \- 110px)
   top 55px
-  z-index 90
+  z-index 3
   .edit-seo
     &__header-container
       cursor pointer

--- a/client/apps/edit/routes.coffee
+++ b/client/apps/edit/routes.coffee
@@ -11,7 +11,7 @@ sd = require('sharify').data
     partner_channel_id: channel.get('id') if channel.get('type') is 'partner'
     partner_ids: [channel.get('id')] if channel.get('type') is 'partner'
     author: { name: channel.get('name'), id: req.user.get('id') }
-    layout: if channel.get('type') is 'editorial' then 'standard' else 'classic'
+    layout: req.query.layout or 'classic'
   }
   setChannelIndexable channel, article
   render req, res, article

--- a/client/apps/edit/test/routes.test.coffee
+++ b/client/apps/edit/test/routes.test.coffee
@@ -30,21 +30,13 @@ describe 'routes', ->
       @res.render.args[0][1].article.get('channel_id').should.equal '4d8cd73191a5c50ce200002b'
       @res.render.args[0][1].article.get('author').name.should.equal 'Editorial'
 
-    it 'sets layout to standard for editorial channels', ->
-      @req.user.set('current_channel', {
-        id: '456'
-        name: 'Test Channel'
-        type: 'editorial'
-      })
+    it 'sets layout to the query param', ->
+      @req.query.layout = 'standard'
       @routes.create @req, @res
       @res.render.args[0][1].article.get('layout').should.equal 'standard'
 
-    it 'sets layout to classic for non-editorial channels', ->
-      @req.user.set('current_channel', {
-        id: '4d8cd73191a5c50ce200002b'
-        name: 'Gagosian'
-        type: 'partner'
-      })
+    it 'sets layout to default to classic', ->
+      @req.query.layout = null
       @routes.create @req, @res
       @res.render.args[0][1].article.get('layout').should.equal 'classic'
 

--- a/client/components/layout/stylesheets/sidebar.styl
+++ b/client/components/layout/stylesheets/sidebar.styl
@@ -13,18 +13,21 @@ triangle-size = 12px
   text-align center
   padding-top 20px
   z-index 8
-  a:not(#layout-sidebar-home), #layout-sidebar-profile
+  > *:not(#layout-sidebar-home), #layout-sidebar-profile
     display block
     margin-top 40px
     avant-garde(s-headline)
     color gray-dark-color
     transition color 0.3s
     text-decoration none
+    position relative
     &:hover, &.is-active
       cursor pointer
       color white
       svg
         fill-color white
+    &:hover .layout-sidebar-dropdown
+      display block
 
   svg
     width 22px
@@ -65,37 +68,14 @@ triangle-size = 12px
     img
       opacity 1
       filter none
-    #layout-sidebar-profile-menu
-      display block
   svg
-    width 40px
-    height @width
+    width 41px
+    height 40px
     display inline-block
     margin-bottom 10px
     filter grayscale(100%)
     transition filter 0.3s ease-in-out, opacity 0.3s ease-in-out
     opacity 0.8
-  #layout-sidebar-profile-menu
-    position absolute
-    width 232px
-    background black
-    left sidebar-width
-    border-left 20px solid white
-    text-align left
-    top -55px
-    padding 15px
-    display none
-    &::before
-      content '.'
-      color transparent
-      width 0
-      height 0
-      border-top triangle-size solid transparent
-      border-bottom triangle-size solid transparent
-      border-right triangle-size solid black
-      left -(triangle-size)
-      position absolute
-      top 68px
     a
       color white
       padding 15px
@@ -162,3 +142,44 @@ triangle-size = 12px
     color white
     br
       display none
+
+.layout-sidebar-dropdown
+  padding 30px
+  background black
+  position absolute
+  left sidebar-width
+  border-left 30px solid white
+  list-style none
+  text-align left
+  avant-garde(s-headline)
+  white-space nowrap
+  line-height 0
+  display none
+  top 50%
+  margin-top -50%
+  z-index 2
+  &::after
+    content '.'
+    color transparent
+    width 20px
+    height 20px
+    background #000
+    -webkit-transform rotate(60deg)
+    -moz-transform: rotate(60deg)
+    -o-transform rotate(60deg)
+    -ms-transform rotate(60deg)
+    transform rotate(45deg)
+    position absolute
+    left -10px
+    top calc(50% - 10px)
+    z-index 2
+  a
+    margin-bottom 30px
+    display block
+    color gray-dark-color
+    text-decoration none
+    transition color 0.3s
+    &:last-child
+      margin-bottom 0px
+    &:hover
+      color white

--- a/client/components/layout/templates/sidebar.jade
+++ b/client/components/layout/templates/sidebar.jade
@@ -2,13 +2,23 @@
   nav#layout-sidebar
     a#layout-sidebar-home( href='/' )
       include ../public/icons/logo.svg
-    a#layout-sidebar-new-article(
-      href='/articles/new'
-      class=(sd.URL == '/articles/new' ? 'is-active' : '')
-    )
-      include ../public/icons/layout_new_article.svg
-      br
-      | New Article
+    if channel && channel.isEditorial()
+      #layout-sidebar-new-article(
+        class=(sd.URL == '/articles/new' ? 'is-active' : '')
+      )
+        include ../public/icons/layout_new_article.svg
+        br
+        | New Article
+        nav.layout-sidebar-dropdown
+          a( href='/articles/new?layout=standard' ) Standard Article
+          a( href='/articles/new?layout=feature' ) Feature Article
+    else
+      a#layout-sidebar-new-article(
+        class=(sd.URL == '/articles/new' ? 'is-active' : '')
+      )
+        include ../public/icons/layout_new_article.svg
+        br
+        | New Article
     a( href='/articles'
        class=(sd.URL == '/articles' ? 'is-active' : '') )
       include ../public/icons/layout_published.svg
@@ -33,7 +43,9 @@
         = user.get('name').split(' ')[0]
 
       - var hasChannelMenu = (user.get('channel_ids') && user.get('channel_ids').length > 1) || (user.get('partner_ids') && user.get('partner_ids').length > 1) || user.isAdmin()
-      nav#layout-sidebar-profile-menu(class="#{ hasChannelMenu ? '' : 'has-only-child'}")
+      nav.layout-sidebar-dropdown(
+        class="#{ hasChannelMenu ? '' : 'has-only-child'}"
+      )
         a( href='/logout' ) Sign out
         if hasChannelMenu
           a#layout-sidebar-switch-channel Switch channel

--- a/client/lib/middleware.coffee
+++ b/client/lib/middleware.coffee
@@ -6,6 +6,7 @@
 viewHelpers = require './view_helpers'
 uaParser = require 'ua-parser'
 crypto = require 'crypto'
+Channel = require '../models/channel'
 
 @helpers = (req, res, next) ->
   res.backboneError = (model, err) -> next err
@@ -15,6 +16,7 @@ crypto = require 'crypto'
   res.locals.sd.URL = req.url
   res.locals.sd.USER = req.user?.toJSON()
   res.locals.user = req.user
+  res.locals.channel = new Channel req.user.get('current_channel') if req.user
   res.locals[key] = helper for key, helper of viewHelpers
   next()
 


### PR DESCRIPTION
Addresses https://github.com/artsy/positron/issues/1118

This adds the standard vs. classic article links to the New Article menu item. I wasn't totally sure this was the right design for this, but I saw it as an item [in the launch ticket](https://waffle.io/artsy/publishing/cards/59dbdce0b33ffa0050b0273d) that seemed easy to pick off. Lmk what you think.

![image](https://user-images.githubusercontent.com/555859/31400023-2fad41d4-adbc-11e7-915f-9bb49f320cfb.png)
