### PR TITLE
@damassi => Fix relatedArticlesPanel resolver

### DIFF
--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -108,7 +108,8 @@ export const relatedArticlesPanel = (root) => {
   if (root.related_articles_ids) {
     omittedIds.concat(root.related_article_ids)
   }
-  const tags = root.tags || null
+  const tags = (root.tags && root.tags.length > 0) ? root.tags : null
+
   const args = {
     omit: omittedIds,
     published: true,
@@ -118,6 +119,7 @@ export const relatedArticlesPanel = (root) => {
     limit: 3,
     sort: '-published_at'
   }
+
   const relatedArticleArgs = {
     ids: root.related_article_ids,
     limit: 3,

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -223,6 +223,15 @@ describe('resolvers', () => {
         e.message.should.containEql('No Results')
       })
     })
+
+    it('strips tags from args when the article does not have tags', async () => {
+      promisedMongoFetch.onFirstCall().resolves(articles)
+      await resolvers.relatedArticlesPanel({
+        id: '54276766fd4f50996aeca2b8',
+        tags: []
+      })
+      Object.keys(promisedMongoFetch.args[0][0]).should.not.containEql('tags')
+    })
   })
 
   describe('tags', () => {


### PR DESCRIPTION
The standard article was breaking for articles that had empty tags. This fixes the query to account for both `tags: null` and `tags: []`