### PR TITLE
@kanaabe => add slideshows back

### DIFF
--- a/client/apps/edit/components/content2/section_container/index.coffee
+++ b/client/apps/edit/components/content2/section_container/index.coffee
@@ -8,9 +8,8 @@ React = require 'react'
 _ = require 'underscore'
 Text = React.createFactory require '../sections/text/index.coffee'
 { SectionVideo } = require '../sections/video/index.jsx'
-Slideshow = React.createFactory require '../../content/sections/slideshow/index.coffee'
+Slideshow = React.createFactory require '../sections/slideshow/index.coffee'
 Embed = React.createFactory require '../sections/embed/index.coffee'
-Fullscreen = React.createFactory require '../../content/sections/fullscreen/index.coffee'
 ImageCollection = React.createFactory require '../sections/image_collection/index.coffee'
 { div, nav, button } = React.DOM
 icons = -> require('../../icons.jade') arguments...
@@ -62,21 +61,20 @@ module.exports = React.createClass
       'data-type': @props.section.get('type')
       'data-layout': @props.section.get('layout') or 'column_width'
     },
-      unless @props.section.get('type') is 'fullscreen'
-        div {
-          className: 'edit-section__hover-controls'
-          onClick: @setEditing(on)
-        },
-          unless @props.isHero
-            button {
-              className: "edit-section__drag button-reset"
-              dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
-            }
+      div {
+        className: 'edit-section__hover-controls'
+        onClick: @setEditing(on)
+      },
+        unless @props.isHero
           button {
-            className: "edit-section__remove button-reset"
-            onClick: @removeSection
-            dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
+            className: "edit-section__drag button-reset"
+            dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
           }
+        button {
+          className: "edit-section__remove button-reset"
+          onClick: @removeSection
+          dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
+        }
       if @props.section.get('type') is 'video'
         React.createElement(
           SectionVideo, @sectionProps()
@@ -86,10 +84,8 @@ module.exports = React.createClass
           when 'text' then Text
           when 'slideshow' then Slideshow
           when 'embed' then Embed
-          when 'fullscreen' then Fullscreen
           when 'image_set' then ImageCollection
           when 'image_collection' then ImageCollection
-          when 'image' then ImageCollection
         )( @sectionProps() )
       div {
         className: 'edit-section__container-bg'

--- a/client/apps/edit/components/content2/section_list/test/index.test.coffee
+++ b/client/apps/edit/components/content2/section_list/test/index.test.coffee
@@ -48,7 +48,16 @@ describe 'SectionList', ->
         sections: @sections = new Sections [
           { body: 'Foo to the bar', type: 'text' }
           { body: 'Foo to the bar', type: 'text' }
-          { type: 'image', url: 'http://artsy.net/image.jpg', caption: '<p>An image caption</p>', layout: 'column_width'}
+          {
+            type: 'image_collection'
+            images: [
+              {
+                url: 'http://artsy.net/image.jpg'
+                caption: '<p>An image caption</p>'
+              }
+            ]
+            layout: 'column_width'
+          }
           {
             type: 'image_collection'
             images: [

--- a/client/apps/edit/components/content2/sections/header/test/index.test.js
+++ b/client/apps/edit/components/content2/sections/header/test/index.test.js
@@ -165,7 +165,7 @@ describe('Header', () => {
       expect(component.html()).toMatch('StandardHeader__Vertical')
       expect(component.html()).toMatch('Art Market')
       expect(component.html()).toMatch('StandardHeader__Title')
-      expect(component.html()).toMatch('Artsy Editorial')
+      expect(component.html()).toMatch('Artsy Editors')
     })
 
     it('renders a saved title', () => {

--- a/client/apps/edit/components/content2/sections/slideshow/index.coffee
+++ b/client/apps/edit/components/content2/sections/slideshow/index.coffee
@@ -1,0 +1,61 @@
+#
+# Slideshow section that appears at the top of a post. Used mainly as a way
+# to drop in in migrated posts.
+#
+
+_ = require 'underscore'
+React = require 'react'
+imagesLoaded = require 'imagesloaded'
+{ getIframeUrl } = require '../../../../../../models/section.coffee'
+{ div, section, ul, li, img, p, strong, iframe } = React.DOM
+
+module.exports = React.createClass
+  displayName: 'SectionSlideshow'
+
+  componentDidMount: ->
+    @props.section.fetchSlideshowArtworks success: => @forceUpdate()
+    # @lockWidths()
+
+  componentDidUpdate: ->
+    # @lockWidths()
+
+  lockWidths: ->
+    imagesLoaded @refs.list, =>
+      width = 0
+      $(@refs.list).children('li').each ->
+        $(this).width $(this).find('img').width()
+        width += $(this).outerWidth(true)
+      $(@refs.list).width width
+
+  render: ->
+    section { className: 'edit-section--slideshow' },
+      div { className: 'ess-container', onClick: @props.setEditing(on) },
+        ul { className: 'ess-list', ref: 'list' },
+          (for item in @props.section.get('items')
+            li {},
+              (switch item.type
+                when 'artwork'
+                  (
+                    if (artwork = @props.section.artworks.findWhere _id: item.id)?
+                      [
+                        img { src: artwork.imageUrl() }
+                        div { className: 'ess-artwork-details' },
+                          p {},
+                            strong {}, artwork.get('artist')?.name
+                          p {}, artwork.get('title')
+                          p {}, artwork.get('partner')?.name
+                      ]
+                    else
+                      div { className: 'ess-loading-artwork' },
+                        div { className: 'loading-spinner' }
+                  )
+                when 'image'
+                  img { src: item.url }
+                when 'video'
+                  iframe {
+                    src: getIframeUrl(item.url)
+                    height: '500px'
+                    width: '888px'
+                  }
+              )
+          )

--- a/client/apps/edit/components/content2/sections/slideshow/index.styl
+++ b/client/apps/edit/components/content2/sections/slideshow/index.styl
@@ -1,6 +1,5 @@
 @import '../../../stylus_lib'
 
-img-height = 500px
 li-height = 620px
 
 .edit-section-container[data-type=slideshow]
@@ -10,10 +9,10 @@ li-height = 620px
 .edit-section-container[data-type=slideshow]
 .edit-section-container[data-type=slideshow] .edit-section-hover-controls
 .edit-section-container[data-type=slideshow][data-editing=true]::after
-.edit-section-slideshow li
+.edit-section--slideshow li
   height li-height
 
-.edit-section-slideshow
+.edit-section--slideshow
   li
     display inline-block
     vertical-align top
@@ -21,15 +20,10 @@ li-height = 620px
     text-align left
     img
       max-height 100%
-      height img-height
+      height 500px
 
   .ess-container
-    margin-left (sidebar-width + controls-padding * 2)
-    width "calc(100% - %s)" % (sidebar-width + controls-padding * 2)
-    left 0
-    position absolute
     overflow scroll
-    text-align center
 
   .ess-list
     width 99999px

--- a/client/apps/edit/components/content2/sections/slideshow/test/index.coffee
+++ b/client/apps/edit/components/content2/sections/slideshow/test/index.coffee
@@ -1,0 +1,49 @@
+benv = require 'benv'
+sinon = require 'sinon'
+Backbone = require 'backbone'
+{ resolve } = require 'path'
+React = require 'react'
+ReactDOM = require 'react-dom'
+ReactTestUtils = require 'react-addons-test-utils'
+ReactDOMServer = require 'react-dom/server'
+Section = require '../../../../../../../models/section'
+fixtures = require '../../../../../../../../test/helpers/fixtures'
+
+describe 'SectionSlideshow', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose $: benv.require 'jquery'
+      @SectionSlideshow = benv.require resolve __dirname, '../index'
+      sinon.stub Backbone, 'sync'
+      @component = ReactDOM.render React.createElement(@SectionSlideshow,
+        section: new Section { type: 'slideshow', items: [
+          { type: 'artwork', id: 'foo' }
+          { type: 'artwork', id: 'bar' }
+        ] }
+        editing: false
+        setEditing: ->
+        changeLayout: ->
+      ), (@$el = $ "<div></div>")[0], => setTimeout =>
+        sinon.stub @component, 'setState'
+        done()
+
+  afterEach ->
+    Backbone.sync.restore()
+    benv.teardown()
+
+  it 'fetches the artworks on mount', ->
+    @component.componentDidMount()
+    Backbone.sync.args[0][1].url().should.containEql 'foo'
+    Backbone.sync.args[1][1].url().should.containEql 'bar'
+
+  it 'renders the images', ->
+    rendered = ReactDOMServer.renderToString React.createElement(@SectionSlideshow,
+      section: new Section { type: 'slideshow', items: [
+        { type: 'image', url: 'http://foobar.jpg' }
+      ] }
+      editing: false
+      setEditing: ->
+      changeLayout: ->
+    )
+    $(rendered).html().should.containEql 'http://foobar.jpg'

--- a/client/apps/edit/index.styl
+++ b/client/apps/edit/index.styl
@@ -25,6 +25,7 @@
 @import './components/content2/sections/embed'
 @import './components/content2/sections/header'
 @import './components/content2/sections/image_collection'
+@import './components/content2/sections/slideshow'
 @import './components/content2/sections/text'
 @import './components/content2/sections/video'
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.0.2",
-    "@artsy/reaction-force": "^0.10.2",
+    "@artsy/reaction-force": "^0.11.2",
     "airtable": "^0.4.5",
     "artsy-backbone-mixins": "artsy/artsy-backbone-mixins",
     "artsy-ezel-components": "artsy/artsy-ezel-components",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@^0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.10.2.tgz#c949c3e5c0dfec5b8574b7fe6f32580044e11989"
+"@artsy/reaction-force@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.11.2.tgz#6d1ce4ca9fa322eec24ca384eaaaec378c014145"
   dependencies:
     "@storybook/addon-options" "^3.2.1"
     "@storybook/react" "^3.2.12"


### PR DESCRIPTION
They aren't pretty, but they're back!

- Adds slideshows to `/content2`
- Adds slideshows to `SectionContainer`
- Removes support for fullscreen and image from SectionContainer
- Update Reaction to 11.2