### PR TITLE
@eessex => Update reaction paths and fix Display schema

### DIFF
--- a/api/apps/graphql/schemas/display.js
+++ b/api/apps/graphql/schemas/display.js
@@ -1,11 +1,13 @@
 import Joi from 'api/lib/joi.coffee'
 const { API_MAX, API_PAGE_SIZE } = process.env
 
-const unitSchema = Joi.object().keys({
+const unitSchema = Joi.object().meta({
+  name: 'DisplayUnit',
+  isTypeOf: (data) => {}
+}).keys({
   assets: Joi.array().items(
     Joi.object().keys({
-      name: Joi.string().allow(''),
-      slug: Joi.string()
+      url: Joi.string()
     })
   ),
   body: Joi.string(),

--- a/client/apps/edit/components/content/sections/image_collection/components/artwork.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/components/artwork.coffee
@@ -1,6 +1,6 @@
 React = require 'react'
-components = require('@artsy/reaction-force/dist/Components/Publishing/index').default
-Artwork = React.createFactory components.Artwork
+{ Artwork } = require('@artsy/reaction-force/dist/Components/Publishing')
+Artwork = React.createFactory Artwork
 icons = -> require('../../../../icons.jade') arguments...
 { div, span, img, button, p, strong } = React.DOM
 

--- a/client/apps/edit/components/content/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content/sections/image_collection/index.coffee
@@ -11,8 +11,8 @@ DragContainer = React.createFactory require '../../../../../../components/drag_d
 { fillWidth }  = require '../../../../../../components/fill_width/index.coffee'
 { div, section, ul, li } = React.DOM
 
-components = require('@artsy/reaction-force/dist/Components/Publishing/index').default
-ImageSetPreview = React.createFactory components.ImageSetPreviewClassic
+{ ImageSetPreviewClassic } = require('@artsy/reaction-force/dist/Components/Publishing')
+ImageSetPreview = React.createFactory ImageSetPreviewClassic
 
 module.exports = React.createClass
   displayName: 'SectionImageCollection'

--- a/client/apps/edit/components/content2/section_controls/index.jsx
+++ b/client/apps/edit/components/content2/section_controls/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
-const IconImageFullscreen = components.Icon.ImageFullscreen
+import { Icon } from '@artsy/reaction-force/dist/Components/Publishing'
+const IconImageFullscreen = Icon.IconImageFullscreen
 
 export default class SectionControls extends Component {
   constructor (props) {

--- a/client/apps/edit/components/content2/section_controls/index.jsx
+++ b/client/apps/edit/components/content2/section_controls/index.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Icon } from '@artsy/reaction-force/dist/Components/Publishing'
-const IconImageFullscreen = Icon.IconImageFullscreen
+import { IconImageFullscreen } from '@artsy/reaction-force/dist/Components/Publishing'
 
 export default class SectionControls extends Component {
   constructor (props) {

--- a/client/apps/edit/components/content2/section_controls/test/index.test.js
+++ b/client/apps/edit/components/content2/section_controls/test/index.test.js
@@ -4,8 +4,8 @@ import { mount } from 'enzyme'
 import Channel from '/client/models/channel.coffee'
 import Section from '/client/models/section.coffee'
 import SectionControls from '../index.jsx'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
-const { StandardArticle, FeatureArticle } = components.Fixtures
+import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
+const { StandardArticle, FeatureArticle } = Fixtures
 
 describe('Section Controls', () => {
   beforeAll(() => {

--- a/client/apps/edit/components/content2/section_tool/index.jsx
+++ b/client/apps/edit/components/content2/section_tool/index.jsx
@@ -1,15 +1,14 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
+import { Icon } from '@artsy/reaction-force/dist/Components/Publishing'
 
-const IconEditEmbed = components.Icon.EditEmbed
-const IconEditImages = components.Icon.EditImages
-const IconEditSection = components.Icon.EditSection
-const IconEditText = components.Icon.EditText
-const IconEditVideo = components.Icon.EditVideo
-
-const IconHeroImage = components.Icon.HeroImage
-const IconHeroVideo = components.Icon.HeroVideo
+const IconEditEmbed = Icon.IconEditEmbed
+const IconEditImages = Icon.IconEditImages
+const IconEditSection = Icon.IconEditSection
+const IconEditText = Icon.IconEditText
+const IconEditVideo = Icon.IconEditVideo
+const IconHeroImage = Icon.IconHeroImage
+const IconHeroVideo = Icon.IconHeroVideo
 
 export default class SectionTool extends Component {
   constructor (props) {

--- a/client/apps/edit/components/content2/section_tool/index.jsx
+++ b/client/apps/edit/components/content2/section_tool/index.jsx
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Icon } from '@artsy/reaction-force/dist/Components/Publishing'
-
-const IconEditEmbed = Icon.IconEditEmbed
-const IconEditImages = Icon.IconEditImages
-const IconEditSection = Icon.IconEditSection
-const IconEditText = Icon.IconEditText
-const IconEditVideo = Icon.IconEditVideo
-const IconHeroImage = Icon.IconHeroImage
-const IconHeroVideo = Icon.IconHeroVideo
+import {
+  IconEditEmbed,
+  IconEditImages,
+  IconEditSection,
+  IconEditText,
+  IconEditVideo,
+  IconHeroImage,
+  IconHeroVideo
+} from '@artsy/reaction-force/dist/Components/Publishing'
 
 export default class SectionTool extends Component {
   constructor (props) {

--- a/client/apps/edit/components/content2/section_tool/test/index.test.js
+++ b/client/apps/edit/components/content2/section_tool/test/index.test.js
@@ -1,22 +1,18 @@
 import React from 'react'
 import Backbone from 'backbone'
 import { mount } from 'enzyme'
-
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
+import { Icon, Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
 import SectionTool from '../index.jsx'
 
-const IconEditEmbed = components.Icon.EditEmbed
-const IconEditImages = components.Icon.EditImages
-const IconEditText = components.Icon.EditText
-const IconEditVideo = components.Icon.EditVideo
-
-const IconHeroImage = components.Icon.HeroImage
-const IconHeroVideo = components.Icon.HeroVideo
-
-const { FeatureArticle } = components.Fixtures
+const IconEditEmbed = Icon.EditEmbed
+const IconEditImages = Icon.EditImages
+const IconEditText = Icon.EditText
+const IconEditVideo = Icon.EditVideo
+const IconHeroImage = Icon.HeroImage
+const IconHeroVideo = Icon.HeroVideo
+const { FeatureArticle } = Fixtures
 
 describe('SectionTool', () => {
-
   const props = {
     isEditing: false,
     isHero: false,

--- a/client/apps/edit/components/content2/section_tool/test/index.test.js
+++ b/client/apps/edit/components/content2/section_tool/test/index.test.js
@@ -1,15 +1,16 @@
 import React from 'react'
 import Backbone from 'backbone'
 import { mount } from 'enzyme'
-import { Icon, Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
+import {
+  Fixtures,
+  IconEditEmbed,
+  IconEditImages,
+  IconEditText,
+  IconEditVideo,
+  IconHeroImage,
+  IconHeroVideo
+} from '@artsy/reaction-force/dist/Components/Publishing'
 import SectionTool from '../index.jsx'
-
-const IconEditEmbed = Icon.EditEmbed
-const IconEditImages = Icon.EditImages
-const IconEditText = Icon.EditText
-const IconEditVideo = Icon.EditVideo
-const IconHeroImage = Icon.HeroImage
-const IconHeroVideo = Icon.HeroVideo
 const { FeatureArticle } = Fixtures
 
 describe('SectionTool', () => {

--- a/client/apps/edit/components/content2/sections/embed/index.coffee
+++ b/client/apps/edit/components/content2/sections/embed/index.coffee
@@ -4,8 +4,8 @@
 
 React = require 'react'
 Controls = React.createFactory require './controls.coffee'
-components = require('@artsy/reaction-force/dist/Components/Publishing/index').default
-Embed = React.createFactory components.Embed
+{ Embed } = require('@artsy/reaction-force/dist/Components/Publishing')
+Embed = React.createFactory Embed
 { div, section } = React.DOM
 
 module.exports = React.createClass

--- a/client/apps/edit/components/content2/sections/header/controls.jsx
+++ b/client/apps/edit/components/content2/sections/header/controls.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
+import { Icon } from '@artsy/reaction-force/dist/Components/Publishing'
 
-const IconFullscreen = components.Icon.LayoutFullscreen
-const IconSplit = components.Icon.LayoutSplit
-const IconText = components.Icon.LayoutText
+const IconFullscreen = Icon.IconLayoutFullscreen
+const IconSplit = Icon.IconLayoutSplit
+const IconText = Icon.IconLayoutText
 
 export default class FeatureHeaderControls extends Component {
   constructor (props) {
@@ -53,8 +53,8 @@ export default class FeatureHeaderControls extends Component {
       return (
         <div
           onClick={this.toggleLayoutControls}
-          className='edit-header--controls__bg'>
-        </div>
+          className='edit-header--controls__bg'
+        />
       )
     }
   }

--- a/client/apps/edit/components/content2/sections/header/controls.jsx
+++ b/client/apps/edit/components/content2/sections/header/controls.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Icon } from '@artsy/reaction-force/dist/Components/Publishing'
-
-const IconFullscreen = Icon.IconLayoutFullscreen
-const IconSplit = Icon.IconLayoutSplit
-const IconText = Icon.IconLayoutText
+import {
+  IconLayoutFullscreen,
+  IconLayoutSplit,
+  IconLayoutText
+ } from '@artsy/reaction-force/dist/Components/Publishing'
 
 export default class FeatureHeaderControls extends Component {
   constructor (props) {
@@ -28,19 +28,19 @@ export default class FeatureHeaderControls extends Component {
           <a
             onClick={this.onChangeLayout}
             name='text'>
-            <IconText />
+            <IconLayoutText />
             Default
           </a>
           <a
             onClick={this.onChangeLayout}
             name='fullscreen'>
-            <IconFullscreen />
+            <IconLayoutFullscreen />
             Overlay
           </a>
           <a
             onClick={this.onChangeLayout}
             name='split'>
-            <IconSplit />
+            <IconLayoutSplit />
             Split
           </a>
         </div>

--- a/client/apps/edit/components/content2/sections/header/index.jsx
+++ b/client/apps/edit/components/content2/sections/header/index.jsx
@@ -1,11 +1,10 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Header, Icon } from '@artsy/reaction-force/dist/Components/Publishing'
+import { Header, IconRemove } from '@artsy/reaction-force/dist/Components/Publishing'
 import Controls from './controls.jsx'
 import FileInput from '/client/components/file_input/index.jsx'
 import { PlainText } from '/client/components/rich_text2/components/plain_text.jsx'
 import Paragraph from '/client/components/rich_text2/components/paragraph.coffee'
-const IconRemove = Icon.IconRemove
 
 export default class SectionHeader extends Component {
   constructor (props) {

--- a/client/apps/edit/components/content2/sections/header/index.jsx
+++ b/client/apps/edit/components/content2/sections/header/index.jsx
@@ -1,13 +1,11 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
+import { Header, Icon } from '@artsy/reaction-force/dist/Components/Publishing'
 import Controls from './controls.jsx'
 import FileInput from '/client/components/file_input/index.jsx'
 import { PlainText } from '/client/components/rich_text2/components/plain_text.jsx'
 import Paragraph from '/client/components/rich_text2/components/paragraph.coffee'
-
-const Header = components.Header
-const IconRemove = components.Icon.Remove
+const IconRemove = Icon.IconRemove
 
 export default class SectionHeader extends Component {
   constructor (props) {

--- a/client/apps/edit/components/content2/sections/header/test/controls.test.js
+++ b/client/apps/edit/components/content2/sections/header/test/controls.test.js
@@ -2,10 +2,10 @@ import React from 'react'
 import Controls from '../controls.jsx'
 import { mount } from 'enzyme'
 
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
-const Fullscreen = components.Icon.LayoutFullscreen
-const Split = components.Icon.LayoutSplit
-const Text = components.Icon.LayoutText
+import { Icon } from '@artsy/reaction-force/dist/Components/Publishing'
+const Fullscreen = Icon.IconLayoutFullscreen
+const Split = Icon.IconLayoutSplit
+const Text = Icon.IconLayoutText
 
 describe('Feature Header Controls', () => {
 

--- a/client/apps/edit/components/content2/sections/header/test/controls.test.js
+++ b/client/apps/edit/components/content2/sections/header/test/controls.test.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import Controls from '../controls.jsx'
 import { mount } from 'enzyme'
-
-import { Icon } from '@artsy/reaction-force/dist/Components/Publishing'
-const Fullscreen = Icon.IconLayoutFullscreen
-const Split = Icon.IconLayoutSplit
-const Text = Icon.IconLayoutText
+import {
+  IconLayoutFullscreen,
+  IconLayoutSplit,
+  IconLayoutText
+} from '@artsy/reaction-force/dist/Components/Publishing'
 
 describe('Feature Header Controls', () => {
 
@@ -27,9 +27,9 @@ describe('Feature Header Controls', () => {
     )
     component.find('.edit-header--controls-open').simulate('click')
     expect(component.state().isOpen).toBe(true)
-    expect(component.find(Fullscreen).length).toBe(1)
-    expect(component.find(Split).length).toBe(1)
-    expect(component.find(Text).length).toBe(1)
+    expect(component.find(IconLayoutFullscreen).length).toBe(1)
+    expect(component.find(IconLayoutSplit).length).toBe(1)
+    expect(component.find(IconLayoutText).length).toBe(1)
   })
 
   it('changes the layout click', () => {

--- a/client/apps/edit/components/content2/sections/header/test/index.test.js
+++ b/client/apps/edit/components/content2/sections/header/test/index.test.js
@@ -4,11 +4,10 @@ import { PlainText } from '/client/components/rich_text2/components/plain_text.j
 import SectionHeader from '../index.jsx'
 import { mount } from 'enzyme'
 
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
-const Header = components.Header
-const ClassicArticle = components.Fixtures.ClassicArticle
-const FeatureArticle = components.Fixtures.FeatureArticle
-const StandardArticle = components.Fixtures.StandardArticle
+import { Fixtures, Header } from '@artsy/reaction-force/dist/Components/Publishing'
+const ClassicArticle = Fixtures.ClassicArticle
+const FeatureArticle = Fixtures.FeatureArticle
+const StandardArticle = Fixtures.StandardArticle
 
 jest.mock('react-sizeme', () => jest.fn(c => d => d))
 

--- a/client/apps/edit/components/content2/sections/hero/test/index.test.js
+++ b/client/apps/edit/components/content2/sections/hero/test/index.test.js
@@ -6,8 +6,8 @@ import HeroSection from '../index.jsx'
 import SectionContainer from '../../../section_container/index.coffee'
 import SectionTool from '../../../section_tool/index.jsx'
 
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
-const { FeatureArticle } = components.Fixtures
+import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
+const { FeatureArticle } = Fixtures
 
 describe('HeroSection', () => {
   const props = {

--- a/client/apps/edit/components/content2/sections/image_collection/components/artwork.jsx
+++ b/client/apps/edit/components/content2/sections/image_collection/components/artwork.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
-const IconRemove = components.Icon.Remove
-const Artwork = components.Artwork
+import { Artwork, Icon } from '@artsy/reaction-force/dist/Components/Publishing'
+const IconRemove = Icon.IconRemove
 
 export default class ImageCollectionArtwork extends Component {
   renderRemoveButton (artwork) {

--- a/client/apps/edit/components/content2/sections/image_collection/components/artwork.jsx
+++ b/client/apps/edit/components/content2/sections/image_collection/components/artwork.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Artwork, Icon } from '@artsy/reaction-force/dist/Components/Publishing'
-const IconRemove = Icon.IconRemove
+import { Artwork, IconRemove } from '@artsy/reaction-force/dist/Components/Publishing'
 
 export default class ImageCollectionArtwork extends Component {
   renderRemoveButton (artwork) {

--- a/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
+++ b/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Paragraph from '../../../../../../../components/rich_text2/components/paragraph.coffee'
-import { Icon, Image } from '@artsy/reaction-force/dist/Components/Publishing'
-const IconRemove = Icon.IconRemove
+import { IconRemove, Image } from '@artsy/reaction-force/dist/Components/Publishing'
 
 export default class ImageCollectionImage extends Component {
   onCaptionChange = (html) => {

--- a/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
+++ b/client/apps/edit/components/content2/sections/image_collection/components/image.jsx
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Paragraph from '../../../../../../../components/rich_text2/components/paragraph.coffee'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
-const IconRemove = components.Icon.Remove
-const Image = components.Image
+import { Icon, Image } from '@artsy/reaction-force/dist/Components/Publishing'
+const IconRemove = Icon.IconRemove
 
 export default class ImageCollectionImage extends Component {
   onCaptionChange = (html) => {

--- a/client/apps/edit/components/content2/sections/image_collection/index.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/index.coffee
@@ -3,16 +3,15 @@
 #
 _ = require 'underscore'
 React = require 'react'
-components = require('@artsy/reaction-force/dist/Components/Publishing/index').default
+{ ImageSetPreview, ImageSetPreviewClassic } = require('@artsy/reaction-force/dist/Components/Publishing')
 FillWidth = require('@artsy/reaction-force/dist/Utils/fillwidth').default
 imagesLoaded = require 'imagesloaded'
-
 Artwork = require './components/artwork.jsx'
 Controls = require './components/controls.jsx'
 DragContainer = React.createFactory require '../../../../../../components/drag_drop/index.coffee'
 Image = require './components/image.jsx'
-ImageSetPreview = React.createFactory components.ImageSetPreview
-ImageSetPreviewClassic = React.createFactory components.ImageSetPreviewClassic
+ImageSetPreview = React.createFactory ImageSetPreview
+ImageSetPreviewClassic = React.createFactory ImageSetPreviewClassic
 { div, section, ul, li } = React.DOM
 
 module.exports = React.createClass
@@ -65,12 +64,12 @@ module.exports = React.createClass
   removeItem: (item) -> =>
     @setState imagesLoaded: false
     newImages = _.without @props.section.get('images'), item
-    @props.section.set images: newImages
+    @props.section.set(images: newImages)
     @onChange()
 
   onDragEnd: (images) ->
     @setState imagesLoaded: false
-    @props.section.set images: images
+    @props.section.set(images: images)
     @onChange()
 
   isImageSetWrapping: ->

--- a/client/apps/edit/components/content2/sections/image_collection/test/artwork.test.js
+++ b/client/apps/edit/components/content2/sections/image_collection/test/artwork.test.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import Artwork from '../components/artwork.jsx'
 import Backbone from 'backbone'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
+import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
 import { extend } from 'lodash'
 import { mount } from 'enzyme'
-const { StandardArticle } = components.Fixtures
+const { StandardArticle } = Fixtures
 
 describe('Artwork', () => {
   const props = {

--- a/client/apps/edit/components/content2/sections/image_collection/test/controls.test.js
+++ b/client/apps/edit/components/content2/sections/image_collection/test/controls.test.js
@@ -1,16 +1,15 @@
 import React from 'react'
 import Backbone from 'backbone'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
+import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
 import Controls from '../components/controls.jsx'
 import SectionControls from '../../../section_controls/index.jsx'
 import sinon from 'sinon'
 import { extend } from 'lodash'
 import { mount, shallow } from 'enzyme'
-const { StandardArticle } = components.Fixtures
+const { StandardArticle } = Fixtures
 require('typeahead.js')
 
 describe('ImageCollectionControls', () => {
-
   const props = {
     article: new Backbone.Model(StandardArticle),
     channel: {

--- a/client/apps/edit/components/content2/sections/image_collection/test/image.test.js
+++ b/client/apps/edit/components/content2/sections/image_collection/test/image.test.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import Backbone from 'backbone'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
+import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
 import Image from '../components/image.jsx'
 import { mount } from 'enzyme'
-const { StandardArticle } = components.Fixtures
+const { StandardArticle } = Fixtures
 
 describe('Image', () => {
   const props = {

--- a/client/apps/edit/components/content2/sections/text/index.coffee
+++ b/client/apps/edit/components/content2/sections/text/index.coffee
@@ -2,11 +2,11 @@ React = require 'react'
 ReactDOM = require 'react-dom'
 _s = require 'underscore.string'
 sd = require('sharify').data
-components = require('@artsy/reaction-force/dist/Components/Publishing/index').default
+{ Text } = require('@artsy/reaction-force/dist/Components/Publishing')
 Config = require './draft_config.coffee'
 Nav = React.createFactory require '../../../../../../components/rich_text2/components/nav.coffee'
 InputUrl = React.createFactory require '../../../../../../components/rich_text2/components/input_url.coffee'
-Text = React.createFactory components.Text
+Text = React.createFactory Text
 Utils = require '../../../../../../components/rich_text2/utils/index.coffee'
 { CompositeDecorator,
   ContentState,
@@ -16,7 +16,6 @@ Utils = require '../../../../../../components/rich_text2/utils/index.coffee'
   Modifier } = require 'draft-js'
 editor = (props) -> React.createElement Editor, props
 { div } = React.DOM
-
 
 module.exports = React.createClass
   displayName: 'SectionText'
@@ -96,7 +95,7 @@ module.exports = React.createClass
     selection = Utils.getSelectionDetails(@state.editorState)
     # only merge a section if cursor is in first character of first block
     if selection.isFirstBlock and selection.anchorOffset is 0 and
-     @props.sections.models[@props.index - 1]?.get('type') is 'text'
+    @props.sections.models[@props.index - 1]?.get('type') is 'text'
       mergeIntoHTML = @props.sections.models[@props.index - 1].get('body')
       @props.sections.models[@props.index - 1].destroy()
       newHTML = mergeIntoHTML + @state.html
@@ -115,7 +114,7 @@ module.exports = React.createClass
     # or cursor is arrowing back from first character of first block,
     # jump to adjacent section
     if selection.isLastBlock and selection.isLastCharacter and direction is 1 or
-     selection.isFirstBlock and selection.isFirstCharacter and direction is -1
+    selection.isFirstBlock and selection.isFirstCharacter and direction is -1
       @props.onSetEditing @props.index + direction
     else if e.key in ['ArrowLeft', 'ArrowRight']
       # manually move cursor to make up for draft's missing l/r arrow fallbacks
@@ -163,7 +162,7 @@ module.exports = React.createClass
     selection = editorState.getSelection()
     noLinks = RichUtils.toggleLink editorState, selection, null
     noBlocks = RichUtils.toggleBlockType noLinks, 'unstyled'
-    noStyles = noBlocks.getCurrentContent().getBlocksAsArray().map (contentBlock) =>
+    noStyles = noBlocks.getCurrentContent().getBlocksAsArray().map (contentBlock) ->
       Utils.stripCharacterStyles contentBlock
     newState = ContentState.createFromBlockArray noStyles
     if !selection.isCollapsed()
@@ -185,7 +184,7 @@ module.exports = React.createClass
       @handleBackspace e
     else if e in ['italic', 'bold']
       if @props.article.get('layout') is 'classic' and
-       Utils.getSelectionDetails(@state.editorState).anchorType is 'header-three'
+      Utils.getSelectionDetails(@state.editorState).anchorType is 'header-three'
         return 'handled'
       newState = RichUtils.handleKeyCommand @state.editorState, e
       @onChange newState if newState

--- a/client/apps/edit/components/content2/sections/video/index.jsx
+++ b/client/apps/edit/components/content2/sections/video/index.jsx
@@ -2,9 +2,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Controls from './controls.jsx'
 import Paragraph from '../../../../../../components/rich_text2/components/paragraph.coffee'
-import { Video as VideoComponent, Icon } from '@artsy/reaction-force/dist/Components/Publishing'
-const Video = VideoComponent
-const IconRemove = Icon.IconRemove
+import { Video, IconRemove } from '@artsy/reaction-force/dist/Components/Publishing'
 
 export default class SectionVideo extends Component {
   constructor (props) {

--- a/client/apps/edit/components/content2/sections/video/index.jsx
+++ b/client/apps/edit/components/content2/sections/video/index.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Controls from './controls.jsx'
 import Paragraph from '../../../../../../components/rich_text2/components/paragraph.coffee'
-import components from '@artsy/reaction-force/dist/Components/Publishing/index'
-const Video = components.Video
-const IconRemove = components.Icon.Remove
+import { Video as VideoComponent, Icon } from '@artsy/reaction-force/dist/Components/Publishing'
+const Video = VideoComponent
+const IconRemove = Icon.IconRemove
 
 export default class SectionVideo extends Component {
   constructor (props) {

--- a/client/components/drag_drop/test/index.test.coffee
+++ b/client/components/drag_drop/test/index.test.coffee
@@ -9,7 +9,8 @@ ReactTestUtils = require 'react-addons-test-utils'
 Sections = require '../../../collections/sections.coffee'
 Section = require '../../../models/section.coffee'
 Article = require '../../../models/article.coffee'
-{ StandardArticle } = require('@artsy/reaction-force/dist/Components/Publishing/index').default.Fixtures
+{ Fixtures } = require('@artsy/reaction-force/dist/Components/Publishing')
+StandardArticle = Fixtures.StandardArticle
 r =
   find: ReactTestUtils.scryRenderedDOMComponentsWithClass
   simulate: ReactTestUtils.Simulate
@@ -20,7 +21,7 @@ describe 'DragDropContainer Default', ->
     benv.setup =>
       benv.expose
         $: benv.require 'jquery'
-      global.HTMLElement = () => {}
+      global.HTMLElement = () -> {}
       window.matchMedia = sinon.stub().returns(
         {
           matches: false
@@ -69,7 +70,7 @@ describe 'DragDropContainer Default', ->
           }
         )
       ]
-      @component = ReactDOM.render React.createElement(@DragDropContainer, @props, @children), (@$el = $ "<div></div>")[0], =>
+      @component = ReactDOM.render React.createElement(@DragDropContainer, @props, @children), (@$el = $ "<div></div>")[0], ->
       done()
 
   afterEach (done) ->
@@ -220,7 +221,7 @@ describe 'DragDropContainer Vertical', ->
       ]
       @component = ReactDOM.render(
         React.createElement(@DragDropContainer, @props, @children)
-        (@$el = $ "<div></div>")[0], =>
+        (@$el = $ "<div></div>")[0], ->
       )
       done()
 

--- a/client/components/rich_text2/components/paragraph.coffee
+++ b/client/components/rich_text2/components/paragraph.coffee
@@ -28,10 +28,10 @@ Utils = require '../utils/index.coffee'
 { convertToHTML, convertFromHTML } = require 'draft-convert'
 { div, a } = React.DOM
 editor = (props) -> React.createElement Editor, props
-components = require('@artsy/reaction-force/dist/Components/Publishing/index').default
+{ Text } = require('@artsy/reaction-force/dist/Components/Publishing')
 Nav = React.createFactory require './nav.coffee'
 InputUrl = React.createFactory require './input_url.coffee'
-Text = React.createFactory components.Text
+Text = React.createFactory Text
 
 module.exports = React.createClass
   displayName: 'Paragraph'
@@ -190,10 +190,10 @@ module.exports = React.createClass
       selectionTarget: null
     })
     @onChange RichUtils.toggleLink(
-        newEditorState
-        newEditorState.getSelection()
-        entityKey
-      )
+      newEditorState
+      newEditorState.getSelection()
+      entityKey
+    )
 
   removeLink: (e) ->
     e.preventDefault()

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.0.2",
-    "@artsy/reaction-force": "^0.8.3",
+    "@artsy/reaction-force": "^0.9.0",
     "airtable": "^0.4.5",
     "artsy-backbone-mixins": "git://github.com/artsy/artsy-backbone-mixins.git",
     "artsy-ezel-components": "git://github.com/artsy/artsy-ezel-components.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.8.3.tgz#3d3fc8f8d7af81c9eb77e2e66e467da9eb68ec35"
+"@artsy/reaction-force@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.9.0.tgz#5cc59d1b38cdd5886f700c22b0be9cfcd0761816"
   dependencies:
     "@storybook/addon-options" "^3.2.1"
     "@storybook/react" "^3.2.12"


### PR DESCRIPTION
(For Monday)
- Updates reaction paths post export default killing
- Fixes Display schema to use `url` as the asset and adds meta information on display schema to support fragments