### PR TITLE
@eessex => Fixes authors query to return null when no authors_ids

### DIFF
--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -70,12 +70,20 @@ export const relatedAuthors = (root) => {
     ids: root.author_ids
   }
   return new Promise(async (resolve, reject) => {
-    Author.mongoFetch(args, (err, results) => {
-      if (err) {
-        reject(new Error(err))
-      }
-      resolve(results.results)
-    })
+    if (args.ids && args.ids.length) {
+      Author.mongoFetch(args, (err, {results}) => {
+        if (err) {
+          reject(new Error(err))
+        }
+        if (results.length) {
+          resolve(results)
+        } else {
+          resolve(null)
+        }
+      })
+    } else {
+      resolve(null)
+    }
   })
 }
 

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -77,10 +77,13 @@ export const relatedAuthors = (root) => {
         }
         if (results.length) {
           resolve(results)
+        } else {
+          resolve(null)
         }
       })
+    } else {
+      resolve(null)
     }
-    resolve(null)
   })
 }
 

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -77,13 +77,10 @@ export const relatedAuthors = (root) => {
         }
         if (results.length) {
           resolve(results)
-        } else {
-          resolve(null)
         }
       })
-    } else {
-      resolve(null)
     }
+    resolve(null)
   })
 }
 

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -131,13 +131,28 @@ describe('resolvers', () => {
 
   describe('relatedAuthors', () => {
     it('can find authors', async () => {
-      const args = {ids: [{ id: '123' }]}
-      const results = await resolvers.relatedAuthors({}, args, req, {})
+      const root = { author_ids: [{ id: '123' }] }
+      const results = await resolvers.relatedAuthors(root)
       results.length.should.equal(1)
       results[0].name.should.equal('Halley Johnson')
       results[0].bio.should.equal('Writer based in NYC')
       results[0].twitter_handle.should.equal('kanaabe')
       results[0].image_url.should.equal('https://artsy-media.net/halley.jpg')
+    })
+
+    it('returns null if there are no authors from fetch', async () => {
+      resolvers.__set__('Author', {
+        mongoFetch: sinon.stub().yields(null, { results: [] })
+      })
+      const root = { author_ids: [{ id: '123' }] }
+      const results = await resolvers.relatedAuthors(root)
+      _.isNull(results).should.be.true()
+    })
+
+    it('returns null if the article has no author_ids', async () => {
+      const root = { author_ids: null }
+      const results = await resolvers.relatedAuthors(root)
+      _.isNull(results).should.be.true()
     })
   })
 


### PR DESCRIPTION
If there are no `author_ids`, we should resolve with null which avoids rendering the Author component. Right now, a query like: 
```
{
  article(id:"editorial-heraldic-patterns-and-funky-variances-in-polly") {
    authors{
      id
      name
    }
  }
}
```

Returns 10 of the latest authors since the null value defaults to a `find({})` on the Authors collection. 