### PR TITLE
@damassi => Launch /edit2 to internal channels

### DIFF
--- a/client/apps/articles_list/client/client.coffee
+++ b/client/apps/articles_list/client/client.coffee
@@ -72,7 +72,7 @@ module.exports.ArticlesListView = ArticlesListView = React.createClass
           selected: null
           contentType: 'article'
           checkable: false
-          isEditorial: @props.channel.isEditorial() # TODO - REMOVE POST ARTICLE2
+          isArtsyChannel: @props.channel.isArtsyChannel() # TODO - REMOVE POST ARTICLE2
         }
     else
       @showEmptyMessage()

--- a/client/apps/edit/components/content2/section_container/index.coffee
+++ b/client/apps/edit/components/content2/section_container/index.coffee
@@ -7,7 +7,7 @@
 React = require 'react'
 _ = require 'underscore'
 Text = React.createFactory require '../sections/text/index.coffee'
-Video = require '../sections/video/index.jsx'
+{ SectionVideo } = require '../sections/video/index.jsx'
 Slideshow = React.createFactory require '../../content/sections/slideshow/index.coffee'
 Embed = React.createFactory require '../sections/embed/index.coffee'
 Fullscreen = React.createFactory require '../../content/sections/fullscreen/index.coffee'
@@ -79,7 +79,7 @@ module.exports = React.createClass
           }
       if @props.section.get('type') is 'video'
         React.createElement(
-          Video.default, @sectionProps()
+          SectionVideo, @sectionProps()
         )
       else
         (switch @props.section.get('type')

--- a/client/apps/edit/components/content2/section_controls/index.jsx
+++ b/client/apps/edit/components/content2/section_controls/index.jsx
@@ -27,7 +27,7 @@ export default class SectionControls extends Component {
 
   getHeaderSize = () => {
     // Add extra space for channels with Yoast
-    return this.props.channel.isEditorial() ? 95 : 55
+    return this.props.channel.isArtsyChannel() ? 95 : 55
   }
 
   getPositionBottom () {

--- a/client/apps/edit/components/content2/section_controls/index.styl
+++ b/client/apps/edit/components/content2/section_controls/index.styl
@@ -30,8 +30,8 @@
   transition opacity 0.3s
   opacity 0.5
   cursor pointer
-    &:hover
-      opacity 1
+  &:hover
+    opacity 1
   &[data-active=true]
     opacity 1
   &[name=fillwidth]

--- a/client/apps/edit/components/content2/section_controls/test/index.test.js
+++ b/client/apps/edit/components/content2/section_controls/test/index.test.js
@@ -183,7 +183,7 @@ describe('Section Controls', () => {
   })
 
   describe('#getHeaderSize', () => {
-    it('returns 55 when channel is not editorial', () => {
+    it('returns 55 when channel is not artsy channel', () => {
       const component = mount(
         <SectionControls {...props} />
       )
@@ -191,9 +191,8 @@ describe('Section Controls', () => {
       expect(header).toBe(55)
     })
 
-    it('returns 95 when channel is editorial', () => {
-      Channel.prototype.isEditorial = sinon.stub().returns(true)
-      Channel.prototype.hasFeature = sinon.stub().returns(true)
+    it('returns 95 when channel is artsy channel', () => {
+      Channel.prototype.isArtsyChannel = sinon.stub().returns(true)
       const component = mount(
         <SectionControls {...props} />
       )

--- a/client/apps/edit/components/content2/section_list/index.coffee
+++ b/client/apps/edit/components/content2/section_list/index.coffee
@@ -56,6 +56,7 @@ module.exports = React.createClass
           key: 1
           isEditing: @state.editingIndex isnt null
           firstSection: true
+          isDraggable: false
         }
       )
       if @props.sections.length
@@ -87,6 +88,7 @@ module.exports = React.createClass
                     index: i
                     key: 'tool-' + i
                     isEditing: @state.editingIndex isnt null
+                    isDraggable: false
                   }
                 )
               ]

--- a/client/apps/edit/components/content2/section_tool/index.jsx
+++ b/client/apps/edit/components/content2/section_tool/index.jsx
@@ -14,7 +14,6 @@ export default class SectionTool extends Component {
   constructor (props) {
     super(props)
 
-    this.type = {displayName: 'SectionTool'}
     this.state = {
       open: false
     }
@@ -150,6 +149,7 @@ SectionTool.propTypes = {
   firstSection: PropTypes.bool,
   index: PropTypes.number,
   isEditing: PropTypes.bool,
+  isDraggable: PropTypes.bool,
   isHero: PropTypes.bool,
   onSetEditing: PropTypes.func,
   section: PropTypes.object,

--- a/client/apps/edit/components/content2/sections/embed/test/index.test.coffee
+++ b/client/apps/edit/components/content2/sections/embed/test/index.test.coffee
@@ -28,7 +28,7 @@ describe 'SectionEmbed', ->
         section: new Section {type: 'embed'}
         editing: true
         article: new Backbone.Model {layout: 'standard'}
-        channel: { isEditorial: sinon.stub().returns(true) }
+        channel: { isArtsyChannel: sinon.stub().returns(true) }
         setEditing: ->
       ), (@$el = $ "<div></div>")[0], => setTimeout =>
         sinon.stub Backbone, 'sync'

--- a/client/apps/edit/components/content2/sections/image_collection/test/controls.test.js
+++ b/client/apps/edit/components/content2/sections/image_collection/test/controls.test.js
@@ -14,7 +14,7 @@ describe('ImageCollectionControls', () => {
     article: new Backbone.Model(StandardArticle),
     channel: {
       hasFeature: sinon.stub().returns(true),
-      isEditorial: sinon.stub().returns(true)
+      isArtsyChannel: sinon.stub().returns(true)
     },
     editing: true,
     onChange: jest.fn(),

--- a/client/apps/edit/components/content2/sections/image_collection/test/index.test.coffee
+++ b/client/apps/edit/components/content2/sections/image_collection/test/index.test.coffee
@@ -69,7 +69,7 @@ describe 'ImageCollection', ->
         setEditing: @setEditing = sinon.stub()
         article: new Backbone.Model
           layout: 'classic'
-        channel: { hasFeature: hasFeature = sinon.stub().returns(true), isEditorial: sinon.stub().returns(true) }
+        channel: { hasFeature: hasFeature = sinon.stub().returns(true), isArtsyChannel: sinon.stub().returns(true) }
       }
       @component = ReactDOM.render React.createElement(@ImageCollection, @props), (@$el = $ "<div></div>")[0], =>
       @component.onImagesLoaded = sinon.stub()

--- a/client/apps/edit/components/content2/sections/video/controls.jsx
+++ b/client/apps/edit/components/content2/sections/video/controls.jsx
@@ -1,12 +1,9 @@
+import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import FileInput from '../../../../../../components/file_input/index.jsx'
 import SectionControls from '../../section_controls/index.jsx'
 
-export default class VideoControls extends Component {
-  constructor (props) {
-    super(props)
-  }
-
+export class Controls extends Component {
   componentDidMount () {
     if (!this.props.section.get('url').length) {
       this.refs.input.focus()
@@ -22,26 +19,36 @@ export default class VideoControls extends Component {
   }
 
   render () {
+    const { articleLayout, channel, isHero, section, sectionLayouts, onProgress } = this.props
     return (
       <SectionControls
-        section={this.props.section}
-        channel={this.props.channel}
-        isHero={this.props.isHero}
-        sectionLayouts={this.props.sectionLayouts}
-        articleLayout={this.props.articleLayout}>
+        section={section}
+        channel={channel}
+        isHero={isHero}
+        sectionLayouts={sectionLayouts}
+        articleLayout={articleLayout}>
         <h2>Video</h2>
         <input
           className='bordered-input bordered-input-dark'
           onChange={this.onUrlChange}
-          defaultValue={this.props.section.get('url')}
+          defaultValue={section.get('url')}
           placeholder='Paste a youtube or vimeo url (e.g. http://youtube.com/watch?v=id)'
           ref='input' />
         <FileInput
           onUpload={this.onCoverImageChange}
-          onProgress={this.props.onProgress}
-          hasImage={this.props.section.get('cover_image_url')}
+          onProgress={onProgress}
+          hasImage={section.get('cover_image_url')}
           label='Cover Image' />
       </SectionControls>
     )
   }
+}
+
+Controls.propTypes = {
+  articleLayout: PropTypes.string,
+  channel: PropTypes.object,
+  isHero: PropTypes.bool,
+  section: PropTypes.object,
+  sectionLayouts: PropTypes.bool,
+  onProgress: PropTypes.func
 }

--- a/client/apps/edit/components/content2/sections/video/index.jsx
+++ b/client/apps/edit/components/content2/sections/video/index.jsx
@@ -1,17 +1,13 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
-import Controls from './controls.jsx'
 import Paragraph from '../../../../../../components/rich_text2/components/paragraph.coffee'
+import React, { Component } from 'react'
+import { Controls } from './controls.jsx'
 import { Video, IconRemove } from '@artsy/reaction-force/dist/Components/Publishing'
 
-export default class SectionVideo extends Component {
+export class SectionVideo extends Component {
   constructor (props) {
     super(props)
     this.state = { progress: null }
-  }
-
-  onCaptionChange = (html) => {
-    this.props.section.set('caption', html)
   }
 
   onClickOff = () => {
@@ -22,12 +18,6 @@ export default class SectionVideo extends Component {
 
   onProgress = (progress) => {
     this.setState({progress})
-  }
-
-  onRemoveImage = () => {
-    if (this.props.section.get('cover_image_url')) {
-      this.props.section.set('cover_image_url', null)
-    }
   }
 
   renderUploadProgress () {
@@ -59,7 +49,9 @@ export default class SectionVideo extends Component {
   renderRemoveButton () {
     if (this.props.section.get('cover_image_url')) {
       return (
-        <div className='edit-section__remove' onClick={this.onRemoveImage}>
+        <div
+          className='edit-section__remove'
+          onClick={() => this.props.section.set('cover_image_url', null)}>
           <IconRemove />
         </div>
       )
@@ -72,17 +64,13 @@ export default class SectionVideo extends Component {
       return (
         <Video
           layout={article.get('layout')}
-          section={{
-            caption: section.get('caption'),
-            url: section.get('url'),
-            cover_image_url: section.get('cover_image_url')
-          }}>
+          section={section.attributes}>
           {editing && this.renderRemoveButton()}
           <Paragraph
             type='caption'
             placeholder='Video Caption (required)'
             html={section.get('caption')}
-            onChange={this.onCaptionChange}
+            onChange={(html) => section.set('caption', html)}
             stripLinebreaks
             layout={article.get('layout')} />
         </Video>

--- a/client/apps/edit/components/content2/sections/video/index.styl
+++ b/client/apps/edit/components/content2/sections/video/index.styl
@@ -10,6 +10,8 @@
     &:hover
       circle
         fill red-color
+  .public-DraftEditorPlaceholder-inner
+    position absolute
   div[class*="video__VideoContainer-"]
     z-index -1
   &.is-editing

--- a/client/apps/edit/components/content2/sections/video/test/index.test.js
+++ b/client/apps/edit/components/content2/sections/video/test/index.test.js
@@ -1,7 +1,7 @@
-import React from 'react'
-import Video from '../index.jsx'
-import { mount, shallow } from 'enzyme'
 import Backbone from 'backbone'
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { SectionVideo } from '../index.jsx'
 
 describe('Video', () => {
 
@@ -23,7 +23,7 @@ describe('Video', () => {
 
   it('renders a placeholder', () => {
     const component = shallow(
-      <Video {...props} />
+      <SectionVideo {...props} />
     )
     expect(component.html()).toMatch('edit-section__placeholder')
     expect(component.text()).toMatch('Add a video above')
@@ -32,7 +32,7 @@ describe('Video', () => {
   it('renders a saved video and cover image', () => {
     props.section.set('url', 'https://youtu.be/Bv_5Zv5c-Ts')
     const component = mount(
-      <Video {...props} />
+      <SectionVideo {...props} />
     )
     expect(component.children().nodes[0].props.section.url).toMatch('https://youtu.be/Bv_5Zv5c-Ts')
     expect(component.children().nodes[0].props.section.cover_image_url).toMatch('http://image.jpg')
@@ -43,7 +43,7 @@ describe('Video', () => {
   it('renders the section controls when editing', () => {
     props.editing = true
     const component = mount(
-      <Video {...props} />
+      <SectionVideo {...props} />
     )
     expect(component.html()).toMatch('<div class="edit-controls"')
     expect(component.find('a.layout').length).toEqual(2)
@@ -55,7 +55,7 @@ describe('Video', () => {
     props.editing = true
     props.article.set('layout', 'feature')
     const component = mount(
-      <Video {...props} />
+      <SectionVideo {...props} />
     )
     expect(component.find('a.layout').length).toEqual(3)
   })
@@ -65,23 +65,23 @@ describe('Video', () => {
     props.editing = true
     props.section.set('url', 'https://youtu.be/Bv_5Zv5c-Ts')
     const component = mount(
-      <Video {...props} />
+      <SectionVideo {...props} />
     )
     expect(component.children().nodes[1].props.children[0].props.className).toMatch('edit-section__remove')
   })
 
-  it('#onRemoveImage removes the cover_image_url', () => {
+  it('Can remove the cover_image_url', () => {
     const component = mount(
-      <Video {...props} />
+      <SectionVideo {...props} />
     )
-    component.instance().onRemoveImage()
+    component.find('.edit-section__remove').simulate('click')
     expect(component.props().section.get('cover_image_url')).toBeFalsy()
   })
 
-  it('#onProgress sets state.progress and renders progress container if state.propgress is not null', () => {
+  it('#onProgress sets state.progress and renders progress container if state.progress is not null', () => {
     props.editing = true
     const component = mount(
-      <Video {...props} />
+      <SectionVideo {...props} />
     )
     component.instance().onProgress(.5)
     expect(component.state().progress).toEqual(.5)
@@ -92,7 +92,7 @@ describe('Video', () => {
     props.section.set('url', '')
     const spy = jest.spyOn(props.section, 'destroy')
     const component = mount(
-      <Video {...props} />
+      <SectionVideo {...props} />
     )
     component.instance().onClickOff()
     expect(spy).toHaveBeenCalled()

--- a/client/apps/edit/components/header/index.coffee
+++ b/client/apps/edit/components/header/index.coffee
@@ -10,7 +10,8 @@ module.exports = class EditHeader extends Backbone.View
     { @article } = options
     @finished = false
     @user = new User sd.USER
-    @article.on 'change', @saving
+    unless sd.EDIT_2
+      @article.on 'change', @saving
     @article.on 'change', @toggleCheckmarks
     @article.on 'error', @error
     @article.on 'sync', @done

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -21,9 +21,11 @@ module.exports = class EditLayout extends Backbone.View
     @article.on 'loading', @showSpinner
     @article.once 'sync', @onFirstSave if @article.isNew()
     @article.on 'savePublished', @savePublished
+    if @channel?.isArtsyChannel()
+      @setupYoast()
+      @article.on 'change', @onYoastKeyup
     @setupOnBeforeUnload()
     @toggleAstericks()
-    @setupYoast() if @channel.isEditorial()
     @$('#edit-sections-spinner').hide()
 
   onFirstSave: =>
@@ -114,7 +116,7 @@ module.exports = class EditLayout extends Backbone.View
       contentField: @getBodyText()
 
   onYoastKeyup: ->
-    return unless @channel.isEditorial()
+    return unless @channel?.isArtsyChannel()
     @yoastView.onKeyup @getBodyText()
 
   getBodyText: =>
@@ -179,5 +181,5 @@ module.exports = class EditLayout extends Backbone.View
     switch result._type
       when "artist" then "#{sd.FORCE_URL}/artist/#{result._source.slug}"
       when "partner" then "#{sd.FORCE_URL}/#{result._source.slug}"
-      when "city" then "#{sd.FORCE_URL}/#{result._source.slug}"
+      when "city" then "#{sd.FORCE_URL}/shows/#{result._source.slug}"
       else null

--- a/client/apps/edit/components/layout/index.jade
+++ b/client/apps/edit/components/layout/index.jade
@@ -6,7 +6,7 @@ block locals
 block content
   include ../header/index
   #edit-tab-pages
-    if sd.CURRENT_CHANNEL.get('type') === 'editorial'
+    if sd.CURRENT_CHANNEL.isArtsyChannel()
       #edit-seo
         .edit-seo__header-container
           .edit-seo__header

--- a/client/apps/edit/components/layout/test/index.coffee
+++ b/client/apps/edit/components/layout/test/index.coffee
@@ -17,6 +17,7 @@ describe 'EditLayout', ->
       sd = _.extend fixtures().locals.sd,
         CURRENT_CHANNEL: @channel = new Channel fixtures().channels
         USER: accessToken: 'foo'
+        FORCE_URL: 'https://artsy.net'
       locals = _.extend fixtures().locals,
         article: @article = new Article fixtures().articles
         sd: sd
@@ -27,6 +28,7 @@ describe 'EditLayout', ->
         sinon.stub Backbone.history, 'navigate'
         @EditLayout = rewire '../index.coffee'
         @EditLayout.__set__ 'YoastView', @YoastView = sinon.stub().returns onKeyup: @yoastKeyup = sinon.stub()
+        @EditLayout.__set__ 'sd', sd
         sinon.stub _, 'debounce'
         $.fn.autosize = sinon.stub()
         _.debounce.callsArg 0
@@ -119,12 +121,13 @@ describe 'EditLayout', ->
 
   describe '#onYoastKeyup', ->
 
-    it 'returns if its not an editorial channel', ->
-      @view.channel.set 'type', 'team'
+    it 'returns if its not an artsy internal channel', ->
+      @view.channel.set 'type', 'partner'
       @view.onYoastKeyup()
       @yoastKeyup.callCount.should.equal 0
 
     it 'calls onKeyup on the yoast view', ->
+      @view.channel.set 'type', 'team'
       @view.onYoastKeyup()
       @yoastKeyup.callCount.should.equal 1
 

--- a/client/components/article_list/index.coffee
+++ b/client/components/article_list/index.coffee
@@ -56,7 +56,7 @@ module.exports = React.createClass
             }
           a {
             className: 'article-list__article'
-            href: "/articles/#{result.id}/#{if @props.isEditorial then 'edit2' else 'edit'}"
+            href: "/articles/#{result.id}/#{if @props.isArtsyChannel then 'edit2' else 'edit'}"
           },   # TODO - ONLY EDIT POST ARTICLE2
             div {
               className: 'article-list__image paginated-list-img'

--- a/client/components/article_list/test/index.test.coffee
+++ b/client/components/article_list/test/index.test.coffee
@@ -57,12 +57,12 @@ describe 'ArticleList', ->
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Game of Thrones'
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'http://artsy.net/article/artsy-editorial-game-of-thrones'
 
-  it 'renders a link to /edit if not props.isEditorial', ->
+  it 'renders a link to /edit if not props.isArtsyChannel', ->
     rendered = ReactDOMServer.renderToString React.createElement(@ArticleList, @props)
     $(rendered).html().should.containEql 'href="/articles/125/edit"'
 
-  it 'renders a link to /edit2 if props.isEditorial', ->
-    @props.isEditorial = true
+  it 'renders a link to /edit2 if props.isArtsyChannel', ->
+    @props.isArtsyChannel = true
     rendered = ReactDOMServer.renderToString React.createElement(@ArticleList, @props)
     $(rendered).html().should.containEql 'href="/articles/125/edit2"'
 

--- a/client/components/drag_drop/index.coffee
+++ b/client/components/drag_drop/index.coffee
@@ -67,7 +67,8 @@ module.exports = React.createClass
       children.map (child, i) =>
         uniqueKey = if child.props.section then child.props.section.cid + i else i
 
-        if child.type.displayName is 'SectionTool' or !@props.isDraggable
+        if child.type.displayName is 'SectionTool' or #TODO - REMOVE DISPLAYNAME CHECK POST ARTICLE2
+         child.props.isDraggable is false or !@props.isDraggable
           child
         else
           i = child.props.index or i

--- a/client/components/filter_search/index.coffee
+++ b/client/components/filter_search/index.coffee
@@ -55,7 +55,7 @@ module.exports = React.createClass
           checkable: @props.checkable
           selected: @selected
           display: @props.display
-          isEditorial: @props.isEditorial  # TODO - REMOVE POST ARTICLE2
+          isArtsyChannel: @props.isArtsyChannel  # TODO - REMOVE POST ARTICLE2
         }
       else if @props.contentType is 'tag'
         TagList {

--- a/client/models/channel.coffee
+++ b/client/models/channel.coffee
@@ -15,6 +15,9 @@ module.exports = class Channel extends Backbone.Model
   isEditorial: ->
     @get('type') is 'editorial'
 
+  isArtsyChannel: ->
+    @get('type') in ['editorial', 'support', 'team']
+
   hasFeature: (feature) ->
     type = @get('type')
     if type is 'editorial'

--- a/client/test/models/channel.test.coffee
+++ b/client/test/models/channel.test.coffee
@@ -125,6 +125,23 @@ describe "Channel", ->
       @channel.hasAssociation('partners').should.be.true()
       @channel.hasAssociation('auctions').should.be.true()
 
+  describe '#isArtsyChannel', ->
+
+    beforeEach ->
+      @channel = new Channel fixtures().channels
+
+    it 'returns true for editorial type', ->
+      @channel.set
+        name: 'Editorial'
+        type: 'editorial'
+      @channel.isArtsyChannel().should.be.true()
+
+    it 'returns false for partner type', ->
+      @channel.set
+        name: 'Gagosian'
+        type: 'partner'
+      @channel.isArtsyChannel().should.be.false()
+
   describe '#fetchChannelOrPartner' , ->
 
     it 'returns an error if it cannot find either' , (done) ->


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1344
Closes https://github.com/artsy/positron/issues/1324
Closes https://github.com/artsy/positron/issues/1268
Closes https://github.com/artsy/positron/issues/1325
Closes https://github.com/artsy/publishing/issues/99

- Uses /edit2 for internal artsy channels
- Adds 'isArtsyChannel' to channel model to identify internal channels
- Adds Yoast to internal channels
- Fixes save indicators in edit header
- Fixes drag-drop bugs in /edit2
- Minor cleanup in the Video component