### PR TITLE
@kanaabe => Remove edit2 references

### DIFF
--- a/client/apps/edit/client.coffee
+++ b/client/apps/edit/client.coffee
@@ -12,8 +12,7 @@ EditLayout = require './components/layout/index.coffee'
 EditHeader = require './components/header/index.coffee'
 EditDisplay = require './components/display/index.coffee'
 EditAdmin = React.createFactory require './components/admin/index.coffee'
-EditContent = React.createFactory require './components/content/index.coffee'
-EditContent2 = React.createFactory require './components/content2/index.coffee'
+EditContent = React.createFactory require './components/content2/index.coffee'
 
 async = require 'async'
 
@@ -28,13 +27,7 @@ async = require 'async'
     EditAdmin(article: @article, channel: channel)
     $('#edit-admin')[0]
   )
-  if sd.EDIT_2
-    ReactDOM.render(
-      EditContent2(article: @article, channel: channel)
-      $('#edit-content')[0]
-    )
-  else
-    ReactDOM.render(
-      EditContent(article: @article, channel: channel)
-      $('#edit-content')[0]
-    )
+  ReactDOM.render(
+    EditContent(article: @article, channel: channel)
+    $('#edit-content')[0]
+  )

--- a/client/apps/edit/index.coffee
+++ b/client/apps/edit/index.coffee
@@ -11,4 +11,3 @@ app.set 'view engine', 'jade'
 
 app.get '/articles/new', routes.create
 app.get '/articles/:id/edit', routes.edit
-app.get '/articles/:id/edit2', routes.edit

--- a/client/apps/edit/routes.coffee
+++ b/client/apps/edit/routes.coffee
@@ -24,7 +24,6 @@ sd = require('sharify').data
       return next() unless req.user.hasArticleAccess article
       res.locals.sd.ACCESS_TOKEN = req.user.get('access_token')
       res.locals.sd.CURRENT_CHANNEL = new Channel req.user.get('current_channel')
-      res.locals.sd.EDIT_2 = req.originalUrl.includes('/edit2') and req.user.isAdmin()
       if (article.get('channel_id') or article.get('partner_channel_id')) isnt req.user.get('current_channel').id
         res.redirect "/switch_channel/#{article.get('channel_id') or article.get('partner_channel_id')}?redirect-to=#{req.url}"
       else

--- a/client/apps/edit/test/routes.test.coffee
+++ b/client/apps/edit/test/routes.test.coffee
@@ -95,11 +95,3 @@ describe 'routes', ->
         channel_id: null
       @res.redirect.calledOnce.should.be.true()
       @res.redirect.args[0][0].should.containEql '/switch_channel/1234?'
-
-    it 'can render the edit2 app', ->
-      @req.originalUrl = 'foo/edit2'
-      @req.user.set current_channel: id: '4d8cd73191a5c50ce200002b'
-      @req.params.id = 'foo'
-      @routes.edit @req, @res
-      Backbone.sync.args[0][2].success a = _.extend fixtures().articles, channel_id: '4d8cd73191a5c50ce200002b'
-      @res.locals.sd.EDIT_2.should.eql true

--- a/client/assets/main.coffee
+++ b/client/assets/main.coffee
@@ -12,7 +12,6 @@ class Router extends Backbone.Router
   routes:
     'articles/new': 'articleEdit'
     'articles/:id/edit': 'articleEdit'
-    'articles/:id/edit2': 'articleEdit'
     'settings/curations/:id/edit': 'curationsEdit'
     'settings/channels/:id/edit': 'channelsEdit'
     'queue': 'queueEdit'

--- a/client/components/article_list/index.coffee
+++ b/client/components/article_list/index.coffee
@@ -56,8 +56,8 @@ module.exports = React.createClass
             }
           a {
             className: 'article-list__article'
-            href: "/articles/#{result.id}/#{if @props.isArtsyChannel then 'edit2' else 'edit'}"
-          },   # TODO - ONLY EDIT POST ARTICLE2
+            href: "/articles/#{result.id}/edit"
+          },
             div {
               className: 'article-list__image paginated-list-img'
               style: if attrs.image then backgroundImage: "url(#{attrs.image})" else {}

--- a/client/components/article_list/test/index.test.coffee
+++ b/client/components/article_list/test/index.test.coffee
@@ -57,14 +57,9 @@ describe 'ArticleList', ->
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Game of Thrones'
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'http://artsy.net/article/artsy-editorial-game-of-thrones'
 
-  it 'renders a link to /edit if not props.isArtsyChannel', ->
+  it 'renders a link to /edit', ->
     rendered = ReactDOMServer.renderToString React.createElement(@ArticleList, @props)
     $(rendered).html().should.containEql 'href="/articles/125/edit"'
-
-  it 'renders a link to /edit2 if props.isArtsyChannel', ->
-    @props.isArtsyChannel = true
-    rendered = ReactDOMServer.renderToString React.createElement(@ArticleList, @props)
-    $(rendered).html().should.containEql 'href="/articles/125/edit2"'
 
   it 'selects the article when clicking the check button', ->
     r.simulate.click @component.refs['123']


### PR DESCRIPTION
A soft launch -- this turns on edit2 for everyone, and removes the dual routing system. 

In a separate PR I will `content2`, it's going to require a fine tooth comb and don't want to rush deleting tons of code for tonight. 
