### PR TITLE
@eessex => Adds support for display to be nested in an article fetch

### DIFF
--- a/api/apps/graphql/index.js
+++ b/api/apps/graphql/index.js
@@ -25,6 +25,10 @@ const metaFields = {
   relatedArticlesPanel: array().items(object(Article.inputSchema)).meta({
     name: 'RelatedArticlesPanel',
     resolve: resolvers.relatedArticlesPanel
+  }),
+  display: Display.schema.meta({
+    args: Display.querySchema,
+    resolve: resolvers.display
   })
 }
 


### PR DESCRIPTION
Pretty straightforward -- lets us make queries like: 

```
articles(published: true) {
   display {
       headline
   }
}
```