### PR TITLE
@eessex: Update the display resolver to return a single object instead of a list

### DIFF
--- a/api/apps/graphql/index.js
+++ b/api/apps/graphql/index.js
@@ -37,7 +37,7 @@ const schema = joiql({
       resolve: resolvers.articles
     }),
     article: ArticleSchema.meta({
-      args: {id: string()},
+      args: { id: string() },
       resolve: resolvers.article
     }),
     authors: array().items(object(
@@ -56,7 +56,7 @@ const schema = joiql({
       args: Channel.querySchema,
       resolve: resolvers.channels
     }),
-    display: array().items(Display.schema).meta({
+    display: Display.schema.meta({
       args: Display.querySchema,
       resolve: resolvers.display
     }),

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -88,7 +88,7 @@ export const channels = (root, args, req, ast) => {
 
 export const display = (root, args, req, ast) => {
   return new Promise((resolve, reject) => {
-    Curation.mongoFetch({'_id': ObjectId(DISPLAY_ID)}, (err, results) => {
+    Curation.mongoFetch({ '_id': ObjectId(DISPLAY_ID) }, (err, results) => {
       if (err) {
         reject(new Error(err))
       }
@@ -97,7 +97,7 @@ export const display = (root, args, req, ast) => {
         outcomes.push(_.times((campaign.sov * 100), () => campaign.name))
       })
       const result = _.sample(_.flatten(outcomes))
-      const data = _.where(results.results[0].campaigns, {name: result})
+      const data = _.findWhere(results.results[0].campaigns, { name: result })
       resolve(data)
     })
   })

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -80,7 +80,7 @@ describe('resolvers', () => {
 
   describe('article', () => {
     it('rejects with an error when no article is found', async () => {
-      const args = {id: '123'}
+      const args = { id: '123' }
       resolvers.__set__('find', (sinon.stub().yields(null, null)))
       try {
         await resolvers.article({}, args, {}, {})
@@ -90,8 +90,8 @@ describe('resolvers', () => {
     })
 
     it('rejects with an error when trying to view an unauthorized draft', async () => {
-      const args = {id: '123'}
-      const newArticle = _.extend({}, article, {channel_id: '000', published: false})
+      const args = { id: '123' }
+      const newArticle = _.extend({}, article, { channel_id: '000', published: false })
       resolvers.__set__('find', (sinon.stub().yields(null, newArticle)))
       try {
         await resolvers.article({}, args, {}, {})
@@ -101,15 +101,15 @@ describe('resolvers', () => {
     })
 
     it('can view drafts', async () => {
-      const args = {id: '123'}
-      const newArticle = _.extend({}, article, {published: false})
+      const args = { id: '123' }
+      const newArticle = _.extend({}, article, { published: false })
       resolvers.__set__('find', (sinon.stub().yields(null, newArticle)))
       const results = await resolvers.article({}, args, req, {})
       results.slug.should.equal('slug-2')
     })
 
     it('can view published articles', async () => {
-      const args = {id: '123'}
+      const args = { id: '123' }
       resolvers.__set__('find', (sinon.stub().yields(null, article)))
       const results = await resolvers.article({}, args, req, {})
       results.slug.should.equal('slug-2')
@@ -146,14 +146,17 @@ describe('resolvers', () => {
 
   describe('display', () => {
     it('can fetch campaign data', async () => {
-      const display = { total: 20, count: 1, results: [fixtures().display] }
+      const display = {
+        total: 20,
+        count: 1,
+        results: [{ campaigns: [fixtures().display] }]
+      }
       resolvers.__set__('Curation', { mongoFetch: (sinon.stub().yields(null, display)) })
 
-      const results = await resolvers.curations({}, {}, req, {})
-      results.length.should.equal(1)
-      results[0].name.should.equal('Sample Campaign')
-      results[0].canvas.headline.should.containEql('Sample copy')
-      results[0].panel.headline.should.containEql('Euismod Inceptos Quam')
+      const result = await resolvers.display({}, {}, req, {})
+      result.name.should.equal('Sample Campaign')
+      result.canvas.headline.should.containEql('Sample copy')
+      result.panel.headline.should.containEql('Euismod Inceptos Quam')
     })
   })
 


### PR DESCRIPTION
Since we're implementing the SOV logic server-side this seems like a more appropriate type.

![image](https://user-images.githubusercontent.com/555859/31516585-0f275b00-af67-11e7-96a7-ab9fcdeb2fc9.png)
