### PR TITLE
@kanaabe => Display admin

### DIFF
--- a/api/apps/articles/model/distribute.coffee
+++ b/api/apps/articles/model/distribute.coffee
@@ -21,7 +21,7 @@ jade = require 'jade'
 Article = require '../../../models/article.coffee'
 moment = require 'moment'
 particle = require 'particle'
-cloneDeep = require 'lodash.clonedeep'
+{ cloneDeep } = require 'lodash'
 
 @distributeArticle = (article, cb) =>
   cleanArticlesInSailthru article.slugs

--- a/api/apps/articles/model/index.js
+++ b/api/apps/articles/model/index.js
@@ -4,7 +4,7 @@
 //
 import _ from 'underscore'
 import async from 'async'
-import cloneDeep from 'lodash.clonedeep'
+import { cloneDeep } from 'lodash'
 import schema from './schema.coffee'
 import Joi from '../../../lib/joi.coffee'
 import retrieve from './retrieve.coffee'

--- a/client/apps/edit/components/admin/components/image_upload.coffee
+++ b/client/apps/edit/components/admin/components/image_upload.coffee
@@ -36,8 +36,9 @@ module.exports = React.createClass
       add: (src) =>
         @setState src: src, progress: 0.1, isDragover: false
       done: (src) =>
-        @setState src: src, progress: 0, error: false, errorType: null
         @props.onChange(@props.name, src) if @props.onChange
+        src = '' if @props.hidePreview
+        @setState src: src, progress: 0, error: false, errorType: null
 
   onClick: ->
     @setState error: false, errorType: null
@@ -108,7 +109,7 @@ module.exports = React.createClass
         className: 'image-upload-form-input'
         disabled: @props.disabled
       }
-      @previewImage()
+      @previewImage() unless @props.hidePreview
       @progressBar()
 
       if @state.error

--- a/client/apps/edit/components/admin/test/image_upload.test.coffee
+++ b/client/apps/edit/components/admin/test/image_upload.test.coffee
@@ -34,16 +34,32 @@ describe 'ImageUpload', ->
 
     it 'Renders the file input', ->
       $(ReactDOM.findDOMNode(@component)).find('input[type=file]').length.should.eql 1
+      $(ReactDOM.findDOMNode(@component)).html().should.containEql 'accept="image/jpg,image/jpeg,image/gif,image/png"'
 
-    it 'Renders an image preview if image is present', ->
+    it 'Renders an image preview if file is present', ->
       @component.setState src: 'http://artsy.net/image.jpg'
       $(ReactDOM.findDOMNode(@component)).html().should.containEql 'background-image: url(http://artsy.net/image.jpg)'
 
+    it 'Hides the preview if props.hidePreview is true', ->
+      @props.hidePreview = true
+      component = ReactDOM.render React.createElement(@ImageUpload, @props), (@$el = $ "<div></div>")[0]
+      component.setState src: 'http://artsy.net/image.jpg'
+      $(ReactDOM.findDOMNode(component)).html().should.not.containEql 'background-image: url(http://artsy.net/image.jpg)'
+
+    it 'Allows video uploads if props.hasVideo is true', ->
+      @props.hasVideo = true
+      component = ReactDOM.render React.createElement(@ImageUpload, @props), (@$el = $ "<div></div>")[0]
+      $(ReactDOM.findDOMNode(component)).html().should.containEql 'accept="image/jpg,image/jpeg,image/gif,image/png,video/mp4"'
+
+    it 'Renders a video preview if file is present', ->
+      @component.setState src: 'http://artsy.net/video.mp4'
+      $(ReactDOM.findDOMNode(@component)).html().should.containEql '<video src="http://artsy.net/video.mp4">'
+      
     it 'Disables the file input if prop includes disabled', ->
-      @props['disabled'] = true
-      @component = ReactDOM.render React.createElement(@ImageUpload, @props), (@$el = $ "<div></div>")[0]
-      $(ReactDOM.findDOMNode(@component)).hasClass('disabled').should.eql true
-      $(ReactDOM.findDOMNode(@component)).find('input[type=file]').prop('disabled').should.eql true
+      @props.disabled = true
+      component = ReactDOM.render React.createElement(@ImageUpload, @props), (@$el = $ "<div></div>")[0]
+      $(ReactDOM.findDOMNode(component)).hasClass('disabled').should.eql true
+      $(ReactDOM.findDOMNode(component)).find('input[type=file]').prop('disabled').should.eql true
 
     it 'Renders a progress bar if progress', ->
       @component.setState progress: .5

--- a/client/apps/settings/client/curations.coffee
+++ b/client/apps/settings/client/curations.coffee
@@ -6,6 +6,7 @@ _ = require('underscore')
 React = require 'react'
 ReactDOM = require 'react-dom'
 VeniceAdmin = React.createFactory require './curations/venice_admin.coffee'
+DisplayAdmin = require './curations/display/index.jsx'
 
 module.exports.CurationEditView = class CurationEditView extends Backbone.View
 
@@ -19,12 +20,17 @@ module.exports.CurationEditView = class CurationEditView extends Backbone.View
         VeniceAdmin(curation: @curation)
         $('#venice-root')[0]
       )
+    else if @curation.get('type') is 'display-admin'
+      ReactDOM.render(
+        React.createElement(DisplayAdmin.default, { curation: @curation })
+        $('#react-root')[0]
+      )
     else
       new AdminEditView
         model: @curation
         el: $('body')
         onDeleteUrl: '/settings/curations'
-    @initMenuState() if @curation.get('type') is 'editorial-feature'
+    @initMenuState() if @curation.get('type') is 'editorial-feature' or 'display-admin'
 
   initMenuState: =>
     $('.page-header').addClass 'sticky'

--- a/client/apps/settings/client/curations/display/components/campaign.jsx
+++ b/client/apps/settings/client/curations/display/components/campaign.jsx
@@ -1,6 +1,12 @@
+import moment from 'moment'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Col, Row } from 'react-styled-flexboxgrid'
+
+function onChangeDate (name, value, index, onChange) {
+  const date = moment(value).toISOString()
+  onChange(name, date, index)
+}
 
 const Campaign = (props) => {
   const {campaign, index, onChange} = props
@@ -20,24 +26,23 @@ const Campaign = (props) => {
           <input
             type='date'
             className='bordered-input'
-            placeholder='Start Date'
-            defaultValue={campaign.start_date}
-            onChange={(e) => onChange('start_date', e.target.value, index)} />
+            defaultValue={moment(campaign.start_date).format('YYYY-MM-DD')}
+            onChange={(e) => onChangeDate('start_date', e.target.value, index, onChange)} />
         </Col>
         <Col lg>
           <label>End Date</label>
           <input
             type='date'
             className='bordered-input'
-            placeholder='Title'
-            defaultValue={campaign.end_date}
+            defaultValue={campaign.end_date && moment(campaign.end_date).format('YYYY-MM-DD')}
             onChange={(e) => onChange('end_date', e.target.value, index)} />
         </Col>
         <Col lg>
           <label>Traffic Quantity</label>
           <select
+            defaultValue={campaign.sov}
             className='bordered-input'
-            onChange={(e) => onChange('sov', e.target.value, index)} >
+            onChange={(e) => onChange('sov', parseFloat(e.target.value), index)} >
             <option value='0.25'>25%</option>
             <option value='0.50'>50%</option>
             <option value='0.75'>75%</option>

--- a/client/apps/settings/client/curations/display/components/campaign.jsx
+++ b/client/apps/settings/client/curations/display/components/campaign.jsx
@@ -1,0 +1,57 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Col, Row } from 'react-styled-flexboxgrid'
+
+const Campaign = (props) => {
+  const {campaign, index, onChange} = props
+  return (
+    <div className='display-admin__section--campaign'>
+      <Row key={index}>
+        <Col lg>
+          <label>Title</label>
+          <input
+            className='bordered-input'
+            placeholder='Partner Name'
+            defaultValue={campaign.name}
+            onChange={(e) => onChange('name', e.target.value, index)} />
+        </Col>
+        <Col lg>
+          <label>Start Date</label>
+          <input
+            type='date'
+            className='bordered-input'
+            placeholder='Start Date'
+            defaultValue={campaign.start_date}
+            onChange={(e) => onChange('start_date', e.target.value, index)} />
+        </Col>
+        <Col lg>
+          <label>End Date</label>
+          <input
+            type='date'
+            className='bordered-input'
+            placeholder='Title'
+            defaultValue={campaign.end_date}
+            onChange={(e) => onChange('end_date', e.target.value, index)} />
+        </Col>
+        <Col lg>
+          <label>Traffic Quantity</label>
+          <select
+            className='bordered-input'
+            onChange={(e) => onChange('sov', e.target.value, index)} >
+            <option value='0.25'>25%</option>
+            <option value='0.50'>50%</option>
+            <option value='0.75'>75%</option>
+          </select>
+        </Col>
+      </Row>
+    </div>
+  )
+}
+
+Campaign.propTypes = {
+  campaign: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired
+}
+
+export default Campaign

--- a/client/apps/settings/client/curations/display/components/campaign.jsx
+++ b/client/apps/settings/client/curations/display/components/campaign.jsx
@@ -26,7 +26,7 @@ const Campaign = (props) => {
           <input
             type='date'
             className='bordered-input'
-            defaultValue={moment(campaign.start_date).format('YYYY-MM-DD')}
+            defaultValue={campaign.start_date && moment(campaign.start_date).format('YYYY-MM-DD')}
             onChange={(e) => onChangeDate('start_date', e.target.value, index, onChange)} />
         </Col>
         <Col lg>
@@ -35,7 +35,7 @@ const Campaign = (props) => {
             type='date'
             className='bordered-input'
             defaultValue={campaign.end_date && moment(campaign.end_date).format('YYYY-MM-DD')}
-            onChange={(e) => onChange('end_date', e.target.value, index)} />
+            onChange={(e) => onChangeDate('end_date', e.target.value, index, onChange)} />
         </Col>
         <Col lg>
           <label>Traffic Quantity</label>

--- a/client/apps/settings/client/curations/display/components/campaign.jsx
+++ b/client/apps/settings/client/curations/display/components/campaign.jsx
@@ -8,7 +8,7 @@ function onChangeDate (name, value, index, onChange) {
   onChange(name, date, index)
 }
 
-const Campaign = (props) => {
+export const Campaign = (props) => {
   const {campaign, index, onChange} = props
   return (
     <div className='display-admin__section--campaign'>

--- a/client/apps/settings/client/curations/display/components/canvas.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas.jsx
@@ -64,16 +64,16 @@ export default class Canvas extends React.Component {
                     type='textarea'
                     label='Body'
                     placeholder='Body'
-                    defaultValue={campaign.canvas ? campaign.canvas.body : ''}
+                    defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
                     onChange={(html) => onChange('canvas.body', html, index)}
                     html
-                    limit={90} />
+                    limit={70} />
                 : <CharacterLimitInput
                     label='headline'
                     placeholder='Headline'
                     defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
                     onChange={(e) => onChange('canvas.headline', e.target.value, index)}
-                    limit={25} />
+                    limit={45} />
                 }
             </div>
             <div className='field-group'>
@@ -99,7 +99,7 @@ export default class Canvas extends React.Component {
                 placeholder='Enter legal disclaimer here'
                 defaultValue={campaign.canvas ? campaign.canvas.body : ''}
                 onChange={(e) => onChange('canvas.body', e.target.value, index)}
-                limit={90} />
+                limit={150} />
             </div>
           </Col>
           <Col lg>

--- a/client/apps/settings/client/curations/display/components/canvas.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas.jsx
@@ -5,87 +5,126 @@ import { Col, Row } from 'react-styled-flexboxgrid'
 import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
 import CharacterLimitInput from 'client/components/character_limit/index.jsx'
 
-const Canvas = (props) => {
-  const {campaign, index, onChange} = props
-  return (
-    <div className='display-admin__section--campaign'>
-      <Row key={index} className='inputs--text'>
-        <Col lg>
-          <div className='field-group'>
-            {campaign.canvas.layout === 'overlay'
-              ? <CharacterLimitInput
-                  type='textarea'
-                  label='Body'
-                  placeholder='Body'
-                  defaultValue={campaign.canvas ? campaign.canvas.body : ''}
-                  onChange={(html) => onChange('canvas.body', html, index)}
-                  html
-                  limit={90} />
-              : <CharacterLimitInput
-                  label='headline'
-                  placeholder='Headline'
-                  defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
-                  onChange={(e) => onChange('canvas.headline', e.target.value, index)}
-                  limit={25} />
-              }
-          </div>
-          <div className='field-group'>
-            <CharacterLimitInput
-              label='CTA Text'
-              placeholder='Find Out More'
-              defaultValue={campaign.canvas && campaign.canvas.link ? campaign.canvas.link.text : ''}
-              onChange={(e) => onChange('canvas.link.text', e.target.value, index)}
-              limit={25} />
-          </div>
-          <div className='field-group'>
-            <label>CTA Link</label>
-            <input
-              className='bordered-input'
-              placeholder='Find Out More'
-              defaultValue={campaign.canvas && campaign.canvas.link ? campaign.canvas.link.url : ''}
-              onChange={(e) => onChange('canvas.link.url', e.target.value, index)} />
-          </div>
-          <div className='field-group'>
-            <CharacterLimitInput
-              type='textarea'
-              label='Disclaimer (optional)'
-              placeholder='Enter legal disclaimer here'
-              defaultValue={campaign.canvas ? campaign.canvas.body : ''}
-              onChange={(e) => onChange('canvas.body', e.target.value, index)}
-              limit={90} />
-          </div>
-        </Col>
-        <Col lg>
-          <Row key={index} className='inputs--images'>
-            <Col lg>
-              <label>Image</label>
-              <ImageUpload
-                name='canvas.assets'
-                hasVideo
-                src={campaign.canvas.assets[0] ? campaign.canvas.assets[0].url : ''}
-                onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
-                disabled={false} />
-            </Col>
-            <Col lg>
-              <label>Logo</label>
-              <ImageUpload
-                name='canvas.logo'
-                src={campaign.canvas && campaign.canvas.logo}
-                onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
-                disabled={false} />
-            </Col>
-          </Row>
-        </Col>
-      </Row>
-    </div>
-  )
-}
-
-const onImageInputChange = (key, value, i, onChange) => {
-  if (key.includes('assets')) {
-    value = value.length ? [{url: value}] : []
+export default class Canvas extends React.Component {
+  renderAssets = () => {
+    const { assets } = this.props.campaign.canvas
+    const uploads = assets.map((asset, imgIndex) => {
+      return this.renderImageUpload(assets, imgIndex)
+    })
+    return uploads
   }
-  onChange(key, value, i)
+
+  renderImageUpload = (assets, imgIndex) => {
+    return (
+      <ImageUpload
+        key={'canvas-assets-' + imgIndex}
+        name='canvas.assets'
+        hasVideo
+        src={assets[imgIndex].url}
+        onChange={(name, url) => this.onImageInputChange(name, url, imgIndex)}
+        disabled={false} />
+    )
+  }
+
+  onSlideshowImageChange = (imgIndex, url) => {
+    const { assets } = this.props.campaign.canvas
+
+    if (imgIndex || imgIndex === 0) {
+      if (url.length) {
+        assets[imgIndex].url = url
+      } else {
+        assets.splice(imgIndex, 1)
+      }
+    } else {
+      assets.push({ url })
+    }
+    return assets
+  }
+
+  onImageInputChange = (key, value, imgIndex) => {
+    const { canvas } = this.props.campaign
+    let newValue
+    if (canvas.layout === 'slideshow') {
+      newValue = this.onSlideshowImageChange(imgIndex, value)
+    } else {
+      newValue = value.length ? [{url: value}] : []
+    }
+    this.props.onChange(key, newValue, this.props.index)
+  }
+
+  render () {
+    const {campaign, index, onChange} = this.props
+    return (
+      <div className='display-admin__section--campaign'>
+        <Row key={index} className='inputs--text'>
+          <Col lg>
+            <div className='field-group'>
+              {campaign.canvas.layout === 'overlay'
+                ? <CharacterLimitInput
+                    type='textarea'
+                    label='Body'
+                    placeholder='Body'
+                    defaultValue={campaign.canvas ? campaign.canvas.body : ''}
+                    onChange={(html) => onChange('canvas.body', html, index)}
+                    html
+                    limit={90} />
+                : <CharacterLimitInput
+                    label='headline'
+                    placeholder='Headline'
+                    defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
+                    onChange={(e) => onChange('canvas.headline', e.target.value, index)}
+                    limit={25} />
+                }
+            </div>
+            <div className='field-group'>
+              <CharacterLimitInput
+                label='CTA Text'
+                placeholder='Find Out More'
+                defaultValue={campaign.canvas && campaign.canvas.link ? campaign.canvas.link.text : ''}
+                onChange={(e) => onChange('canvas.link.text', e.target.value, index)}
+                limit={25} />
+            </div>
+            <div className='field-group'>
+              <label>CTA Link</label>
+              <input
+                className='bordered-input'
+                placeholder='Find Out More'
+                defaultValue={campaign.canvas && campaign.canvas.link ? campaign.canvas.link.url : ''}
+                onChange={(e) => onChange('canvas.link.url', e.target.value, index)} />
+            </div>
+            <div className='field-group'>
+              <CharacterLimitInput
+                type='textarea'
+                label='Disclaimer (optional)'
+                placeholder='Enter legal disclaimer here'
+                defaultValue={campaign.canvas ? campaign.canvas.body : ''}
+                onChange={(e) => onChange('canvas.body', e.target.value, index)}
+                limit={90} />
+            </div>
+          </Col>
+          <Col lg>
+            <Row key={index} className='inputs--images'>
+              <Col lg>
+                <label>Image</label>
+                {campaign.canvas.layout === 'slideshow'
+                  ? this.renderAssets(campaign, index, onChange)
+                  : this.renderImageUpload(campaign.canvas.assets, 0)
+                }
+              </Col>
+              <Col lg>
+                <label>Logo</label>
+                <ImageUpload
+                  name='canvas.logo'
+                  src={campaign.canvas && campaign.canvas.logo}
+                  onChange={(name, url) => onChange(name, url, this.props.index)}
+                  disabled={false} />
+              </Col>
+            </Row>
+          </Col>
+        </Row>
+      </div>
+    )
+  }
 }
 
 Canvas.propTypes = {
@@ -93,5 +132,3 @@ Canvas.propTypes = {
   index: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired
 }
-
-export default Canvas

--- a/client/apps/settings/client/curations/display/components/canvas.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas.jsx
@@ -20,7 +20,7 @@ export default class Canvas extends React.Component {
         key={'canvas-assets-' + imgIndex}
         name='canvas.assets'
         hasVideo
-        src={assets[imgIndex].url}
+        src={assets[imgIndex] ? assets[imgIndex].url : ''}
         onChange={(name, url) => this.onImageInputChange(name, url, imgIndex)}
         disabled={false} />
     )
@@ -108,7 +108,7 @@ export default class Canvas extends React.Component {
                 <label>Image</label>
                 {campaign.canvas.layout === 'slideshow'
                   ? this.renderAssets(campaign, index, onChange)
-                  : this.renderImageUpload(campaign.canvas.assets, 0)
+                  : this.renderImageUpload(campaign.canvas.assets || [], 0)
                 }
               </Col>
               <Col lg>

--- a/client/apps/settings/client/curations/display/components/canvas.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas.jsx
@@ -2,70 +2,69 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Col, Row } from 'react-styled-flexboxgrid'
 
-import CanvasImages from './canvas_images.jsx'
-import CharacterLimitInput from 'client/components/character_limit/index.jsx'
+import { CanvasImages } from './canvas_images.jsx'
+import { CharacterLimit } from 'client/components/character_limit/index.jsx'
 
-export default class Canvas extends React.Component {
-  render () {
-    const {campaign, index, onChange} = this.props
-    return (
-      <div className='display-admin__section--campaign'>
-        <Row key={index} className='inputs--text'>
-          <Col lg>
-            <div className='field-group'>
-              {campaign.canvas.layout === 'overlay'
-                ? <CharacterLimitInput
-                    type='textarea'
-                    label='Body'
-                    placeholder='Body'
-                    defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
-                    onChange={(html) => onChange('canvas.headline', html, index)}
-                    limit={70} />
-                : <CharacterLimitInput
-                    label='headline'
-                    placeholder='Headline'
-                    defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
-                    onChange={(e) => onChange('canvas.headline', e.target.value, index)}
-                    limit={45} />
-                }
-            </div>
-            <div className='field-group'>
-              <CharacterLimitInput
-                label='CTA Text'
-                placeholder='Find Out More'
-                defaultValue={campaign.canvas && campaign.canvas.link ? campaign.canvas.link.text : ''}
-                onChange={(e) => onChange('canvas.link.text', e.target.value, index)}
-                limit={25} />
-            </div>
-            <div className='field-group'>
-              <label>CTA Link</label>
-              <input
-                className='bordered-input'
-                placeholder='Find Out More'
-                defaultValue={campaign.canvas && campaign.canvas.link ? campaign.canvas.link.url : ''}
-                onChange={(e) => onChange('canvas.link.url', e.target.value, index)} />
-            </div>
-            <div className='field-group'>
-              <CharacterLimitInput
-                type='textarea'
-                label='Disclaimer (optional)'
-                placeholder='Enter legal disclaimer here'
-                defaultValue={campaign.canvas ? campaign.canvas.body : ''}
-                onChange={(e) => onChange('canvas.body', e.target.value, index)}
-                limit={150} />
-            </div>
-          </Col>
-          <Col lg>
-            <CanvasImages
-              key={index}
-              campaign={campaign}
-              index={index}
-              onChange={onChange} />
-          </Col>
-        </Row>
-      </div>
-    )
-  }
+export const Canvas = (props) => {
+  const { campaign, index, onChange } = props
+  const { canvas } = campaign
+  return (
+    <div className='display-admin__section--campaign'>
+      <Row key={index} className='inputs--text'>
+        <Col lg>
+          <div className='field-group'>
+            {campaign.canvas.layout === 'overlay'
+              ? <CharacterLimit
+                  type='textarea'
+                  label='Body'
+                  placeholder='Body'
+                  defaultValue={canvas.headline || ''}
+                  onChange={(html) => onChange('canvas.headline', html, index)}
+                  limit={70} />
+              : <CharacterLimit
+                  label='headline'
+                  placeholder='Headline'
+                  defaultValue={canvas.headline || ''}
+                  onChange={(e) => onChange('canvas.headline', e.target.value, index)}
+                  limit={45} />
+              }
+          </div>
+          <div className='field-group'>
+            <CharacterLimit
+              label='CTA Text'
+              placeholder='Find Out More'
+              defaultValue={canvas.link ? canvas.link.text : ''}
+              onChange={(e) => onChange('canvas.link.text', e.target.value, index)}
+              limit={25} />
+          </div>
+          <div className='field-group'>
+            <label>CTA Link</label>
+            <input
+              className='bordered-input'
+              placeholder='Find Out More'
+              defaultValue={canvas.link ? campaign.canvas.link.url : ''}
+              onChange={(e) => onChange('canvas.link.url', e.target.value, index)} />
+          </div>
+          <div className='field-group'>
+            <CharacterLimit
+              type='textarea'
+              label='Disclaimer (optional)'
+              placeholder='Enter legal disclaimer here'
+              defaultValue={canvas.body || ''}
+              onChange={(e) => onChange('canvas.body', e.target.value, index)}
+              limit={150} />
+          </div>
+        </Col>
+        <Col lg>
+          <CanvasImages
+            key={index}
+            campaign={campaign}
+            index={index}
+            onChange={onChange} />
+        </Col>
+      </Row>
+    </div>
+  )
 }
 
 Canvas.propTypes = {

--- a/client/apps/settings/client/curations/display/components/canvas.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas.jsx
@@ -1,0 +1,97 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Col, Row } from 'react-styled-flexboxgrid'
+
+import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
+import CharacterLimitInput from 'client/components/character_limit/index.jsx'
+
+const Canvas = (props) => {
+  const {campaign, index, onChange} = props
+  return (
+    <div className='display-admin__section--campaign'>
+      <Row key={index} className='inputs--text'>
+        <Col lg>
+          <div className='field-group'>
+            {campaign.canvas.layout === 'overlay'
+              ? <CharacterLimitInput
+                  type='textarea'
+                  label='Body'
+                  placeholder='Body'
+                  defaultValue={campaign.canvas ? campaign.canvas.body : ''}
+                  onChange={(html) => onChange('canvas.body', html, index)}
+                  html
+                  limit={90} />
+              : <CharacterLimitInput
+                  label='headline'
+                  placeholder='Headline'
+                  defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
+                  onChange={(e) => onChange('canvas.headline', e.target.value, index)}
+                  limit={25} />
+              }
+          </div>
+          <div className='field-group'>
+            <CharacterLimitInput
+              label='CTA Text'
+              placeholder='Find Out More'
+              defaultValue={campaign.canvas && campaign.canvas.link ? campaign.canvas.link.text : ''}
+              onChange={(e) => onChange('canvas.link.text', e.target.value, index)}
+              limit={25} />
+          </div>
+          <div className='field-group'>
+            <label>CTA Link</label>
+            <input
+              className='bordered-input'
+              placeholder='Find Out More'
+              defaultValue={campaign.canvas && campaign.canvas.link ? campaign.canvas.link.url : ''}
+              onChange={(e) => onChange('canvas.link.url', e.target.value, index)} />
+          </div>
+          <div className='field-group'>
+            <CharacterLimitInput
+              type='textarea'
+              label='Disclaimer (optional)'
+              placeholder='Enter legal disclaimer here'
+              defaultValue={campaign.canvas ? campaign.canvas.body : ''}
+              onChange={(e) => onChange('canvas.body', e.target.value, index)}
+              limit={90} />
+          </div>
+        </Col>
+        <Col lg>
+          <Row key={index} className='inputs--images'>
+            <Col lg>
+              <label>Image</label>
+              <ImageUpload
+                name='canvas.assets'
+                hasVideo
+                src={campaign.canvas.assets[0] ? campaign.canvas.assets[0].url : ''}
+                onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
+                disabled={false} />
+            </Col>
+            <Col lg>
+              <label>Logo</label>
+              <ImageUpload
+                name='canvas.logo'
+                src={campaign.canvas && campaign.canvas.logo}
+                onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
+                disabled={false} />
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+    </div>
+  )
+}
+
+const onImageInputChange = (key, value, i, onChange) => {
+  if (key.includes('assets')) {
+    value = value.length ? [{url: value}] : []
+  }
+  onChange(key, value, i)
+}
+
+Canvas.propTypes = {
+  campaign: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired
+}
+
+export default Canvas

--- a/client/apps/settings/client/curations/display/components/canvas.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas.jsx
@@ -2,58 +2,15 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Col, Row } from 'react-styled-flexboxgrid'
 
-import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
+import CanvasImages from './canvas_images.jsx'
 import CharacterLimitInput from 'client/components/character_limit/index.jsx'
 
 export default class Canvas extends React.Component {
-  renderAssets = () => {
-    const { assets } = this.props.campaign.canvas
-    const uploads = assets.map((asset, imgIndex) => {
-      return this.renderImageUpload(assets, imgIndex)
-    })
-    return uploads
-  }
-
-  renderImageUpload = (assets, imgIndex) => {
-    return (
-      <ImageUpload
-        key={'canvas-assets-' + imgIndex}
-        name='canvas.assets'
-        hasVideo
-        src={assets[imgIndex] ? assets[imgIndex].url : ''}
-        onChange={(name, url) => this.onImageInputChange(name, url, imgIndex)}
-        disabled={false} />
-    )
-  }
-
-  onSlideshowImageChange = (imgIndex, url) => {
-    const { assets } = this.props.campaign.canvas
-
-    if (imgIndex || imgIndex === 0) {
-      if (url.length) {
-        assets[imgIndex].url = url
-      } else {
-        assets.splice(imgIndex, 1)
-      }
-    } else {
-      assets.push({ url })
-    }
-    return assets
-  }
-
-  onImageInputChange = (key, value, imgIndex) => {
-    const { canvas } = this.props.campaign
-    let newValue
-    if (canvas.layout === 'slideshow') {
-      newValue = this.onSlideshowImageChange(imgIndex, value)
-    } else {
-      newValue = value.length ? [{url: value}] : []
-    }
-    this.props.onChange(key, newValue, this.props.index)
-  }
 
   render () {
     const {campaign, index, onChange} = this.props
+    const isSlideshow = campaign.canvas && campaign.canvas.layout === 'slideshow'
+
     return (
       <div className='display-admin__section--campaign'>
         <Row key={index} className='inputs--text'>
@@ -65,7 +22,7 @@ export default class Canvas extends React.Component {
                     label='Body'
                     placeholder='Body'
                     defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
-                    onChange={(html) => onChange('canvas.body', html, index)}
+                    onChange={(html) => onChange('canvas.headline', html, index)}
                     html
                     limit={70} />
                 : <CharacterLimitInput
@@ -103,23 +60,12 @@ export default class Canvas extends React.Component {
             </div>
           </Col>
           <Col lg>
-            <Row key={index} className='inputs--images'>
-              <Col lg>
-                <label>Image</label>
-                {campaign.canvas.layout === 'slideshow'
-                  ? this.renderAssets(campaign, index, onChange)
-                  : this.renderImageUpload(campaign.canvas.assets || [], 0)
-                }
-              </Col>
-              <Col lg>
-                <label>Logo</label>
-                <ImageUpload
-                  name='canvas.logo'
-                  src={campaign.canvas && campaign.canvas.logo}
-                  onChange={(name, url) => onChange(name, url, this.props.index)}
-                  disabled={false} />
-              </Col>
-            </Row>
+            <CanvasImages
+              key={index}
+              campaign={campaign}
+              index={index}
+              onChange={onChange}
+              isSlideshow={isSlideshow} />
           </Col>
         </Row>
       </div>

--- a/client/apps/settings/client/curations/display/components/canvas.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas.jsx
@@ -6,11 +6,8 @@ import CanvasImages from './canvas_images.jsx'
 import CharacterLimitInput from 'client/components/character_limit/index.jsx'
 
 export default class Canvas extends React.Component {
-
   render () {
     const {campaign, index, onChange} = this.props
-    const isSlideshow = campaign.canvas && campaign.canvas.layout === 'slideshow'
-
     return (
       <div className='display-admin__section--campaign'>
         <Row key={index} className='inputs--text'>
@@ -23,7 +20,6 @@ export default class Canvas extends React.Component {
                     placeholder='Body'
                     defaultValue={campaign.canvas ? campaign.canvas.headline : ''}
                     onChange={(html) => onChange('canvas.headline', html, index)}
-                    html
                     limit={70} />
                 : <CharacterLimitInput
                     label='headline'
@@ -64,8 +60,7 @@ export default class Canvas extends React.Component {
               key={index}
               campaign={campaign}
               index={index}
-              onChange={onChange}
-              isSlideshow={isSlideshow} />
+              onChange={onChange} />
           </Col>
         </Row>
       </div>

--- a/client/apps/settings/client/curations/display/components/canvas_container.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas_container.jsx
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import Canvas from './canvas.jsx'
+
+export default class CanvasContainer extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      activeLayout: props.campaign.canvas.layout || 'overlay'
+    }
+  }
+
+  setActiveLayout = (layout) => {
+    layout = layout === this.state.activeLayout ? null : layout
+    this.setState({activeLayout: layout})
+    this.props.onChange('canvas.layout', layout, this.props.index)
+  }
+
+  render () {
+    const { campaign, index, onChange } = this.props
+    return (
+      <div className='display-admin--canvas'>
+        <div className='display-admin__section-title'>Canvas</div>
+        <div className='display-admin--canvas__layouts'>
+          <button
+            className='avant-garde-button'
+            onClick={() => this.setActiveLayout('overlay')}
+            data-active={this.state.activeLayout === 'overlay'}>
+            Overlay
+          </button>
+          <button
+            className='avant-garde-button'
+            onClick={() => this.setActiveLayout('standard')}
+            data-active={this.state.activeLayout === 'standard'}>
+            Image/Video
+          </button>
+          <button
+            className='avant-garde-button'
+            onClick={() => this.setActiveLayout('slideshow')}
+            data-active={this.state.activeLayout === 'slideshow'}>
+            Slideshow
+          </button>
+          </div>
+        <Canvas campaign={campaign} index={index} onChange={onChange} />
+      </div>
+    )
+  }
+}
+
+CanvasContainer.propTypes = {
+  campaign: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired
+}

--- a/client/apps/settings/client/curations/display/components/canvas_container.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas_container.jsx
@@ -11,7 +11,6 @@ export default class CanvasContainer extends React.Component {
   }
 
   setActiveLayout = (layout) => {
-    layout = layout === this.state.activeLayout ? null : layout
     this.setState({activeLayout: layout})
     this.props.onChange('canvas.layout', layout, this.props.index)
   }

--- a/client/apps/settings/client/curations/display/components/canvas_container.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas_container.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Canvas from './canvas.jsx'
+import { Canvas } from './canvas.jsx'
 
-export default class CanvasContainer extends React.Component {
+export class CanvasContainer extends React.Component {
   constructor (props) {
     super(props)
     this.state = {

--- a/client/apps/settings/client/curations/display/components/canvas_images.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas_images.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Col, Row } from 'react-styled-flexboxgrid'
 import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
 
-export default class CanvasImages extends React.Component {
+export class CanvasImages extends React.Component {
   onSlideshowImageChange = (imgIndex, url) => {
     const { assets } = this.props.campaign.canvas
     if (imgIndex || imgIndex === 0) {

--- a/client/apps/settings/client/curations/display/components/canvas_images.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas_images.jsx
@@ -28,6 +28,10 @@ export default class CanvasImages extends React.Component {
     this.props.onChange(key, newValue, this.props.index)
   }
 
+  isSlideshow = () => {
+    return this.props.campaign.canvas && this.props.campaign.canvas.layout === 'slideshow'
+  }
+
   renderAssets = () => {
     const { assets } = this.props.campaign.canvas
     const uploads = assets.map((asset, imgIndex) => {
@@ -46,13 +50,14 @@ export default class CanvasImages extends React.Component {
   }
 
   renderSlideshowImages = () => {
+    const { assets } = this.props.campaign.canvas
+    const newImage = <Col lg className='add-new'>{this.renderImageUpload(assets)}</Col>
     return (
       <Row className='slideshow-images'>
         {this.renderAssets()}
-        {this.props.campaign.canvas.assets.length < 5 &&
-          <Col lg className='add-new'>
-            {this.renderImageUpload(this.props.campaign.canvas.assets)}
-          </Col>
+        {assets.length && assets.length < 5 
+          ? newImage
+          : false
         }
       </Row>
     )
@@ -73,7 +78,7 @@ export default class CanvasImages extends React.Component {
   }
 
   renderImageUpload = (assets, imgIndex) => {
-    const hasVideo = this.props.campaign.canvas.layout !== 'slideshow'
+    const hasVideo = this.props.campaign.canvas.layout === 'standard'
     const hidePreview = !imgIndex && imgIndex !== 0 && !hasVideo
     return (
       <ImageUpload
@@ -82,15 +87,15 @@ export default class CanvasImages extends React.Component {
         hasVideo={hasVideo}
         hidePreview={hidePreview}
         src={assets[imgIndex] ? assets[imgIndex].url : ''}
-        onChange={(name, url) => this.onImageInputChange(name, url, imgIndex)} />
+        onChange={(name, url) => this.onImageInputChange(name, url, imgIndex || null)} />
     )
   }
 
   renderLabel = (imgIndex) => {
-    const { campaign, isSlideshow } = this.props
+    const { campaign } = this.props
     if (campaign.canvas.layout === 'overlay') {
       return 'Background Image'
-    } else if (isSlideshow) {
+    } else if (this.isSlideshow()) {
       const index = imgIndex ? imgIndex + 1 : 1
       return 'Image ' + index.toString()
     } else {
@@ -99,8 +104,7 @@ export default class CanvasImages extends React.Component {
   }
 
   render () {
-    const { campaign, isSlideshow } = this.props
-
+    const { campaign } = this.props
     return (
       <div
         className='display-admin--canvas-images'
@@ -112,7 +116,7 @@ export default class CanvasImages extends React.Component {
             {this.renderImageUpload(campaign.canvas.assets || [], 0)}
           </Col>
         </Row>
-        {isSlideshow && this.renderSlideshowImages()}
+        {this.isSlideshow() && this.renderSlideshowImages()}
       </div>
     )
   }
@@ -121,6 +125,5 @@ export default class CanvasImages extends React.Component {
 CanvasImages.propTypes = {
   campaign: PropTypes.object.isRequired,
   index: PropTypes.number.isRequired,
-  isSlideshow: PropTypes.bool,
   onChange: PropTypes.func.isRequired
 }

--- a/client/apps/settings/client/curations/display/components/canvas_images.jsx
+++ b/client/apps/settings/client/curations/display/components/canvas_images.jsx
@@ -1,0 +1,126 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Col, Row } from 'react-styled-flexboxgrid'
+import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
+
+export default class CanvasImages extends React.Component {
+  onSlideshowImageChange = (imgIndex, url) => {
+    const { assets } = this.props.campaign.canvas
+    if (imgIndex || imgIndex === 0) {
+      if (url.length) {
+        assets[imgIndex].url = url
+      } else {
+        assets.splice(imgIndex, 1)
+      }
+    } else {
+      assets.push({ url })
+    }
+    return assets
+  }
+
+  onImageInputChange = (key, value, imgIndex) => {
+    let newValue
+    if (this.props.campaign.canvas.layout === 'slideshow') {
+      newValue = this.onSlideshowImageChange(imgIndex, value)
+    } else {
+      newValue = value.length ? [{url: value}] : []
+    }
+    this.props.onChange(key, newValue, this.props.index)
+  }
+
+  renderAssets = () => {
+    const { assets } = this.props.campaign.canvas
+    const uploads = assets.map((asset, imgIndex) => {
+      if (imgIndex === 0) {
+        return false
+      } else {
+        return (
+          <Col lg key={'slideshow-image-' + imgIndex}>
+            <label>{this.renderLabel(imgIndex)}</label>
+            {this.renderImageUpload(assets, imgIndex)}
+          </Col>
+        )
+      }
+    })
+    return uploads
+  }
+
+  renderSlideshowImages = () => {
+    return (
+      <Row className='slideshow-images'>
+        {this.renderAssets()}
+        {this.props.campaign.canvas.assets.length < 5 &&
+          <Col lg className='add-new'>
+            {this.renderImageUpload(this.props.campaign.canvas.assets)}
+          </Col>
+        }
+      </Row>
+    )
+  }
+
+  renderLogoUpload = () => {
+    const {campaign, index, onChange} = this.props
+    return (
+      <Col lg>
+        <label>Logo</label>
+        <ImageUpload
+          name='canvas.logo'
+          src={campaign.canvas && campaign.canvas.logo}
+          onChange={(name, url) => onChange(name, url, index)}
+          disabled={false} />
+      </Col>
+    )
+  }
+
+  renderImageUpload = (assets, imgIndex) => {
+    const hasVideo = this.props.campaign.canvas.layout !== 'slideshow'
+    const hidePreview = !imgIndex && imgIndex !== 0 && !hasVideo
+    return (
+      <ImageUpload
+        key={'canvas-assets-' + (imgIndex || 0)}
+        name='canvas.assets'
+        hasVideo={hasVideo}
+        hidePreview={hidePreview}
+        src={assets[imgIndex] ? assets[imgIndex].url : ''}
+        onChange={(name, url) => this.onImageInputChange(name, url, imgIndex)} />
+    )
+  }
+
+  renderLabel = (imgIndex) => {
+    const { campaign, isSlideshow } = this.props
+    if (campaign.canvas.layout === 'overlay') {
+      return 'Background Image'
+    } else if (isSlideshow) {
+      const index = imgIndex ? imgIndex + 1 : 1
+      return 'Image ' + index.toString()
+    } else {
+      return 'Image / Video'
+    }
+  }
+
+  render () {
+    const { campaign, isSlideshow } = this.props
+
+    return (
+      <div
+        className='display-admin--canvas-images'
+        data-layout={campaign.canvas.layout || 'overlay'}>
+        <Row>
+          {this.renderLogoUpload()}
+          <Col lg>
+            <label>{this.renderLabel()}</label>
+            {this.renderImageUpload(campaign.canvas.assets || [], 0)}
+          </Col>
+        </Row>
+        {isSlideshow && this.renderSlideshowImages()}
+      </div>
+    )
+  }
+}
+
+CanvasImages.propTypes = {
+  campaign: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  isSlideshow: PropTypes.bool,
+  onChange: PropTypes.func.isRequired
+}

--- a/client/apps/settings/client/curations/display/components/panel.jsx
+++ b/client/apps/settings/client/curations/display/components/panel.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Col, Row } from 'react-styled-flexboxgrid'
+import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
+import CharacterLimitInput from 'client/components/character_limit/index.jsx'
+
+const Panel = (props) => {
+  const {campaign, index, onChange} = props
+  return (
+    <div className='display-admin__section--panel'>
+      <div className='display-admin__section-title'>Panel</div>
+        <Row key={index}>
+          <Col lg>
+            <div className='field-group'>
+              <CharacterLimitInput
+                label='headline'
+                placeholder='Headline'
+                defaultValue={campaign.panel ? campaign.panel.headline : ''}
+                onChange={(e) => onChange('panel.headline', e.target.value, index)}
+                limit={25} />
+            </div>
+            <div className='field-group'>
+            <label>CTA link</label>
+            <input
+              className='bordered-input'
+              placeholder='Find Out More'
+              defaultValue={campaign.canvas && campaign.panel.link ? campaign.panel.link.url : ''}
+              onChange={(e) => onChange('canvas.link.url', e.target.value, index)} />
+            </div>
+            <div className='field-group'>
+              <CharacterLimitInput
+                type='textarea'
+                label='Body'
+                placeholder='Body'
+                defaultValue={campaign.panel ? campaign.panel.body : ''}
+                onChange={(html) => onChange('panel.body', html, index)}
+                html
+                limit={90} />
+            </div>
+          </Col>
+          <Col lg>
+            <Row key={index}>
+              <Col lg>
+                <label>Image</label>
+                <ImageUpload
+                  name='panel.assets'
+                  src={campaign.panel.assets[0] ? campaign.panel.assets[0].url : ''}
+                  onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
+                  disabled={false} />
+              </Col>
+              <Col lg>
+                <label>Logo</label>
+                <ImageUpload
+                  name='panel.logo'
+                  src={campaign.panel && campaign.panel.logo}
+                  onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
+                  disabled={false} />
+              </Col>
+            </Row>
+          </Col>
+        </Row>
+    </div>
+  )
+}
+
+const onImageInputChange = (key, value, i, onChange) => {
+  if (key.includes('assets')) {
+    value = value.length ? [{url: value}] : []
+  }
+  onChange(key, value, i)
+}
+
+Panel.propTypes = {
+  campaign: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired
+}
+
+export default Panel

--- a/client/apps/settings/client/curations/display/components/panel.jsx
+++ b/client/apps/settings/client/curations/display/components/panel.jsx
@@ -35,7 +35,7 @@ const Panel = (props) => {
                 defaultValue={campaign.panel ? campaign.panel.body : ''}
                 onChange={(html) => onChange('panel.body', html, index)}
                 html
-                limit={90} />
+                limit={45} />
             </div>
           </Col>
           <Col lg>

--- a/client/apps/settings/client/curations/display/components/panel.jsx
+++ b/client/apps/settings/client/curations/display/components/panel.jsx
@@ -13,10 +13,10 @@ const Panel = (props) => {
           <Col lg>
             <div className='field-group'>
               <CharacterLimitInput
-                label='headline'
+                label='Headline'
                 placeholder='Headline'
                 defaultValue={campaign.panel ? campaign.panel.headline : ''}
-                onChange={(e) => onChange('panel.headline', e.target.value, index)}
+                onChange={(value) => onChange('panel.headline', value, index)}
                 limit={25} />
             </div>
             <div className='field-group'>
@@ -25,7 +25,7 @@ const Panel = (props) => {
               className='bordered-input'
               placeholder='Find Out More'
               defaultValue={campaign.canvas && campaign.panel.link ? campaign.panel.link.url : ''}
-              onChange={(e) => onChange('canvas.link.url', e.target.value, index)} />
+              onChange={(e) => onChange('panel.link.url', e.target.value, index)} />
             </div>
             <div className='field-group'>
               <CharacterLimitInput
@@ -33,7 +33,7 @@ const Panel = (props) => {
                 label='Body'
                 placeholder='Body'
                 defaultValue={campaign.panel ? campaign.panel.body : ''}
-                onChange={(html) => onChange('panel.body', html, index)}
+                onChange={(value) => onChange('panel.body', value, index)}
                 html
                 limit={45} />
             </div>
@@ -45,16 +45,14 @@ const Panel = (props) => {
                 <ImageUpload
                   name='panel.assets'
                   src={campaign.panel.assets && campaign.panel.assets[0] ? campaign.panel.assets[0].url : ''}
-                  onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
-                  disabled={false} />
+                  onChange={(name, url) => onImageInputChange(name, url, index, onChange)} />
               </Col>
               <Col lg>
                 <label>Logo</label>
                 <ImageUpload
                   name='panel.logo'
                   src={campaign.panel && campaign.panel.logo}
-                  onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
-                  disabled={false} />
+                  onChange={(name, url) => onImageInputChange(name, url, index, onChange)} />
               </Col>
             </Row>
           </Col>

--- a/client/apps/settings/client/curations/display/components/panel.jsx
+++ b/client/apps/settings/client/curations/display/components/panel.jsx
@@ -2,17 +2,17 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Col, Row } from 'react-styled-flexboxgrid'
 import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
-import CharacterLimitInput from 'client/components/character_limit/index.jsx'
+import { CharacterLimit } from 'client/components/character_limit/index.jsx'
 
-const Panel = (props) => {
-  const {campaign, index, onChange} = props
+export const Panel = (props) => {
+  const { campaign, index, onChange } = props
   return (
     <div className='display-admin__section--panel'>
       <div className='display-admin__section-title'>Panel</div>
         <Row key={index}>
           <Col lg>
             <div className='field-group'>
-              <CharacterLimitInput
+              <CharacterLimit
                 label='Headline'
                 placeholder='Headline'
                 defaultValue={campaign.panel ? campaign.panel.headline : ''}
@@ -28,7 +28,7 @@ const Panel = (props) => {
               onChange={(e) => onChange('panel.link.url', e.target.value, index)} />
             </div>
             <div className='field-group'>
-              <CharacterLimitInput
+              <CharacterLimit
                 type='textarea'
                 label='Body'
                 placeholder='Body'
@@ -44,7 +44,7 @@ const Panel = (props) => {
                 <label>Image</label>
                 <ImageUpload
                   name='panel.assets'
-                  src={campaign.panel.assets && campaign.panel.assets[0] ? campaign.panel.assets[0].url : ''}
+                  src={campaign.panel.assets && campaign.panel.assets.length ? campaign.panel.assets[0].url : ''}
                   onChange={(name, url) => onImageInputChange(name, url, index, onChange)} />
               </Col>
               <Col lg>

--- a/client/apps/settings/client/curations/display/components/panel.jsx
+++ b/client/apps/settings/client/curations/display/components/panel.jsx
@@ -44,7 +44,7 @@ const Panel = (props) => {
                 <label>Image</label>
                 <ImageUpload
                   name='panel.assets'
-                  src={campaign.panel.assets[0] ? campaign.panel.assets[0].url : ''}
+                  src={campaign.panel.assets && campaign.panel.assets[0] ? campaign.panel.assets[0].url : ''}
                   onChange={(name, url) => onImageInputChange(name, url, index, onChange)}
                   disabled={false} />
               </Col>

--- a/client/apps/settings/client/curations/display/index.jsx
+++ b/client/apps/settings/client/curations/display/index.jsx
@@ -1,10 +1,10 @@
-import set from 'lodash.set'
+import { set } from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import CanvasContainer from './components/canvas_container.jsx'
-import Campaign from './components/campaign.jsx'
-import Panel from './components/panel.jsx'
+import { CanvasContainer } from './components/canvas_container.jsx'
+import { Campaign } from './components/campaign.jsx'
+import { Panel } from './components/panel.jsx'
 import DropDownItem from 'client/components/drop_down/index.jsx'
 
 export default class DisplayAdmin extends React.Component {

--- a/client/apps/settings/client/curations/display/index.jsx
+++ b/client/apps/settings/client/curations/display/index.jsx
@@ -1,0 +1,76 @@
+import set from 'lodash.set'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import CanvasContainer from './components/canvas_container.jsx'
+import Campaign from './components/campaign.jsx'
+import Panel from './components/panel.jsx'
+import DropDownItem from 'client/components/drop_down/index.jsx'
+
+export default class DisplayAdmin extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      curation: props.curation,
+      saveStatus: 'Saved',
+      activeSection: 0
+    }
+  }
+
+  setActiveSection = (i) => {
+    i = i === this.state.activeSection ? null : i
+    this.setState({activeSection: i})
+  }
+
+  onChange = (key, value, index) => {
+    const newCuration = this.state.curation.clone()
+    const campaign = newCuration.get('campaigns')[index]
+    set(campaign, key, value)
+    this.setState({
+      curation: newCuration,
+      saveStatus: 'Save'
+    })
+  }
+
+  save = () => {
+    this.state.curation.save({}, {
+      success: () => this.setState({ saveStatus: 'Saved' }),
+      error: error => this.setState({ saveStatus: 'Error' })
+    })
+  }
+
+  render () {
+    const saveColor = this.state.saveStatus !== 'Saved' ? 'rgb(247, 98, 90)' : 'black'
+    return (
+      <div className='display-admin'>
+        {this.state.curation.get('campaigns').map((campaign, index) =>
+          <div className='admin-form-container' key={`display-admin-${index}`}>
+            <DropDownItem
+              active={index === this.state.activeSection}
+              index={index}
+              onClick={() => this.setActiveSection(index)}
+              title={campaign.name}>
+              {this.state.activeSection === index &&
+                <div className='display-admin__section-inner'>
+                  <Campaign campaign={campaign} index={index} onChange={this.onChange} />
+                  <Panel campaign={campaign} index={index} onChange={this.onChange} />
+                  <CanvasContainer campaign={campaign} index={index} onChange={this.onChange} />
+                </div>
+              }
+            </DropDownItem>
+          </div>
+        )}
+        <button
+          className='save-campaign avant-garde-button'
+          onClick={this.save}
+          style={{color: saveColor}}>
+          {this.state.saveStatus}
+        </button>
+      </div>
+    )
+  }
+}
+
+DisplayAdmin.propTypes = {
+  curation: PropTypes.object.isRequired
+}

--- a/client/apps/settings/client/curations/display/index.jsx
+++ b/client/apps/settings/client/curations/display/index.jsx
@@ -45,7 +45,8 @@ export default class DisplayAdmin extends React.Component {
     newCuration.get('campaigns').push(newCampaign)
     this.setState({
       curation: newCuration,
-      saveStatus: 'Save'
+      saveStatus: 'Save',
+      activeSection: newCuration.get('campaigns').length - 1
     })
   }
 

--- a/client/apps/settings/client/curations/display/index.jsx
+++ b/client/apps/settings/client/curations/display/index.jsx
@@ -13,7 +13,7 @@ export default class DisplayAdmin extends React.Component {
     this.state = {
       curation: props.curation,
       saveStatus: 'Saved',
-      activeSection: 0
+      activeSection: null
     }
   }
 
@@ -36,6 +36,16 @@ export default class DisplayAdmin extends React.Component {
     this.state.curation.save({}, {
       success: () => this.setState({ saveStatus: 'Saved' }),
       error: error => this.setState({ saveStatus: 'Error' })
+    })
+  }
+
+  newCampaign = () => {
+    const newCuration = this.state.curation.clone()
+    const newCampaign = {panel: {assets: []}, canvas: {assets: []}}
+    newCuration.get('campaigns').push(newCampaign)
+    this.setState({
+      curation: newCuration,
+      saveStatus: 'Save'
     })
   }
 
@@ -65,6 +75,11 @@ export default class DisplayAdmin extends React.Component {
           onClick={this.save}
           style={{color: saveColor}}>
           {this.state.saveStatus}
+        </button>
+        <button
+          className='new-campaign avant-garde-button avant-garde-button-dark'
+          onClick={this.newCampaign}>
+          Add New Campaign
         </button>
       </div>
     )

--- a/client/apps/settings/client/curations/display/index.styl
+++ b/client/apps/settings/client/curations/display/index.styl
@@ -30,7 +30,7 @@
   .save-campaign
     position fixed
     top 10px
-    right calc(50vw + 55px - (1120px / 2))
+    right calc(50vw + 55px - (1120px / 2)) // align button to right contianer edge
     z-index 110
   .new-campaign
     margin-top 40px

--- a/client/apps/settings/client/curations/display/index.styl
+++ b/client/apps/settings/client/curations/display/index.styl
@@ -46,3 +46,14 @@
     &[data-active=true]
       color white
       background black
+  &-images
+    .slideshow-images
+      div[class^="Col__Col-"]
+        margin-top 20px
+        min-width 50%
+      .add-new
+        margin-top 2em
+    &[data-layout=overlay],
+    &[data-layout=standard]
+      div[class^="Row__Row-"]
+        flex-direction row-reverse

--- a/client/apps/settings/client/curations/display/index.styl
+++ b/client/apps/settings/client/curations/display/index.styl
@@ -7,7 +7,7 @@
   &__section--campaign,
   &__section--panel
     margin 30px 0
-  .rich-text--paragraph
+  .rich-text--paragraph, .plain-text
     position relative
     min-height 4.25em
     p

--- a/client/apps/settings/client/curations/display/index.styl
+++ b/client/apps/settings/client/curations/display/index.styl
@@ -1,0 +1,44 @@
+.display-admin
+  margin-top 80px
+  &__section-title
+    Garamond s23
+    margin-bottom 20px
+  &__section-inner,
+  &__section--campaign,
+  &__section--panel
+    margin 30px 0
+  .rich-text--paragraph
+    position relative
+    min-height 4.25em
+    p
+      font-size 1em
+    .public-DraftEditorPlaceholder-root
+      position absolute
+      color gray-darker-color
+  label
+    display flex
+    justify-content space-between
+    span
+      color gray-color
+      garamond s-caption
+      text-transform none
+      letter-spacing 0
+  select
+    height 2.5em
+  .field-group
+    margin-bottom 20px
+  .save-campaign
+    position fixed
+    top 10px
+    right calc(50vw + 55px - (1120px / 2))
+    z-index 110
+
+.display-admin--canvas
+  &__layouts button
+    padding 12px 20px
+    &:first-child,
+    &:nth-child(2)
+      border-right 0
+    &[data-active=true]
+      color white
+      background black

--- a/client/apps/settings/client/curations/display/index.styl
+++ b/client/apps/settings/client/curations/display/index.styl
@@ -32,6 +32,10 @@
     top 10px
     right calc(50vw + 55px - (1120px / 2))
     z-index 110
+  .new-campaign
+    margin-top 40px
+    width 100%
+    padding 20px
 
 .display-admin--canvas
   &__layouts button

--- a/client/apps/settings/client/curations/display/tests/components/campaign.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/campaign.test.js
@@ -75,7 +75,7 @@ describe('Campaign Admin', () => {
     expect(props.onChange.mock.calls[2][2]).toBe(props.index)
   })
 
-  it('changes the sov on select', () => {
+  it('Changes the sov on select', () => {
     const component = mount(
       <Campaign {...props} />
     )

--- a/client/apps/settings/client/curations/display/tests/components/campaign.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/campaign.test.js
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import React from 'react'
-import Campaign from '../../components/campaign.jsx'
+import { Campaign } from '../../components/campaign.jsx'
 import { mount } from 'enzyme'
 
 describe('Campaign Admin', () => {

--- a/client/apps/settings/client/curations/display/tests/components/campaign.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/campaign.test.js
@@ -1,0 +1,88 @@
+import moment from 'moment'
+import React from 'react'
+import Campaign from '../../components/campaign.jsx'
+import { mount } from 'enzyme'
+
+describe('Campaign Admin', () => {
+  const start_date = moment().toISOString()
+  const end_date = moment(start_date).add(30, 'days').toISOString()
+  const props = {
+    campaign: {
+      name: 'Sample Campaign',
+      start_date,
+      end_date,
+      sov: 0.75
+    },
+    index: 0,
+    onChange: jest.fn()
+  }
+
+  it('renders all fields ', () => {
+    const component = mount(
+      <Campaign {...props} />
+    )
+    expect(component.find('input').at(0).props().placeholder).toMatch('Partner Name')
+    expect(component.find('input[type="date"]').length).toBe(2)
+    expect(component.find('select').length).toBe(1)
+  })
+
+  it('renders saved data ', () => {
+    const component = mount(
+      <Campaign {...props} />
+    )
+    expect(component.find('input').at(0).node.value).toMatch(props.campaign.name)
+    expect(component.find('input[type="date"]').at(0).node.value).toMatch(
+      moment(start_date).format('YYYY-MM-DD')
+    )
+    expect(component.find('input[type="date"]').at(1).node.value).toMatch(
+      moment(end_date).format('YYYY-MM-DD')
+    )
+    expect(component.find('select').at(0).node.value).toBe(props.campaign.sov.toString())
+  })
+
+  it('Changes the campaign name on input', () => {
+    const component = mount(
+      <Campaign {...props} />
+    )
+    const input = component.find('input').at(0)
+    input.simulate('change', { target: { value: 'Campaign Sample' } })
+    expect(props.onChange.mock.calls[0][0]).toMatch('name')
+    expect(props.onChange.mock.calls[0][1]).toMatch('Campaign Sample')
+    expect(props.onChange.mock.calls[0][2]).toBe(props.index)
+  })
+
+  it('Changes the start date on input', () => {
+    const component = mount(
+      <Campaign {...props} />
+    )
+    const input = component.find('input[type="date"]').at(0)
+    const newDate = moment(start_date).add(1, 'year').toISOString()
+    input.simulate('change', { target: { value: newDate } })
+    expect(props.onChange.mock.calls[1][0]).toMatch('start_date')
+    expect(props.onChange.mock.calls[1][1]).toMatch(newDate)
+    expect(props.onChange.mock.calls[1][2]).toBe(props.index)
+  })
+
+  it('Changes the start date on input', () => {
+    const component = mount(
+      <Campaign {...props} />
+    )
+    const input = component.find('input[type="date"]').at(1)
+    const newDate = moment(end_date).add(1, 'year').toISOString()
+    input.simulate('change', { target: { value: newDate } })
+    expect(props.onChange.mock.calls[2][0]).toMatch('end_date')
+    expect(props.onChange.mock.calls[2][1]).toMatch(newDate)
+    expect(props.onChange.mock.calls[2][2]).toBe(props.index)
+  })
+
+  it('changes the sov on select', () => {
+    const component = mount(
+      <Campaign {...props} />
+    )
+    const input = component.find('select')
+    input.simulate('change', { target: { value: '0.25' } })
+    expect(props.onChange.mock.calls[3][0]).toMatch('sov')
+    expect(props.onChange.mock.calls[3][1]).toBe(0.25)
+    expect(props.onChange.mock.calls[3][2]).toBe(props.index)
+  })
+})

--- a/client/apps/settings/client/curations/display/tests/components/campaign.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/campaign.test.js
@@ -17,7 +17,7 @@ describe('Campaign Admin', () => {
     onChange: jest.fn()
   }
 
-  it('renders all fields ', () => {
+  it('renders all fields', () => {
     const component = mount(
       <Campaign {...props} />
     )
@@ -26,7 +26,7 @@ describe('Campaign Admin', () => {
     expect(component.find('select').length).toBe(1)
   })
 
-  it('renders saved data ', () => {
+  it('renders saved data', () => {
     const component = mount(
       <Campaign {...props} />
     )
@@ -63,7 +63,7 @@ describe('Campaign Admin', () => {
     expect(props.onChange.mock.calls[1][2]).toBe(props.index)
   })
 
-  it('Changes the start date on input', () => {
+  it('Changes the end date on input', () => {
     const component = mount(
       <Campaign {...props} />
     )

--- a/client/apps/settings/client/curations/display/tests/components/canvas_container.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/canvas_container.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import Canvas from '../../components/canvas.jsx'
-import CanvasContainer from '../../components/canvas_container.jsx'
+import { Canvas } from '../../components/canvas.jsx'
+import { CanvasContainer } from '../../components/canvas_container.jsx'
 import { mount } from 'enzyme'
 
 describe('Canvas Container', () => {

--- a/client/apps/settings/client/curations/display/tests/components/canvas_container.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/canvas_container.test.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import Canvas from '../../components/canvas.jsx'
+import CanvasContainer from '../../components/canvas_container.jsx'
+import { mount } from 'enzyme'
+
+describe('CanvasContainer', () => {
+  const props = {
+    campaign: {
+      canvas: {},
+      panel: {}
+    },
+    index: 0,
+    onChange: jest.fn()
+  }
+
+  it('renders all fields', () => {
+    const component = mount(
+      <CanvasContainer {...props} />
+    )
+    expect(component.find('.display-admin--canvas__layouts button').length).toBe(3)
+    expect(component.find(Canvas).length).toBe(1)
+  })
+
+  it('Sets the canvas layout to overlay by default', () => {
+    const component = mount(
+      <CanvasContainer {...props} />
+    )
+    expect(component.find('.display-admin--canvas__layouts button').at(0).props()['data-active']).toBe(true)
+  })
+
+  it('Canges the canvas layout on button click', () => {
+    const component = mount(
+      <CanvasContainer {...props} />
+    )
+    component.find('.display-admin--canvas__layouts button').at(2).simulate('click')
+    expect(props.onChange.mock.calls[0][0]).toMatch('canvas.layout')
+    expect(props.onChange.mock.calls[0][1]).toMatch('slideshow')
+    expect(props.onChange.mock.calls[0][2]).toBe(props.index)
+  })
+})

--- a/client/apps/settings/client/curations/display/tests/components/canvas_container.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/canvas_container.test.js
@@ -13,7 +13,7 @@ describe('Canvas Container', () => {
     onChange: jest.fn()
   }
 
-  it('renders all fields', () => {
+  it('Renders all fields', () => {
     const component = mount(
       <CanvasContainer {...props} />
     )
@@ -28,7 +28,7 @@ describe('Canvas Container', () => {
     expect(component.find('.display-admin--canvas__layouts button').at(0).props()['data-active']).toBe(true)
   })
 
-  it('Canges the canvas layout on button click', () => {
+  it('Changes the canvas layout on button click', () => {
     const component = mount(
       <CanvasContainer {...props} />
     )

--- a/client/apps/settings/client/curations/display/tests/components/canvas_container.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/canvas_container.test.js
@@ -3,7 +3,7 @@ import Canvas from '../../components/canvas.jsx'
 import CanvasContainer from '../../components/canvas_container.jsx'
 import { mount } from 'enzyme'
 
-describe('CanvasContainer', () => {
+describe('Canvas Container', () => {
   const props = {
     campaign: {
       canvas: {},

--- a/client/apps/settings/client/curations/display/tests/components/canvas_images.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/canvas_images.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import CanvasImages from '../../components/canvas_images.jsx'
+import { CanvasImages } from '../../components/canvas_images.jsx'
 import { mount } from 'enzyme'
 
 import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'

--- a/client/apps/settings/client/curations/display/tests/components/canvas_images.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/canvas_images.test.js
@@ -1,0 +1,218 @@
+import React from 'react'
+import CanvasImages from '../../components/canvas_images.jsx'
+import { mount } from 'enzyme'
+
+import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
+
+describe('Canvas Images', () => {
+  const props = {
+    campaign: {
+      canvas: {
+        layout: 'overlay',
+        assets: []
+      }
+    },
+    index: 0,
+    onChange: jest.fn()
+  }
+
+  describe('Overlay', () => {
+    it('renders expected fields', () => {
+      const component = mount(
+        <CanvasImages {...props} />
+      )
+      expect(component.html()).toMatch('data-layout="overlay"')
+      expect(component.find(ImageUpload).length).toBe(2)
+      expect(component.find('label').at(0).text()).toMatch('Logo')
+      expect(component.find('label').at(1).text()).toMatch('Background Image')
+      expect(component.find('input').at(1).props().accept).not.toContain('video/mp4')
+    })
+
+    it('renders saved data', () => {
+      props.campaign.canvas.logo = 'http://artsy.net/logo.jpg'
+      props.campaign.canvas.assets.push({url: 'http://artsy.net/image.jpg'})
+      const component = mount(
+        <CanvasImages {...props} />
+      )
+      expect(component.find(ImageUpload).at(0).props().src).toMatch(
+        props.campaign.canvas.logo
+      )
+      expect(component.html()).toMatch(
+        'style="background-image: url(http://artsy.net/logo.jpg)'
+      )
+      expect(component.find(ImageUpload).at(1).props().src).toMatch(
+        props.campaign.canvas.assets[0].url
+      )
+      expect(component.html()).toMatch(
+        'style="background-image: url(http://artsy.net/image.jpg)'
+      )
+    })
+  })
+
+  describe('Standard', () => {
+    it('renders expected fields', () => {
+      props.campaign.canvas.layout = 'standard'
+      const component = mount(
+        <CanvasImages {...props} />
+      )
+      expect(component.html()).toMatch('data-layout="standard"')
+      expect(component.find(ImageUpload).length).toBe(2)
+      expect(component.find('label').at(0).text()).toMatch('Logo')
+      expect(component.find('label').at(1).text()).toMatch('Image / Video')
+      expect(component.find('input').at(1).props().accept).toContain('video/mp4')
+    })
+
+    it('renders saved data', () => {
+      props.campaign.canvas.logo = 'http://artsy.net/logo.jpg'
+      props.campaign.canvas.assets = [{url: 'http://artsy.net/video.mp4'}]
+      const component = mount(
+        <CanvasImages {...props} />
+      )
+      expect(component.find(ImageUpload).at(0).props().src).toMatch(
+        props.campaign.canvas.logo
+      )
+      expect(component.html()).toMatch(
+        'style="background-image: url(http://artsy.net/logo.jpg)'
+      )
+      expect(component.find(ImageUpload).at(1).props().src).toMatch(
+        props.campaign.canvas.assets[0].url
+      )
+      expect(component.html()).not.toMatch(
+        'style="background-image: url(http://artsy.net/image.jpg)'
+      )
+      expect(component.html()).toMatch(
+        '<video src="http://artsy.net/video.mp4">'
+      )
+    })
+  })
+
+  describe('Slideshow', () => {
+    it('renders expected fields', () => {
+      props.campaign.canvas.assets = []
+      props.campaign.canvas.layout = 'slideshow'
+      const component = mount(
+        <CanvasImages {...props} />
+      )
+      expect(component.html()).toMatch('data-layout="slideshow"')
+      expect(component.find(ImageUpload).length).toBe(2)
+      expect(component.find('label').at(0).text()).toMatch('Logo')
+      expect(component.find('label').at(1).text()).toMatch('Image 1')
+      expect(component.find('input').at(1).props().accept).not.toContain('video/mp4')
+    })
+
+    it('renders saved data', () => {
+      props.campaign.canvas.logo = 'http://artsy.net/logo.jpg'
+      props.campaign.canvas.assets = [
+        {url: 'http://artsy.net/image1.jpg'},
+        {url: 'http://artsy.net/image2.jpg'}
+      ]
+      const component = mount(
+        <CanvasImages {...props} />
+      )
+      expect(component.find(ImageUpload).at(0).props().src).toMatch(
+        props.campaign.canvas.logo
+      )
+      expect(component.html()).toMatch(
+        'style="background-image: url(http://artsy.net/logo.jpg)'
+      )
+      expect(component.find(ImageUpload).at(1).props().src).toMatch(
+        props.campaign.canvas.assets[0].url
+      )
+      expect(component.html()).toMatch(
+        'style="background-image: url(http://artsy.net/image1.jpg)'
+      )
+      expect(component.find('label').at(2).text()).toMatch('Image 2')
+      expect(component.find(ImageUpload).at(2).props().src).toMatch(
+        props.campaign.canvas.assets[1].url
+      )
+      expect(component.html()).toMatch(
+        'style="background-image: url(http://artsy.net/image2.jpg)'
+      )
+    })
+  })
+
+  describe('Uploads', () => {
+    describe('Logo', () => {
+      it('Calls props.onChange on input change', () => {
+        const component = mount(
+          <CanvasImages {...props} />
+        )
+        const input = component.find(ImageUpload).at(0).node
+        input.props.onChange(input.props.name, 'http://new-logo.jpg')
+        const onChangeArgs = props.onChange.mock.calls[0]
+
+        expect(onChangeArgs[0]).toMatch('canvas.logo')
+        expect(onChangeArgs[1]).toMatch('http://new-logo.jpg')
+        expect(onChangeArgs[2]).toBe(props.index)
+      })
+
+      it('Can remove an existing file', () => {
+        const component = mount(
+          <CanvasImages {...props} />
+        )
+        component.find('.image-upload-form-remove').at(0).simulate('click')
+        expect(props.onChange.mock.calls[1][0]).toMatch('canvas.logo')
+        expect(props.onChange.mock.calls[1][2]).toBe(props.index)
+      })
+    })
+
+    describe('Assets', () => {
+      it('Calls props.onChange on image change', () => {
+        props.campaign.canvas.assets = []
+        props.campaign.canvas.layout = 'standard'
+        const component = mount(
+          <CanvasImages {...props} />
+        )
+        const input = component.find(ImageUpload).at(1).node
+        input.props.onChange(input.props.name, 'http://new-image.jpg')
+        const onChangeArgs = props.onChange.mock.calls[2]
+
+        expect(onChangeArgs[0]).toMatch('canvas.assets')
+        expect(onChangeArgs[1][0].url).toMatch('http://new-image.jpg')
+        expect(onChangeArgs[2]).toBe(props.index)
+      })
+
+      it('Replaces an existing image on change', () => {
+        props.campaign.canvas.assets = [{url: 'http://image.jpg'}]
+        const component = mount(
+          <CanvasImages {...props} />
+        )
+        const input = component.find(ImageUpload).at(1).node
+        input.props.onChange(input.props.name, 'http://new-image.jpg')
+        const onChangeArgs = props.onChange.mock.calls[3]
+
+        expect(onChangeArgs[0]).toMatch('canvas.assets')
+        expect(onChangeArgs[1][0].url).toMatch('http://new-image.jpg')
+        expect(onChangeArgs[2]).toBe(props.index)
+      })
+
+      it('Can remove an image', () => {
+        const component = mount(
+          <CanvasImages {...props} />
+        )
+        component.find('.image-upload-form-remove').at(1).simulate('click')
+        const onChangeArgs = props.onChange.mock.calls[4]
+
+        expect(onChangeArgs[0]).toMatch('canvas.assets')
+        expect(onChangeArgs[1].length).toBe(0)
+        expect(onChangeArgs[2]).toBe(props.index)
+      })
+
+      it('Can add additional images if slideshow', () => {
+        props.campaign.canvas.layout = 'slideshow'
+        props.campaign.canvas.assets = [{url: 'http://image1.jpg'}]
+        const component = mount(
+          <CanvasImages {...props} />
+        )
+        const input = component.find(ImageUpload).at(2).node
+        input.props.onChange(input.props.name, 'http://image2.jpg')
+        const onChangeArgs = props.onChange.mock.calls[5]
+
+        expect(onChangeArgs[0]).toMatch('canvas.assets')
+        expect(onChangeArgs[1][0].url).toMatch('http://image1.jpg')
+        expect(onChangeArgs[1][1].url).toMatch('http://image2.jpg')
+        expect(onChangeArgs[2]).toBe(props.index)
+      })
+    })
+  })
+})

--- a/client/apps/settings/client/curations/display/tests/components/panel.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/panel.test.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import Panel from '../../components/panel.jsx'
+import { Panel } from '../../components/panel.jsx'
 import { mount } from 'enzyme'
 
 import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
-import CharacterLimitInput from 'client/components/character_limit/index.jsx'
+import { CharacterLimit } from 'client/components/character_limit/index.jsx'
 
 global.window.getSelection = jest.fn(() => {
   return {
@@ -27,7 +27,7 @@ describe('Panel', () => {
       <Panel {...props} />
     )
     expect(component.find('input').length).toBe(4)
-    expect(component.find(CharacterLimitInput).length).toBe(2)
+    expect(component.find(CharacterLimit).length).toBe(2)
     expect(component.find(ImageUpload).length).toBe(2)
     expect(component.find('label').at(0).text()).toMatch('Headline')
     expect(component.find('label').at(0).text()).toMatch('25 Characters')
@@ -88,7 +88,7 @@ describe('Panel', () => {
     const component = mount(
       <Panel {...props} />
     )
-    component.find(CharacterLimitInput).at(1).node.onChange('new value')
+    component.find(CharacterLimit).at(1).node.onChange('new value')
     expect(props.onChange.mock.calls[2][0]).toMatch('panel.body')
     expect(props.onChange.mock.calls[2][1]).toMatch('new value')
     expect(props.onChange.mock.calls[2][2]).toBe(props.index)

--- a/client/apps/settings/client/curations/display/tests/components/panel.test.js
+++ b/client/apps/settings/client/curations/display/tests/components/panel.test.js
@@ -1,0 +1,108 @@
+import React from 'react'
+import Panel from '../../components/panel.jsx'
+import { mount } from 'enzyme'
+
+import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
+import CharacterLimitInput from 'client/components/character_limit/index.jsx'
+
+global.window.getSelection = jest.fn(() => {
+  return {
+    isCollapsed: true,
+    getRangeAt: jest.fn()
+  }
+})
+
+describe('Panel', () => {
+  const props = {
+    campaign: {
+      canvas: {},
+      panel: {}
+    },
+    index: 0,
+    onChange: jest.fn()
+  }
+
+  it('renders all fields', () => {
+    const component = mount(
+      <Panel {...props} />
+    )
+    expect(component.find('input').length).toBe(4)
+    expect(component.find(CharacterLimitInput).length).toBe(2)
+    expect(component.find(ImageUpload).length).toBe(2)
+    expect(component.find('label').at(0).text()).toMatch('Headline')
+    expect(component.find('label').at(0).text()).toMatch('25 Characters')
+    expect(component.find('label').at(2).text()).toMatch('Body')
+    expect(component.find('label').at(2).text()).toMatch('45 Characters')
+  })
+
+  it('renders saved text data', () => {
+    props.campaign.panel = {
+      assets: [{url: 'http://artsy.net/image.jpg'}],
+      body: '<p>Sample body text. <a href="http://artsy.net">Example link</a>.',
+      headline: 'Sample Headline',
+      link: {url: 'http://artsy.net'},
+      logo: 'http://artsy.net/logo.jpg'
+    }
+    const component = mount(
+      <Panel {...props} />
+    )
+    expect(component.find('label').at(0).text()).toMatch('10 Characters')
+    expect(component.find('input').at(0).node.value).toMatch(props.campaign.panel.headline)
+    expect(component.find('input').at(1).node.value).toMatch(props.campaign.panel.link.url)
+    expect(component.find('.rich-text--paragraph').at(0).text()).toMatch('Sample body text.')
+    expect(component.find('.rich-text--paragraph').at(0).text()).toMatch('Example link')
+    expect(component.find('.rich-text--paragraph').at(0).html()).toMatch('<a href="http://artsy.net/">')
+  })
+
+  it('renders saved image data', () => {
+    const component = mount(
+      <Panel {...props} />
+    )
+    expect(component.find(ImageUpload).at(0).props().src).toMatch(props.campaign.panel.assets[0].url)
+    expect(component.html()).toMatch('style="background-image: url(http://artsy.net/image.jpg)')
+    expect(component.find(ImageUpload).at(1).props().src).toMatch(props.campaign.panel.logo)
+    expect(component.html()).toMatch('style="background-image: url(http://artsy.net/logo.jpg)')
+  })
+
+  it('Calls props.onChange on headline change', () => {
+    const component = mount(
+      <Panel {...props} />
+    )
+    component.find('input').at(0).simulate('change', {target: {value: 'New Headline'}})
+    expect(props.onChange.mock.calls[0][0]).toMatch('panel.headline')
+    expect(props.onChange.mock.calls[0][1]).toMatch('New Headline')
+    expect(props.onChange.mock.calls[0][2]).toBe(props.index)
+  })
+
+  it('Calls props.onChange on CTA link change', () => {
+    const component = mount(
+      <Panel {...props} />
+    )
+    component.find('input').at(1).simulate('change', {target: {value: 'http://new-link.com'}})
+    expect(props.onChange.mock.calls[1][0]).toMatch('panel.link.url')
+    expect(props.onChange.mock.calls[1][1]).toMatch('http://new-link.com')
+    expect(props.onChange.mock.calls[1][2]).toBe(props.index)
+  })
+
+  it('Calls props.onChange on body change', () => {
+    const component = mount(
+      <Panel {...props} />
+    )
+    component.find(CharacterLimitInput).at(1).node.onChange('new value')
+    expect(props.onChange.mock.calls[2][0]).toMatch('panel.body')
+    expect(props.onChange.mock.calls[2][1]).toMatch('new value')
+    expect(props.onChange.mock.calls[2][2]).toBe(props.index)
+  })
+
+  it('Calls props.onChange on image change', () => {
+    const component = mount(
+      <Panel {...props} />
+    )
+    const input = component.find(ImageUpload).at(0).node
+
+    input.props.onChange(input.props.name, 'http://new-image.jpg')
+    expect(props.onChange.mock.calls[3][0]).toMatch('panel.assets')
+    expect(props.onChange.mock.calls[3][1][0].url).toMatch('http://new-image.jpg')
+    expect(props.onChange.mock.calls[3][2]).toBe(props.index)
+  })
+})

--- a/client/apps/settings/client/curations/display/tests/index.test.jsx
+++ b/client/apps/settings/client/curations/display/tests/index.test.jsx
@@ -1,0 +1,82 @@
+import Backbone from 'backbone'
+import React from 'react'
+import DisplayAdmin from '../index.jsx'
+import { mount } from 'enzyme'
+
+import CanvasContainer from '../components/canvas_container.jsx'
+import Campaign from '../components/campaign.jsx'
+import Panel from '../components/panel.jsx'
+import DropDownItem from 'client/components/drop_down/index.jsx'
+
+describe('Display Admin', () => {
+  const curation = new Backbone.Model({
+    name: 'Display Admin',
+    type: 'display-admin',
+    campaigns: [
+      {
+        name: 'Sample Campaign 1',
+        canvas: {},
+        panel: {}
+      },
+      {
+        name: 'Sample Campaign 2',
+        canvas: {},
+        panel: {}
+      }
+    ]
+  })
+  const props = {
+    curation
+  }
+
+  it('renders correct buttons and components', () => {
+    const component = mount(
+      <DisplayAdmin {...props} />
+    )
+    expect(component.find(DropDownItem).length).toBe(2)
+    expect(component.find('button').at(0).text()).toMatch('Saved')
+    expect(component.find('button').at(1).text()).toMatch('Add New Campaign')
+  })
+
+  it('opens a campaign admin panel on click', () => {
+    const component = mount(
+      <DisplayAdmin {...props} />
+    )
+    component.find('.drop-down__title').at(1).simulate('click')
+    expect(component.state().activeSection).toBe(1)
+    expect(component.find('.drop-down__title').at(1).props()['data-active']).toBe(true)
+    expect(component.find(Campaign).length).toBe(1)
+    expect(component.find(Panel).length).toBe(1)
+    expect(component.find(CanvasContainer).length).toBe(1)
+  })
+
+  it('#onChange updates state.campaign and changes the save button text/color', () => {
+    const component = mount(
+      <DisplayAdmin {...props} />
+    )
+    component.instance().onChange('canvas.name', 'New Title', 0)
+    expect(component.state().curation.get('campaigns')[0].canvas.name).toMatch('New Title')
+    expect(component.state().saveStatus).toMatch('Save')
+    expect(component.find('button').at(0).props().style.color).toMatch('rgb(247, 98, 90)')
+  })
+
+  it('Save button saves the curation', () => {
+    const component = mount(
+      <DisplayAdmin {...props} />
+    )
+    component.instance().save = jest.fn()
+    component.instance().onChange('canvas.name', 'New Title', 0)
+    component.find('button').at(0).simulate('click')
+    expect(component.instance().save).toHaveBeenCalled()
+  })
+
+  it('Add Campaign button adds a campaign and opens new panel on click', () => {
+    const component = mount(
+      <DisplayAdmin {...props} />
+    )
+    component.find('button').at(1).simulate('click')
+    expect(component.find(DropDownItem).length).toBe(3)
+    expect(component.state().curation.get('campaigns').length).toBe(3)
+    expect(component.state().activeSection).toBe(2)
+  })
+})

--- a/client/apps/settings/stylesheets/index.styl
+++ b/client/apps/settings/stylesheets/index.styl
@@ -1,8 +1,9 @@
 @import '../../../components/stylus_lib'
-@import '/editorial_features'
-@import '/venice_admin'
-@import '/tags'
+@import '../client/curations/display'
 @import '/authors'
+@import '/editorial_features'
+@import '/tags'
+@import '/venice_admin'
 
 #channel-edit__users
   input

--- a/client/apps/settings/templates/curations/curation_edit.jade
+++ b/client/apps/settings/templates/curations/curation_edit.jade
@@ -39,3 +39,5 @@ block content
           include ./editorial_feature_edit.jade
       else
         #venice-root.max-width-container
+    when 'display-admin'
+      #react-root.max-width-container

--- a/client/assets/main.styl
+++ b/client/assets/main.styl
@@ -13,6 +13,7 @@
 @import '../components/rich_text_caption'
 @import '../components/tag_list'
 @import '../components/drag_drop'
+@import '../components/drop_down'
 @import '../apps/edit'
 @import '../apps/settings/stylesheets'
 @import '../apps/queue'

--- a/client/components/character_limit/index.jsx
+++ b/client/components/character_limit/index.jsx
@@ -3,7 +3,7 @@ import PlainText from '/client/components/rich_text2/components/plain_text.jsx'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-export default class CharacterLimitInput extends React.Component {
+export class CharacterLimit extends React.Component {
   constructor (props) {
     super(props)
 
@@ -72,7 +72,7 @@ export default class CharacterLimitInput extends React.Component {
   }
 }
 
-CharacterLimitInput.propTypes = {
+CharacterLimit.propTypes = {
   defaultValue: PropTypes.string,
   html: PropTypes.bool,
   label: PropTypes.string,

--- a/client/components/character_limit/test/index.test.js
+++ b/client/components/character_limit/test/index.test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme'
 import React from 'react'
 
-import CharacterLimit from 'client/components/character_limit'
+import { CharacterLimit } from 'client/components/character_limit'
 import Paragraph from 'client/components/rich_text2/components/paragraph.coffee'
 import PlainText from 'client/components/rich_text2/components/plain_text.jsx'
 

--- a/client/components/drop_down/index.jsx
+++ b/client/components/drop_down/index.jsx
@@ -13,7 +13,7 @@ export default class DropDown extends React.Component {
     return (
       <div className='drop-down'>
         <div className='drop-down__title' onClick={() => onClick(index)} data-active={active}>
-          <h1>{title || 'Missing Title'}</h1>
+          <h1 className={!title && 'placeholder'}>{title || 'Missing Title'}</h1>
           <div className='icon' />
         </div>
         {active &&

--- a/client/components/drop_down/index.styl
+++ b/client/components/drop_down/index.styl
@@ -1,5 +1,5 @@
 .drop-down
-  &__item
+  &__title
     display flex
     align-items center
     padding 15px 0

--- a/client/components/drop_down/index.styl
+++ b/client/components/drop_down/index.styl
@@ -7,6 +7,8 @@
     h1
       garamond headline
       margin-right 20px
+      &.placeholder
+        color gray-color
     div
       height 1.25em
     .icon

--- a/client/components/image_upload_form/index.styl
+++ b/client/components/image_upload_form/index.styl
@@ -69,6 +69,12 @@ fill-form()
   background-size cover
   z-index 1
   display none
+  overflow hidden
+  video
+    width 100%
+    height 100%
+    object-fit cover
+    object-position center
 
 .image-upload-form-remove
   font-family Helvetica, Arial, sans-serif !important

--- a/client/components/rich_text2/components/plain_text.jsx
+++ b/client/components/rich_text2/components/plain_text.jsx
@@ -1,16 +1,16 @@
+import PropTypes from 'prop-types'
 import React from 'react'
-import ReactDOM from 'react-dom'
 import { ContentState, Editor, EditorState } from 'draft-js'
 
 export default class PlainText extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
 
     const editorState = this.setEditorState()
     this.state = { editorState }
   }
 
-  setEditorState() {
+  setEditorState () {
     if (this.props.content) {
       return this.setStateWithContent()
     } else {
@@ -18,7 +18,7 @@ export default class PlainText extends React.Component {
     }
   }
 
-  setStateWithContent() {
+  setStateWithContent () {
     const content = ContentState.createFromText(this.props.content)
     return EditorState.createWithContent(content)
   }
@@ -26,7 +26,11 @@ export default class PlainText extends React.Component {
   onChange = (editorState) => {
     this.setState({ editorState })
     const content = editorState.getCurrentContent().getPlainText()
-    this.props.onChange(this.props.name, content)
+    if (this.props.name) {
+      this.props.onChange(this.props.name, content)
+    } else {
+      this.props.onChange(content)
+    }
   }
 
   focus = () => {
@@ -37,7 +41,7 @@ export default class PlainText extends React.Component {
     return 'handled'
   }
 
-  render() {
+  render () {
     return (
       <div
         className='plain-text'
@@ -49,8 +53,15 @@ export default class PlainText extends React.Component {
           placeholder={this.props.placeholder || 'Start Typing...'}
           handleReturn={this.handleReturn}
           onChange={this.onChange}
-          spellcheck={true} />
+          spellcheck />
       </div>
     )
   }
+}
+
+PlainText.propTypes = {
+  content: PropTypes.string,
+  name: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "knox": "^0.9.2",
     "lodash": "^4.17.4",
     "lodash.clonedeep": "^4.3.1",
+    "lodash.set": "^4.3.2",
     "lokka": "^1.7.0",
     "lokka-transport-http": "^1.6.1",
     "mocha": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,6 @@
     "kerberos": "0.0.21",
     "knox": "^0.9.2",
     "lodash": "^4.17.4",
-    "lodash.clonedeep": "^4.3.1",
-    "lodash.set": "^4.3.2",
     "lokka": "^1.7.0",
     "lokka-transport-http": "^1.6.1",
     "mocha": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5652,6 +5652,10 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+
 lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"


### PR DESCRIPTION
Adds a Display Admin to `settings/curations` for creating Panel and Canvas layouts on the display-admin curation. 

This assumes images are still in the standard bucket, and includes minor changes to the admin file-upload component to support images.  Will address using a different bucket in a future PR.

![display-admin](https://user-images.githubusercontent.com/1497424/31501175-81201f42-af37-11e7-93b0-e863c743b14b.gif)
