### PR TITLE
@eessex => Update relatedArticlesPanel resolver to include related_article_ids

### DIFF
--- a/api/apps/articles/model/index.js
+++ b/api/apps/articles/model/index.js
@@ -59,7 +59,7 @@ export const promisedMongoFetch = (input) => {
     .find(query)
     .skip(offset || 0)
     .sort(sort)
-    .limit(limit)
+    .limit(limit || 10)
   return new Promise((resolve, reject) => {
     async.parallel([
       cb => cursor.toArray(cb),

--- a/api/apps/articles/test/model/index/index.test.coffee
+++ b/api/apps/articles/test/model/index/index.test.coffee
@@ -146,3 +146,13 @@ describe 'Article', ->
       Article.getSuperArticleCount(id)
       .then (count) =>
         count.should.equal 1
+
+  describe '#promisedMongoFetch', ->
+    it 'returns results, counts, and totals', ->
+      fabricate 'articles', { _id: ObjectId('5086df098523e60002000018') }, ->
+        Article.promisedMongoFetch({ count: true, ids: [ObjectId('5086df098523e60002000018')] })
+        .then ({ count, total, results }) =>
+          count.should.equal 1
+          total.should.equal 11
+          results.length.should.equal 1
+

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -4,9 +4,10 @@ const Channel = require('api/apps/channels/model.coffee')
 const Curation = require('api/apps/curations/model.coffee')
 const Tag = require('api/apps/tags/model.coffee')
 const User = require('api/apps/users/model.coffee')
-const { mongoFetch, present, presentCollection, find } = require('api/apps/articles/model/index.js')
+const { promisedMongoFetch, mongoFetch, present, presentCollection, find } = require('api/apps/articles/model/index.js')
 const { ObjectId } = require('mongojs')
 const { DISPLAY_ID } = process.env
+const debug = require('debug')('api')
 
 export const articles = (root, args, req, ast) => {
   const unpublished = !args.published || args.scheduled
@@ -108,7 +109,6 @@ export const relatedArticlesPanel = (root) => {
   if (root.related_articles_ids) {
     omittedIds.concat(root.related_article_ids)
   }
-  console.log(omittedIds)
   const tags = root.tags || null
   const args = {
     omit: omittedIds,
@@ -124,21 +124,27 @@ export const relatedArticlesPanel = (root) => {
     limit: 3,
     published: true
   }
-  return new Promise((resolve, reject) => {
-    if (root.related_article_ids && root.related_article_ids.length > 0) {
-      mongoFetch(relatedArticleArgs, (err, relatedArticleResults) => {
-        if (err) { return reject(new Error(err)) }
-        mongoFetch(_.pick(args, _.identity), (err, results) => {
-          if (err) { return reject(new Error(err)) }
-          const limitedArticles = _.first(relatedArticleResults.results.concat(results.results), 3)
-          resolve(limitedArticles)
-        })
-      })
+
+  return new Promise(async (resolve, reject) => {
+    let relatedArticles = []
+
+    const articleResults = await promisedMongoFetch(_.pick(args, _.identity))
+    .catch((e) => reject(e))
+
+    if (root.related_article_ids && root.related_article_ids.length) {
+      // Fetch by related_article_ids and tags
+      const relatedArticleResults = await promisedMongoFetch(relatedArticleArgs)
+      .catch((e) => reject(e))
+
+      relatedArticles = _.first(relatedArticleResults.results.concat(articleResults.results), 3)
     } else {
-      mongoFetch(_.pick(args, _.identity), (err, results) => {
-        if (err) { return reject(new Error(err)) }
-        resolve(results.results)
-      })
+      relatedArticles = articleResults.results
+    }
+
+    if (relatedArticles.length) {
+      resolve(relatedArticles)
+    } else {
+      reject(new Error('No Results'))
     }
   })
 }

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -7,7 +7,6 @@ const User = require('api/apps/users/model.coffee')
 const { promisedMongoFetch, mongoFetch, present, presentCollection, find } = require('api/apps/articles/model/index.js')
 const { ObjectId } = require('mongojs')
 const { DISPLAY_ID } = process.env
-const debug = require('debug')('api')
 
 export const articles = (root, args, req, ast) => {
   const unpublished = !args.published || args.scheduled

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -132,10 +132,8 @@ export const relatedArticlesPanel = (root) => {
     .catch((e) => reject(e))
 
     if (root.related_article_ids && root.related_article_ids.length) {
-      // Fetch by related_article_ids and tags
       const relatedArticleResults = await promisedMongoFetch(relatedArticleArgs)
       .catch((e) => reject(e))
-
       relatedArticles = _.first(relatedArticleResults.results.concat(articleResults.results), 3)
     } else {
       relatedArticles = articleResults.results

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "rewire": "2.2.0",
     "should": "^7.1.0",
     "simple-modal": "git://github.com/craigspaeth/simple-modal.git",
-    "sinon": "^1.17.1",
+    "sinon": "^4.x.x",
     "sqwish": "^0.2.2",
     "typeahead.js": "0.10.x",
     "zombie": "^5.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,17 +43,6 @@
     superagent "^3.6.3"
     uuid "^3.0.1"
 
-"@artsy/stitch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@artsy/stitch/-/stitch-1.1.0.tgz#2e61d5957c240896b5d972f5ec512739d66d6d80"
-  dependencies:
-    babel-runtime "^6.26.0"
-    consolidate "^0.14.5"
-    lodash "^4.17.4"
-    react "^15.6.1"
-    react-dom "^15.6.1"
-    styled-components "^2.1.2"
-
 "@hypnosphi/fuse.js@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"
@@ -1949,10 +1938,6 @@ bluebird@^2.8.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
 
-bluebird@^3.1.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
@@ -2748,12 +2733,6 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-consolidate@^0.14.5:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.14.5.tgz#5a25047bc76f73072667c8cb52c989888f494c63"
-  dependencies:
-    bluebird "^3.1.1"
-
 constantinople@~3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/constantinople/-/constantinople-3.0.2.tgz#4b945d9937907bcd98ee575122c3817516544141"
@@ -3328,6 +3307,10 @@ detective@^4.0.0:
 diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+
+diff@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
 diff@^3.2.0:
   version "3.3.0"
@@ -4432,11 +4415,11 @@ form-data@~1.0.0-rc4:
     combined-stream "^1.0.5"
     mime-types "^2.1.11"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+formatio@1.2.0, formatio@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
-    samsam "~1.1"
+    samsam "1.x"
 
 formidable@^1.1.1:
   version "1.1.1"
@@ -5932,6 +5915,10 @@ jsx-ast-utils@^2.0.0:
   dependencies:
     array-includes "^3.0.3"
 
+just-extend@^1.1.22:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.22.tgz#3330af756cab6a542700c64b2e4e4aa062d52fff"
+
 jwa@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.0.2.tgz#fd79609f1e772e299dce8ddb76d00659dd83511f"
@@ -6157,6 +6144,10 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -6256,9 +6247,13 @@ lokka@^1.7.0:
     babel-runtime "6.x.x"
     uuid "2.x.x"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+lolex@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.1.3.tgz#53f893bbe88c80378156240e127126b905c83087"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -6586,6 +6581,10 @@ nan@^2.3.0, nan@~2.3:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.3.5.tgz#822a0dc266290ce4cd3a12282ca3e7e364668a08"
 
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -6629,6 +6628,16 @@ nib@^1.1.0:
   resolved "https://registry.yarnpkg.com/nib/-/nib-1.1.2.tgz#6a69ede4081b95c0def8be024a4c8ae0c2cbb6c7"
   dependencies:
     stylus "0.54.5"
+
+nise@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.1.1.tgz#1faa07147f3bf2465d4dbedc0e4a84048f081041"
+  dependencies:
+    formatio "^1.2.0"
+    just-extend "^1.1.22"
+    lolex "^1.6.0"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-dir@^0.1.10:
   version "0.1.17"
@@ -7166,6 +7175,12 @@ path-platform@~0.11.15:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -7865,7 +7880,7 @@ react-docgen@^2.15.0:
     node-dir "^0.1.10"
     recast "^0.11.5"
 
-react-dom@^15.5.4, react-dom@^15.6.1:
+react-dom@^15.5.4:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
@@ -8038,16 +8053,6 @@ react-url-query@^1.1.4:
 react@^15.5.4:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
-react@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
     create-react-class "^15.6.0"
     fbjs "^0.8.9"
@@ -8562,9 +8567,9 @@ sailthru-client@^2.0.3:
   dependencies:
     restler ">=0.2.3"
 
-samsam@1.1.2, samsam@~1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+samsam@1.x, samsam@^1.1.3:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
 sane@~1.6.0:
   version "1.6.0"
@@ -8816,14 +8821,20 @@ signal-exit@^3.0.0:
     cssify "*"
     jadeify "*"
 
-sinon@^1.17.1:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@^4.x.x:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.0.1.tgz#e46146a8a8420f837bdba32e2965bd1fe43d5b05"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lodash.get "^4.4.2"
+    lolex "^2.1.3"
+    native-promise-only "^0.8.1"
+    nise "^1.1.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -9360,6 +9371,10 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-encoding@0.6.4, text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -9496,6 +9511,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-is@~1.6.14:
   version "1.6.14"
@@ -9663,7 +9682,7 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3, util@~0.10.1:
+util@0.10.3, util@^0.10.3, util@~0.10.1:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:


### PR DESCRIPTION
- Takes `related_article_ids` into account for the `relatedArticlesPanel` resolver
- Updates sinon a few major versions which gives us `.resolves` and `.rejects` support 
- Adds a `promisedMongoFetch` method