### PR TITLE
@damassi => Resolve null instead of throwing errors on RelatedArticle queries

### DIFF
--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -172,13 +172,16 @@ export const relatedArticlesCanvas = (root) => {
     limit: 4,
     sort: '-published_at'
   }
-  return new Promise((resolve, reject) => {
-    mongoFetch(_.pick(args, _.identity), (err, results) => {
-      if (err) {
-        reject(new Error(err))
-      }
-      resolve(results.results)
-    })
+
+  return new Promise(async (resolve, reject) => {
+    const { results } = await promisedMongoFetch(_.pick(args, _.identity))
+    .catch((e) => reject(e))
+
+    if (results.length) {
+      resolve(results)
+    } else {
+      resolve(null)
+    }
   })
 }
 

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -156,7 +156,7 @@ export const relatedArticlesPanel = (root) => {
     if (relatedArticles.length) {
       resolve(relatedArticles)
     } else {
-      reject(new Error('No Results'))
+      resolve(null)
     }
   })
 }

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -1,5 +1,4 @@
 import _ from 'underscore'
-import should from 'should'
 import rewire from 'rewire'
 import sinon from 'sinon'
 const app = require('api/index.coffee')
@@ -204,12 +203,22 @@ describe('resolvers', () => {
 
   describe('relatedArticlesCanvas', () => {
     it('can find related articles for the canvas', async () => {
+      promisedMongoFetch.onFirstCall().resolves(articles)
       const results = await resolvers.relatedArticlesCanvas({
         id: '54276766fd4f50996aeca2b8',
         vertical: { id: '54276766fd4f50996aeca2b3' }
       })
       results.length.should.equal(1)
       results[0].vertical.id.should.equal('54276766fd4f50996aeca2b3')
+    })
+
+    it('resolves null if it does not have articles', async () => {
+      promisedMongoFetch.onFirstCall().resolves({ results: [] })
+      const results = await resolvers.relatedArticlesCanvas({
+        id: '54276766fd4f50996aeca2b8',
+        vertical: { id: '54276766fd4f50996aeca2b3' }
+      })
+      _.isNull(results).should.be.true()
     })
   })
 

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -255,14 +255,13 @@ describe('resolvers', () => {
       })
     })
 
-    it('returns an error if there are no articles', async () => {
+    it('resolves null if there are no articles', async () => {
       promisedMongoFetch.onFirstCall().resolves({ results: [] })
-      await resolvers.relatedArticlesPanel({
+      const result = await resolvers.relatedArticlesPanel({
         id: '54276766fd4f50996aeca2b8',
         tags: ['dog', 'cat']
-      }).catch((e) => {
-        e.message.should.containEql('No Results')
       })
+      _.isNull(result).should.be.true()
     })
 
     it('strips tags from args when the article does not have tags', async () => {


### PR DESCRIPTION
All non-editorial articles on article2 pages are currently broken like this one: https://www.artsy.net/article2/gallery-insights-the-pop-up-gallery-checklist

They're sadly breaking on related article queries again. I'm thinking of fixing this in two parts. First, we should stop throwing errors if there are no articles to show -- instead resolve with null. 

The second part will be on this try/catch in Force [here](https://github.com/artsy/force/blob/master/desktop/apps/article2/routes.js#L20-L21). I'm thinking of removing the block and handling errors manually. That way, if one of the resolvers throws an error, we don't have to kill the entire page. What's happening now is that the above article can't reach [this line](https://github.com/artsy/force/blob/master/desktop/apps/article2/routes.js#L28) since the Graphql fetch contains an error. 
