### PR TITLE
@kanaabe => Set default campaign SOV

### DIFF
--- a/client/apps/settings/client/curations/display/index.jsx
+++ b/client/apps/settings/client/curations/display/index.jsx
@@ -41,7 +41,7 @@ export default class DisplayAdmin extends React.Component {
 
   newCampaign = () => {
     const newCuration = this.state.curation.clone()
-    const newCampaign = {panel: {assets: []}, canvas: {assets: []}}
+    const newCampaign = {sov: 0.25, panel: {assets: []}, canvas: {assets: []}}
     newCuration.get('campaigns').push(newCampaign)
     this.setState({
       curation: newCuration,

--- a/client/apps/settings/client/curations/display/tests/index.test.jsx
+++ b/client/apps/settings/client/curations/display/tests/index.test.jsx
@@ -77,6 +77,7 @@ describe('Display Admin', () => {
     component.find('button').at(1).simulate('click')
     expect(component.find(DropDownItem).length).toBe(3)
     expect(component.state().curation.get('campaigns').length).toBe(3)
+    expect(component.state().curation.get('campaigns')[2].sov).toBe(0.25)
     expect(component.state().activeSection).toBe(2)
   })
 })


### PR DESCRIPTION
Fixes bug where campaign SOV was not saving unless set.  Adds a default sov of '.25' when creating a campaign.

Alternatively we could set the default to 0, does that seem a useful option to have?