### PR TITLE
@kanaabe => Don't WSOD on deprecated sections

### DIFF
--- a/client/apps/edit/components/content/section_container/index.coffee
+++ b/client/apps/edit/components/content/section_container/index.coffee
@@ -79,11 +79,14 @@ module.exports = React.createClass
         React.createElement(
           SectionVideo, @sectionProps()
         )
+      else if @props.section.get('type') is 'callout'
+        div {}
       else
         (switch @props.section.get('type')
           when 'text' then Text
           when 'slideshow' then Slideshow
           when 'embed' then Embed
+          when 'image' then ImageCollection
           when 'image_set' then ImageCollection
           when 'image_collection' then ImageCollection
         )( @sectionProps() )


### PR DESCRIPTION
Renders nothing if callout, renders image_collection if image. 

TODO:
Backfill hero_section type image to image_collection 
or
Add check on loading edit app and covert into image_collection

This component is on my list to decaffeinate soon.