### PR TITLE
@eessex => Fixes related articles panel links

### DIFF
--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -186,22 +186,24 @@ export const relatedArticlesPanel = (root) => {
   return new Promise(async (resolve, reject) => {
     let relatedArticles = []
 
-    const articleResults = await promisedMongoFetch(_.pick(args, _.identity))
+    const articleFeed = await promisedMongoFetch(_.pick(args, _.identity))
     .catch((e) => reject(e))
 
     if (root.related_article_ids && root.related_article_ids.length) {
       const relatedArticleResults = await promisedMongoFetch(relatedArticleArgs)
       .catch((e) => reject(e))
-      relatedArticles = _.first(
-        relatedArticleResults.results.concat(presentCollection(articleResults).results),
-        3
-      )
+
+      const mergedArticles = {
+        results: relatedArticleResults.results.concat(articleFeed.results)
+      }
+
+      relatedArticles = presentCollection(mergedArticles).results
     } else {
-      relatedArticles = presentCollection(articleResults).results
+      relatedArticles = presentCollection(articleFeed).results
     }
 
     if (relatedArticles.length) {
-      resolve(relatedArticles)
+      resolve(_.first(relatedArticles, 3))
     } else {
       resolve(null)
     }

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -376,6 +376,29 @@ describe('resolvers', () => {
       })
       Object.keys(promisedMongoFetch.args[0][0]).should.not.containEql('tags')
     })
+
+    it('presents related_article_ids and feed articles', async () => {
+      const relatedArticles = {
+        results: [
+          _.extend({}, fixtures.article, {
+            title: 'Related Article',
+            slugs: ['artsy-editorial-slug'],
+            updated_at: '2017-01-01'
+          })
+        ]
+      }
+      promisedMongoFetch.onFirstCall().resolves(articles)
+      promisedMongoFetch.onSecondCall().resolves(relatedArticles)
+      const results = await resolvers.relatedArticlesPanel({
+        id: '54276766fd4f50996aeca2b8',
+        tags: ['dog', 'cat'],
+        related_article_ids: ['54276766fd4f50996aeca2b1']
+      })
+      results.length.should.equal(2)
+      results[0].slug.should.equal('artsy-editorial-slug')
+      results[1].slug.should.equal('slug-1')
+      results[0].updated_at.should.containEql('2017-01-01')
+    })
   })
 
   describe('tags', () => {


### PR DESCRIPTION
Addresses https://waffle.io/artsy/publishing/cards/59fc727221451400241101bf

It looks like we were wrapping the `articleFeed` results with the presenter, but missed the ones fetched from `related_article_ids`.
