### PR TITLE
@eessex => Support SOV less than 100%

### DIFF
--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -1,4 +1,5 @@
 import _ from 'underscore'
+import should from 'should'
 import rewire from 'rewire'
 import sinon from 'sinon'
 const app = require('api/index.coffee')
@@ -197,7 +198,7 @@ describe('resolvers', () => {
       resolvers.__set__('Curation', { mongoFetch: (sinon.stub().yields(null, display)) })
 
       const result = await resolvers.display({}, {}, req, {})
-      result.should.be.false()
+      _.isNull(result).should.be.true()
     })
   })
 

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -149,8 +149,15 @@ describe('resolvers', () => {
     it('can fetch campaign data', async () => {
       const display = {
         total: 20,
-        count: 1,
-        results: [{ campaigns: [fixtures().display] }]
+        count: 4,
+        results: [{
+          campaigns: [
+            fixtures().display,
+            fixtures().display,
+            fixtures().display,
+            fixtures().display
+          ]
+        }]
       }
       resolvers.__set__('Curation', { mongoFetch: (sinon.stub().yields(null, display)) })
 
@@ -158,6 +165,39 @@ describe('resolvers', () => {
       result.name.should.equal('Sample Campaign')
       result.canvas.headline.should.containEql('Sample copy')
       result.panel.headline.should.containEql('Euismod Inceptos Quam')
+    })
+
+    it('rejects if SOV is over 100%', async () => {
+      const display = {
+        total: 20,
+        count: 2,
+        results: [{
+          campaigns: [
+            fixtures().display,
+            fixtures().display,
+            fixtures().display,
+            fixtures().display,
+            fixtures().display
+          ]
+        }]
+      }
+      resolvers.__set__('Curation', { mongoFetch: (sinon.stub().yields(null, display)) })
+
+      await resolvers.display({}, {}, req, {}).catch((e) => {
+        e.message.should.containEql('Share of voice sum cannot be greater than 100')
+      })
+    })
+
+    it('resolves null if there are no campaigns', async () => {
+      const display = {
+        total: 20,
+        count: 1,
+        results: [{ campaigns: [] }]
+      }
+      resolvers.__set__('Curation', { mongoFetch: (sinon.stub().yields(null, display)) })
+
+      const result = await resolvers.display({}, {}, req, {})
+      result.should.be.false()
     })
   })
 

--- a/client/apps/display/routes.js
+++ b/client/apps/display/routes.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom/server'
+import request from 'superagent'
 import { DisplayPanel } from '@artsy/reaction-force/dist/Components/Publishing/Display/DisplayPanel'
 import { ServerStyleSheet } from 'styled-components'
 import { DisplayQuery } from 'client/apps/display/query'
-import request from 'superagent'
 
 const { API_URL } = process.env
 
@@ -11,11 +11,15 @@ export const display = (req, res, next) => {
   request
   .post(API_URL + '/graphql')
   .set('Accept', 'application/json')
-  .query({query: DisplayQuery})
+  .query({ query: DisplayQuery })
   .end((err, response) => {
     if (err) { return next(err) }
 
     const display = response.body.data.display
+    if (!display) {
+      return res.sendStatus(404)
+    }
+
     const DisplayPanelComponent = React.createFactory(DisplayPanel)
     const sheet = new ServerStyleSheet()
     const body = ReactDOM.renderToString(

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -210,7 +210,7 @@ module.exports = ->
       ]
       logo: 'https://artsy-vanity-files-production.s3.amazonaws.com/images/artsy_logo_square_white_transparent.png',
       link: { text: '', url: 'http://artsy.net' }
-    sov: .75
+    sov: .25
     start_date: new Date
   fixtures.locals =
     asset: ->


### PR DESCRIPTION
Returns `display: null` if there is no ad to show which Force/Reaction can safely handle. On the static endpoint, it returns a 404 error. As far as I can tell, IA doesn't have a great way to handle hiding an ad so I'm going to experiment with this 404 and see if I can get something to work in their [Developer tools](https://business.facebook.com/artsy/publishing_tools/?section=INSTANT_ARTICLES_DEVELOPMENT)