### PR TITLE
@kanaabe => Last section tool is visible

### DIFF
--- a/client/apps/edit/components/content/section_tool/index.jsx
+++ b/client/apps/edit/components/content/section_tool/index.jsx
@@ -122,12 +122,13 @@ export default class SectionTool extends Component {
   render () {
     const { isEditing, isHero, sections } = this.props
     const isFirstSection = this.props.firstSection && sections.length === 0
+    const isLastSection = this.props.index === sections.length - 1
     return (
       <div
         className={'edit-tool'}
         data-state-open={this.state.open}
         data-editing={isEditing}
-        data-first={isFirstSection}
+        data-visible={isFirstSection || isLastSection}
         data-hero={isHero}>
         <div
           className='edit-tool__icon'

--- a/client/apps/edit/components/content/section_tool/index.styl
+++ b/client/apps/edit/components/content/section_tool/index.styl
@@ -102,23 +102,23 @@ section-btn-height = 130px
       opacity 0
       &:hover
         opacity 1
-    &[data-first=true]
-      padding-bottom 40px
-      .edit-tool__icon
-        opacity 1
-      &::after
-        content 'Add a section'
-        width 150px
-        display block
-        float left
-        position absolute
-        top -6px
-        left 35px
-        avant-garde()
-        font-size default-avant-garde-font-size - 1
-      &:hover::after,
-      &[data-state-open="true"]::after
-        display none
+  .edit-tool[data-visible=true]
+    padding-bottom 40px
+    .edit-tool__icon
+      opacity 1
+    &::after
+      content 'Add a section'
+      width 150px
+      display block
+      float left
+      position absolute
+      top -6px
+      left 35px
+      avant-garde()
+      font-size default-avant-garde-font-size - 1
+    &:hover::after,
+    &[data-state-open="true"]::after
+      display none
 
 .classic .edit-tool
   max-width classic-body-w-margin

--- a/client/apps/edit/components/content/section_tool/test/index.test.js
+++ b/client/apps/edit/components/content/section_tool/test/index.test.js
@@ -29,6 +29,7 @@ describe('SectionTool', () => {
     component.find('.edit-tool__icon').simulate('click')
     expect(component.state().open).toBe(true)
   })
+
   it('renders the section icons when open', () => {
     const component = mount(
       <SectionTool {...props} />
@@ -39,6 +40,7 @@ describe('SectionTool', () => {
     expect(component.find(IconEditVideo).length).toBe(1)
     expect(component.find(IconEditEmbed).length).toBe(1)
   })
+
   it('adds a new section of the correct type on click', () => {
     const originalSections = props.sections.length
     const component = mount(
@@ -52,7 +54,6 @@ describe('SectionTool', () => {
 })
 
 describe('SectionTool: Hero', () => {
-
   const props = {
     isEditing: false,
     isHero: true,

--- a/client/apps/edit/components/content/section_tool/test/index.test.js
+++ b/client/apps/edit/components/content/section_tool/test/index.test.js
@@ -19,7 +19,7 @@ describe('SectionTool', () => {
     isHero: false,
     section: null,
     index: FeatureArticle.sections.length - 1,
-    sections: new Backbone.Collection(FeatureArticle.sections),
+    sections: new Backbone.Collection(FeatureArticle.sections)
   }
 
   it('opens on click', () => {
@@ -50,6 +50,22 @@ describe('SectionTool', () => {
     component.find(IconEditText).simulate('click')
     expect(component.props().sections.length).toBe(originalSections + 1)
     expect(component.props().sections.pop().get('type')).toMatch('text')
+  })
+
+  it('Adds a data-visible prop to the last section tool', () => {
+    const component = mount(
+      <SectionTool {...props} />
+    )
+    expect(component.html()).toMatch('data-visible="true"')
+  })
+
+  it('Adds a data-visible prop to the first section tool if no sections', () => {
+    props.firstSection = true
+    props.sections = new Backbone.Collection()
+    const component = mount(
+      <SectionTool {...props} />
+    )
+    expect(component.html()).toMatch('data-visible="true"')
   })
 })
 


### PR DESCRIPTION
Fixes visibility for the last section tool -- also added a check in the component for the last section, and renamed the attr to `data-visible` as opposed to `data-first`.