### PR TITLE
@eessex => Require underscore in a few missing places

### DIFF
--- a/client/apps/edit/components/admin/appearances/index.coffee
+++ b/client/apps/edit/components/admin/appearances/index.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore'
 React = require 'react'
 ReactDOM = require 'react-dom'
 { div, label } = React.DOM

--- a/client/apps/edit/components/admin/article/index.coffee
+++ b/client/apps/edit/components/admin/article/index.coffee
@@ -28,7 +28,7 @@ module.exports = AdminArticle = React.createClass
     return 'classic' unless @props.channel?.isEditorial()
     return @props.article?.get('layout') or 'standard'
 
-  onChange: (key, value)->
+  onChange: (key, value) ->
     @props.onChange key, value
     @forceUpdate()
 

--- a/client/apps/edit/components/admin/test/article.test.coffee
+++ b/client/apps/edit/components/admin/test/article.test.coffee
@@ -188,7 +188,6 @@ describe 'AdminArticle', ->
       @component.onChange.args[0][0].should.eql 'published_at'
       @component.onChange.args[0][1].should.containEql moment().local().subtract(1, 'years').format('YYYY-MM-DD')
 
-
   describe 'onChange', ->
 
     it '#onChange sends values to parent and forces re-render', ->

--- a/client/apps/edit/components/admin/test/verticals_tags.test.coffee
+++ b/client/apps/edit/components/admin/test/verticals_tags.test.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore'
 benv = require 'benv'
 sinon = require 'sinon'
 { resolve } = require 'path'

--- a/client/apps/edit/components/admin/verticals_tags/editorial.coffee
+++ b/client/apps/edit/components/admin/verticals_tags/editorial.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore'
 React = require 'react'
 ReactDOM = require 'react-dom'
 Verticals = require '../../../../../collections/verticals.coffee'

--- a/client/apps/settings/client/curations/venice/venice_section.coffee
+++ b/client/apps/settings/client/curations/venice/venice_section.coffee
@@ -2,6 +2,7 @@ React = require 'react'
 ReactDOM = require 'react-dom'
 moment = require 'moment'
 _s = require 'underscore.string'
+_ = require 'underscore'
 { div, input, label, span, textarea } = React.DOM
 AutocompleteList = React.createFactory require '../../../../../components/autocomplete_list/index.coffee'
 imageUpload = React.createFactory require '../../../../edit/components/admin/components/image_upload.coffee'

--- a/client/models/section.coffee
+++ b/client/models/section.coffee
@@ -18,7 +18,7 @@ module.exports = class Section extends Backbone.Model
       href = $(this).attr('href')
       if href?.match('google')
         href = decodeURIComponent( href.replace('https://www.google.com/url?q=','') )
-        href = _.first(href.split('&'))
+        href = href.split('&')[0]
       if href?.match('artsy.net/' + resource)
         _.last url.parse(href).pathname?.split('/')
       else


### PR DESCRIPTION
I'm so curious why this just started happening, but let's just fix this for now -- I wonder if with our former Browserify setup `underscore` was a globally available package or something. Seems like an odd thing to start happening now and Webpack is really the only change. 🤔  

Addresses: https://waffle.io/artsy/publishing/cards/5a05f76ee3cf1200c6a673b3