### PR TITLE
@damassi => Turn on parallel, use --runInBand for Jest tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,4 +47,4 @@ dependencies:
 test:
   override:
     - yarn test:
-        parallel: false
+        parallel: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "sh scripts/start.sh",
     "dev": "sh scripts/dev.sh",
     "test": "sh scripts/test.sh",
-    "test:watch": "yarn jest -- --watch",
+    "test:watch": "yarn jest -- --watch --runInBand",
     "assets": "sh scripts/assets.sh",
     "deploy": "sh scripts/deploy.sh",
     "mocha": "sh scripts/mocha.sh"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,4 +6,4 @@ yarn assets
 yarn mocha $(find api -name '*.test.coffee')
 yarn mocha $(find api -name '*.test.js')
 yarn mocha $(find client -name '*.test.coffee')
-yarn jest $(find client -name '*.test.js')
+yarn jest -- --runInBand $(find client -name '*.test.js')


### PR DESCRIPTION
This turns parallel tests back on for Circle and makes use of `--runInBand` which prevents Jest tests from spawning new processes.

cc @eessex 