### PR TITLE
@craigspaeth => Roll out edit2 for editorial

### DIFF
--- a/client/apps/articles_list/client/client.coffee
+++ b/client/apps/articles_list/client/client.coffee
@@ -4,6 +4,7 @@ ReactDOM = require 'react-dom'
 onInfiniteScroll = require 'jquery-on-infinite-scroll'
 { div, nav, a, h1 } = React.DOM
 Article = require '../../../models/article.coffee'
+Channel = require '../../../models/channel.coffee'
 FilterSearch = React.createFactory require '../../../components/filter_search/index.coffee'
 query = require '../query.coffee'
 sd = require('sharify').data
@@ -71,6 +72,7 @@ module.exports.ArticlesListView = ArticlesListView = React.createClass
           selected: null
           contentType: 'article'
           checkable: false
+          isEditorial: @props.channel.isEditorial() # TODO - REMOVE POST ARTICLE2
         }
     else
       @showEmptyMessage()
@@ -90,12 +92,12 @@ module.exports.ArticlesListView = ArticlesListView = React.createClass
               className: "#{if @state.published is false then 'is-active' else ''} drafts"
               onClick: => @setPublished false
               }, "Drafts"
-          div {className: 'channel-name'}, "#{@props.channel.name}"
+          div {className: 'channel-name'}, "#{@props.channel.get('name')}"
       @showArticlesList()
 
 module.exports.init = ->
   props =
     articles: sd.ARTICLES
     published: sd.HAS_PUBLISHED
-    channel: sd.CURRENT_CHANNEL
+    channel: new Channel sd.CURRENT_CHANNEL
   ReactDOM.render React.createElement(ArticlesListView, props), document.getElementById('articles-list')

--- a/client/apps/articles_list/test/client/client.test.coffee
+++ b/client/apps/articles_list/test/client/client.test.coffee
@@ -7,6 +7,7 @@ ReactDOM = require 'react-dom'
 ReactTestUtils = require 'react-addons-test-utils'
 ReactDOMServer = require 'react-dom/server'
 fixtures = require '../../../../../test/helpers/fixtures.coffee'
+Channel = require '../../../../../client/models/channel.coffee'
 r =
   find: ReactTestUtils.findRenderedDOMComponentWithClass
   simulate: ReactTestUtils.Simulate
@@ -33,7 +34,7 @@ describe 'ArticlesListView', ->
           articles: [_.extend fixtures().articles, id: '456']
           published: true
           offset: 0
-          channel: {name: 'Artsy Editorial'}
+          channel: new Channel {name: 'Artsy Editorial'}
         }
       @rendered = ReactDOMServer.renderToString React.createElement(ArticlesListView, props)
       @component = ReactDOM.render React.createElement(ArticlesListView, props), (@$el = $ "<div></div>")[0], =>

--- a/client/apps/edit/components/content2/sections/header/test/controls.test.js
+++ b/client/apps/edit/components/content2/sections/header/test/controls.test.js
@@ -10,6 +10,7 @@ import {
 describe('Feature Header Controls', () => {
 
   const props = {
+    hero: {},
     onChange: jest.fn()
   }
 

--- a/client/apps/edit/components/header/index.styl
+++ b/client/apps/edit/components/header/index.styl
@@ -17,6 +17,7 @@
     border-right 0
   a:nth-last-child(3)
     border-right 1px solid gray-lighter-color
+    margin-left 0
   a:not(#edit-publish)
     position relative
     color gray-color

--- a/client/components/article_list/index.coffee
+++ b/client/components/article_list/index.coffee
@@ -56,8 +56,8 @@ module.exports = React.createClass
             }
           a {
             className: 'article-list__article'
-            href: "/articles/#{result.id}/edit"
-          },
+            href: "/articles/#{result.id}/#{if @props.isEditorial then 'edit2' else 'edit'}"
+          },   # TODO - ONLY EDIT POST ARTICLE2
             div {
               className: 'article-list__image paginated-list-img'
               style: if attrs.image then backgroundImage: "url(#{attrs.image})" else {}

--- a/client/components/article_list/test/index.test.coffee
+++ b/client/components/article_list/test/index.test.coffee
@@ -16,12 +16,12 @@ describe 'ArticleList', ->
     benv.setup =>
       benv.expose $: benv.require 'jquery'
       window.jQuery = $
-      ArticleList = benv.requireWithJadeify(
+      @ArticleList = benv.requireWithJadeify(
         resolve(__dirname, '../index')
         ['icons']
       )
-      ArticleList.__set__ 'sd', { FORCE_URL: 'http://artsy.net' }
-      props = {
+      @ArticleList.__set__ 'sd', { FORCE_URL: 'http://artsy.net' }
+      @props = {
           articles: [
             {
               id: '123'
@@ -46,8 +46,7 @@ describe 'ArticleList', ->
           checkable: true
           display: 'email'
         }
-      @rendered = ReactDOMServer.renderToString React.createElement(ArticleList, props)
-      @component = ReactDOM.render React.createElement(ArticleList, props), (@$el = $ "<div></div>")[0], => setTimeout =>
+      @component = ReactDOM.render React.createElement(@ArticleList, @props), (@$el = $ "<div></div>")[0], => setTimeout =>
         sinon.stub @component, 'setState'
         done()
 
@@ -55,8 +54,17 @@ describe 'ArticleList', ->
     benv.teardown()
 
   it 'renders an initial set of articles', ->
-    $(@rendered).html().should.containEql 'Game of Thrones'
-    $(@rendered).html().should.containEql 'http://artsy.net/article/artsy-editorial-game-of-thrones'
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Game of Thrones'
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'http://artsy.net/article/artsy-editorial-game-of-thrones'
+
+  it 'renders a link to /edit if not props.isEditorial', ->
+    rendered = ReactDOMServer.renderToString React.createElement(@ArticleList, @props)
+    $(rendered).html().should.containEql 'href="/articles/125/edit"'
+
+  it 'renders a link to /edit2 if props.isEditorial', ->
+    @props.isEditorial = true
+    rendered = ReactDOMServer.renderToString React.createElement(@ArticleList, @props)
+    $(rendered).html().should.containEql 'href="/articles/125/edit2"'
 
   it 'selects the article when clicking the check button', ->
     r.simulate.click @component.refs['123']
@@ -65,11 +73,11 @@ describe 'ArticleList', ->
     @component.props.selected.args[0][0].slug.should.containEql 'artsy-editorial-game-of-thrones'
 
   it 'can render email headlines and images', ->
-    $(@rendered).html().should.containEql 'Email of Thrones'
-    $(@rendered).html().should.containEql 'image_url.jpg'
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Email of Thrones'
+    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'image_url.jpg'
 
   it 'sets the background of the thumbnail image', ->
-    $(@rendered).find('.article-list__image:eq(1)').css('background-image').should.equal 'url(http://artsy.net/image_url.jpg)'
+    $(ReactDOM.findDOMNode(@component)).find('.article-list__image:eq(1)').css('background-image').should.equal 'url(http://artsy.net/image_url.jpg)'
 
   it 'thumbnail image defaults to not setting background when there is no image', ->
-    $(@rendered).find('.article-list__image:eq(2)').css('background-image').length.should.equal 0
+    $(ReactDOM.findDOMNode(@component)).find('.article-list__image:eq(2)').css('background-image').length.should.equal 0

--- a/client/components/filter_search/index.coffee
+++ b/client/components/filter_search/index.coffee
@@ -55,6 +55,7 @@ module.exports = React.createClass
           checkable: @props.checkable
           selected: @selected
           display: @props.display
+          isEditorial: @props.isEditorial  # TODO - REMOVE POST ARTICLE2
         }
       else if @props.contentType is 'tag'
         TagList {

--- a/client/components/layout/templates/sidebar.jade
+++ b/client/components/layout/templates/sidebar.jade
@@ -15,7 +15,7 @@
     else
       a#layout-sidebar-new-article(
         class=(sd.URL == '/articles/new' ? 'is-active' : '')
-        href='/articles/new?layout=standard'
+        href='/articles/new?layout=classic'
       )
         include ../public/icons/layout_new_article.svg
         br

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.0.2",
-    "@artsy/reaction-force": "^0.9.0",
+    "@artsy/reaction-force": "^0.9.1",
     "airtable": "^0.4.5",
     "artsy-backbone-mixins": "git://github.com/artsy/artsy-backbone-mixins.git",
     "artsy-ezel-components": "git://github.com/artsy/artsy-ezel-components.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.9.0.tgz#5cc59d1b38cdd5886f700c22b0be9cfcd0761816"
+"@artsy/reaction-force@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.9.1.tgz#02360092072e2adeefa5ebd987795e6597c7e29e"
   dependencies:
     "@storybook/addon-options" "^3.2.1"
     "@storybook/react" "^3.2.12"


### PR DESCRIPTION
Changes the articles list to link to /edit2 by default for editorial channels. 

This is not permanent logic-- editorial wants to maintain access to both /edit and /edit2 until launch.

When the switch is made for real, we'll render the edit2 component for everyone, and remove the router logic that is currently used to toggle between. 

Also-
- Fixes an error in Hero Section test
- Fixes error in new article button (was creating standard rather than classic for non-editorial)
- Fixes styling bug in article header buttons