### PR TITLE
@kanaabe => Add cover_img_url to GraphQL query

### DIFF
--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -1,5 +1,6 @@
 import _ from 'underscore'
 import moment from 'moment'
+import { get } from 'lodash'
 const Author = require('api/apps/authors/model.coffee')
 const Channel = require('api/apps/channels/model.coffee')
 const Curation = require('api/apps/curations/model.coffee')
@@ -114,10 +115,17 @@ export const display = (root, args, req, ast) => {
     Curation.mongoFetch({
       '_id': ObjectId(DISPLAY_ID)
     }, (err, { results }) => {
-      if (err) { reject(new Error(err)) }
+      if (err) {
+        reject(new Error(err))
+      }
+      if (!results.length) {
+        resolve(null)
+      }
 
+      const firstResultCampaigns = get(results, '0.campaigns', [])
       const outcomes = []
-      results[0].campaigns.map((campaign, i) => {
+
+      firstResultCampaigns.map((campaign, i) => {
         const weightedCampaignArray = _.times((campaign.sov * 100), () => campaign.name)
         outcomes.push(...weightedCampaignArray)
       })

--- a/api/apps/graphql/schemas/display.js
+++ b/api/apps/graphql/schemas/display.js
@@ -11,6 +11,7 @@ const unitSchema = Joi.object().meta({
     })
   ),
   body: Joi.string(),
+  cover_img_url: Joi.string(),
   disclaimer: Joi.string(),
   headline: Joi.string(),
   layout: Joi.string(),

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -216,6 +216,17 @@ describe('resolvers', () => {
       })
     })
 
+    it('resolves null if there are no results', async () => {
+      const display = {
+        total: 20,
+        count: 1,
+        results: []
+      }
+      resolvers.__set__('Curation', { mongoFetch: (sinon.stub().yields(null, display)) })
+      const result = await resolvers.display({}, {}, req, {})
+      _.isNull(result).should.be.true()
+    })
+
     it('resolves null if there are no campaigns', async () => {
       const display = {
         total: 20,


### PR DESCRIPTION
Addresses https://github.com/artsy/publishing/issues/221. 

Adds a new `cover_img_url` to query and fixes an issue with zero results in display fetches. 