### PR TITLE
@damassi => Feature header save bugs

### DIFF
--- a/api/apps/articles/model/index.js
+++ b/api/apps/articles/model/index.js
@@ -81,9 +81,7 @@ export const save = (input, accessToken, options, callback) => {
 
         // Eventually convert these to Joi custom extensions
         modifiedArticle.updated_at = new Date()
-        if (input.hero_section && input.hero_section.type === 'fullscreen') {
-          modifiedArticle.title = modifiedArticle.hero_section.title
-        }
+
         if (input.author) { modifiedArticle.author = input.author }
 
         // Handle publishing, unpublishing, published, draft

--- a/api/apps/articles/model/index.js
+++ b/api/apps/articles/model/index.js
@@ -20,7 +20,9 @@ const { removeFromSearch, deleteArticleFromSailthru } = require('./distribute.co
 //
 export const where = (input, callback) => {
   return Joi.validate(input, schema.querySchema, { stripUnknown: true }, (err, input) => {
-    if (err) { return callback(err) }
+    if (err) {
+      return callback(err)
+    }
     return mongoFetch(input, callback)
   })
 }
@@ -44,7 +46,9 @@ export const mongoFetch = (input, callback) => {
     }
   ], (err, results) => {
     const [articles, total, articleCount] = results
-    if (err) { return callback(err) }
+    if (err) {
+      return callback(err)
+    }
     return callback(null, {
       results: articles,
       total,
@@ -70,19 +74,27 @@ export const save = (input, accessToken, options, callback) => {
     // Find the original article or create an empty one
     const articleId = (input.id || input._id) ? (input.id || input._id).toString() : null
     find(articleId, (err, article) => {
-      if (article == null) { article = {} }
-      if (err) { return callback(err) }
+      if (article == null) {
+        article = {}
+      }
+      if (err) {
+        return callback(err)
+      }
 
       // Create a new article by merging the values of input and article
       const modifiedArticle = _.extend(cloneDeep(article), input)
 
       generateKeywords(input, modifiedArticle, (err, modifiedArticle) => {
-        if (err) { return callback(err) }
+        if (err) {
+          return callback(err)
+        }
 
         // Eventually convert these to Joi custom extensions
         modifiedArticle.updated_at = new Date()
 
-        if (input.author) { modifiedArticle.author = input.author }
+        if (input.author) {
+          modifiedArticle.author = input.author
+        }
 
         // Handle publishing, unpublishing, published, draft
         const publishing = (modifiedArticle.published && !article.published) || (modifiedArticle.scheduled_publish_at && !article.published)
@@ -104,8 +116,12 @@ export const save = (input, accessToken, options, callback) => {
 
 export const publishScheduledArticles = callback => {
   db.articles.find({ scheduled_publish_at: { $lt: new Date() } }, (err, articles) => {
-    if (err) { return callback(err, []) }
-    if (articles.length === 0) { return callback(null, []) }
+    if (err) {
+      return callback(err, [])
+    }
+    if (articles.length === 0) {
+      return callback(null, [])
+    }
     async.map(articles, (article, cb) => {
       article = _.extend(article, {
         published: true,
@@ -115,7 +131,9 @@ export const publishScheduledArticles = callback => {
       return onPublish(article, sanitizeAndSave(cb))
     }
     , (err, results) => {
-      if (err) { return callback(err, []) }
+      if (err) {
+        return callback(err, [])
+      }
       return callback(null, results)
     })
   })
@@ -123,8 +141,12 @@ export const publishScheduledArticles = callback => {
 
 export const unqueue = callback => {
   db.articles.find({ $or: [ { weekly_email: true }, { daily_email: true } ] }, (err, articles) => {
-    if (err) { return callback(err, []) }
-    if (articles.length === 0) { return callback(null, []) }
+    if (err) {
+      return callback(err, [])
+    }
+    if (articles.length === 0) {
+      return callback(null, [])
+    }
     async.map(articles, (article, cb) => {
       article = _.extend(article, {
         weekly_email: false,
@@ -133,7 +155,9 @@ export const unqueue = callback => {
       return onPublish(article, sanitizeAndSave(cb))
     }
     , (err, results) => {
-      if (err) { return callback(err, []) }
+      if (err) {
+        return callback(err, [])
+      }
       return callback(null, results)
     })
   })
@@ -144,11 +168,17 @@ export const unqueue = callback => {
 //
 export const destroy = (id, callback) => {
   find(id, (err, article) => {
-    if (err) { return callback(err) }
-    if (!article) { return callback(new Error('Article not found.')) }
+    if (err) {
+      return callback(err)
+    }
+    if (!article) {
+      return callback(new Error('Article not found.'))
+    }
     deleteArticleFromSailthru(_.last(article.slugs), () => {
       db.articles.remove({ _id: ObjectId(id) }, (err, res) => {
-        if (err) { return callback(err) }
+        if (err) {
+          return callback(err)
+        }
         removeFromSearch(id.toString())
         return callback(null)
       })
@@ -169,7 +199,9 @@ export const presentCollection = (articles) => {
 }
 
 export const present = (article) => {
-  if (!article) { return {} }
+  if (!article) {
+    return {}
+  }
   const id = article._id ? article._id.toString() : null
   const scheduled_publish_at = article.scheduled_publish_at ? moment(article.scheduled_publish_at).toISOString() : null
   const published_at = article.published_at ? moment(article.published_at).toISOString() : null
@@ -187,7 +219,9 @@ export const present = (article) => {
 
 export const getSuperArticleCount = (id) => {
   return new Promise((resolve, reject) => {
-    if (!ObjectId.isValid(id)) { return resolve(0) }
+    if (!ObjectId.isValid(id)) {
+      return resolve(0)
+    }
     db.articles.find({ 'super_article.related_articles': ObjectId(id) }).count((err, count) => {
       if (err) { return reject(err) }
       resolve(count)

--- a/api/apps/articles/test/model/index/persistence.test.coffee
+++ b/api/apps/articles/test/model/index/persistence.test.coffee
@@ -681,17 +681,54 @@ describe 'Article Persistence', ->
           Article.__ResetDependency__ 'onUnpublish'
           done()
 
-    it 'saves a hero_section', (done) ->
+    it 'saves a classic hero_section', (done) ->
       Article.save {
         hero_section:
           url: 'http://youtube.com'
-          type: 'fullscreen'
-          title: 'The Year in Art 2018'
-          intro: 'This year was incredible.'
+          type: 'video'
+          caption: 'This year was incredible.'
       }, 'foo', {}, (err, article) ->
         return done err if err
         article.hero_section.url.should.equal 'http://youtube.com'
+        article.hero_section.type.should.equal 'video'
+        article.hero_section.caption.should.equal 'This year was incredible.'
+        done()
+
+    it 'saves a feature hero_section in fullscreen', (done) ->
+      Article.save {
+        hero_section:
+          url: 'http://image.com'
+          type: 'fullscreen'
+          deck: 'This year was incredible.'
+      }, 'foo', {}, (err, article) ->
+        return done err if err
+        article.hero_section.url.should.equal 'http://image.com'
         article.hero_section.type.should.equal 'fullscreen'
-        article.hero_section.title.should.equal 'The Year in Art 2018'
-        article.hero_section.intro.should.equal 'This year was incredible.'
+        article.hero_section.deck.should.equal 'This year was incredible.'
+        done()
+
+    it 'saves a feature hero_section in text', (done) ->
+      Article.save {
+        hero_section:
+          url: 'http://image.com'
+          type: 'text'
+          deck: 'This year was incredible.'
+      }, 'foo', {}, (err, article) ->
+        return done err if err
+        article.hero_section.url.should.equal 'http://image.com'
+        article.hero_section.type.should.equal 'text'
+        article.hero_section.deck.should.equal 'This year was incredible.'
+        done()
+
+    it 'saves a feature hero_section in split', (done) ->
+      Article.save {
+        hero_section:
+          url: 'http://image.com'
+          type: 'split'
+          deck: 'This year was incredible.'
+      }, 'foo', {}, (err, article) ->
+        return done err if err
+        article.hero_section.url.should.equal 'http://image.com'
+        article.hero_section.type.should.equal 'split'
+        article.hero_section.deck.should.equal 'This year was incredible.'
         done()

--- a/client/apps/edit/components/content2/index.coffee
+++ b/client/apps/edit/components/content2/index.coffee
@@ -11,8 +11,9 @@ module.exports = React.createClass
   componentWillMount: ->
     @debouncedSave = _.debounce((->
       @props.article.save()
-      @forceUpdate()
+      @onChange()
     ), 800)
+    @props.article.on 'change', => @saveArticle()
     @props.article.sections.on 'change add remove reset', => @saveArticle()
     @props.article.heroSection.on 'change remove', => @saveArticle()
 
@@ -22,6 +23,11 @@ module.exports = React.createClass
       @debouncedSave()
     else
       $('#edit-save').removeClass('is-saving').addClass 'attention'
+      @onChange()
+
+  onChange: ->
+    # force an update to reaction components & after admin panel changes
+    @setState lastUpdate: Date.now()
 
   render: ->
     div {className: 'edit-section-layout ' + @props.article.get('layout')},

--- a/client/apps/edit/components/content2/sections/header/index.jsx
+++ b/client/apps/edit/components/content2/sections/header/index.jsx
@@ -23,7 +23,6 @@ export default class SectionHeader extends Component {
     const heroSection = this.props.article.heroSection
     heroSection.set(key, value)
     this.onChange('hero_section', heroSection.attributes)
-    this.forceUpdate() // re-render reaction header
   }
 
   onProgress = (progress) => {

--- a/client/apps/edit/components/content2/sections/header/index.jsx
+++ b/client/apps/edit/components/content2/sections/header/index.jsx
@@ -9,6 +9,7 @@ import Paragraph from '/client/components/rich_text2/components/paragraph.coffee
 export default class SectionHeader extends Component {
   constructor (props) {
     super(props)
+
     this.state = {
       progress: null
     }
@@ -22,22 +23,11 @@ export default class SectionHeader extends Component {
     const heroSection = this.props.article.heroSection
     heroSection.set(key, value)
     this.onChange('hero_section', heroSection.attributes)
-  }
-
-  onChangeLeadParagraph = (html) => {
-    this.onChange('lead_paragraph', html)
-  }
-
-  onUpload = (image, width, height) => {
-    this.onChangeHero('url', image)
+    this.forceUpdate() // re-render reaction header
   }
 
   onProgress = (progress) => {
     this.setState({ progress })
-  }
-
-  onRemoveImage = () => {
-    this.onChangeHero('url', '')
   }
 
   renderTitle (article) {
@@ -64,7 +54,7 @@ export default class SectionHeader extends Component {
     return (
       <FileInput
         type='simple'
-        onUpload={this.onUpload}
+        onUpload={(image) => this.onChangeHero('url', image)}
         prompt={prompt}
         video
         onProgress={this.onProgress} />
@@ -86,7 +76,7 @@ export default class SectionHeader extends Component {
       return (
         <div
           className='edit-header__remove'
-          onClick={this.onRemoveImage}>
+          onClick={() => this.onChangeHero('url', '')}>
           <IconRemove />
         </div>
       )
@@ -114,7 +104,7 @@ export default class SectionHeader extends Component {
     return (
       <Paragraph
         html={article.get('lead_paragraph')}
-        onChange={this.onChangeLeadParagraph}
+        onChange={(input) => this.onChange('lead_paragraph', input)}
         placeholder='Lead Paragraph (optional)'
         type='lead_paragraph'
         linked={false}
@@ -133,7 +123,7 @@ export default class SectionHeader extends Component {
     }
     if (isClassic) {
       return (
-        <div className={'edit-header' + headerClass}>
+        <div className='edit-header'>
           <Header article={article.attributes}>
             {this.renderTitle(article)}
             {this.renderLeadParagraph(article)}

--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -113,7 +113,7 @@ module.exports = class Article extends Backbone.Model
   toJSON: ->
     extended = {}
     extended.sections = @sections.toJSON() if @sections?.length
-    if @heroSection?.keys().length > 1
+    if @heroSection?.keys().length
       extended.hero_section = @heroSection.toJSON()
     else if @heroSection
       extended.hero_section = null

--- a/client/test/models/article.test.coffee
+++ b/client/test/models/article.test.coffee
@@ -201,3 +201,8 @@ describe "Article simple mode", ->
 
     it 'does not serialize associations', ->
       JSON.stringify(@article.toJSON()).should.not.containEql '"hero_section"'
+
+    it 'serializes a hero_section with keys', ->
+      @article.set('hero_section', {type: 'text'})
+      JSON.stringify(@article.toJSON()).should.containEql '"hero_section"'
+      JSON.stringify(@article.toJSON().hero_section.type).should.containEql '"text"'


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1345
Resolves a bug where feature headers were saving inconsistent information. 

- Removes logic for using hero_section title from article model (titles are set directly on the article now)
- Allows hero_section to be saved with 1 or more keys (previously was overwriting 1 or less)
- Adds persistence tests for each hero_section feature layout
- Minor cleanup in the article header component