### PR TITLE
@kanaabe => Edit header uses React over Backbone

### DIFF
--- a/client/apps/edit/components/header2/index.jsx
+++ b/client/apps/edit/components/header2/index.jsx
@@ -1,0 +1,188 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import Icon from '@artsy/reaction-force/dist/Components/Icon'
+import { data as sd } from 'sharify'
+
+export class EditHeader extends Component {
+  static propTypes = {
+    actions: PropTypes.any,
+    article: PropTypes.object,
+    channel: PropTypes.object,
+    edit: PropTypes.object,
+    user: PropTypes.object
+  }
+
+  toggleSection = (activeSection) => {
+    // TODO - connect component to use redux actions directly
+    this.props.actions.changeSection(activeSection)
+  }
+
+  isPublishable = () => {
+    return this.contentIsComplete() && this.displayIsComplete()
+  }
+
+  onPublish = () => {
+    const { actions, article } = this.props
+
+    if (this.isPublishable()) {
+      actions.publishArticle(
+        article,
+        !article.get('published')
+      )
+    }
+  }
+
+  onDelete = () => {
+    const { actions, article } = this.props
+
+    if (confirm('Are you sure?')) {
+      actions.deleteArticle(article)
+    }
+  }
+
+  getSaveColor = () => {
+    const { isSaving, isSaved } = this.props.edit
+
+    if (isSaving) {
+      return 'limegreen'
+    } else if (isSaved) {
+      return 'black'
+    } else {
+      return '#f7625a'
+    }
+  }
+
+  getSaveText = () => {
+    const { article, edit } = this.props
+    const { isSaving } = edit
+
+    if (isSaving) {
+      return 'Saving...'
+    } else if (article.get('published')) {
+      return 'Save Article'
+    } else {
+      return 'Save Draft'
+    }
+  }
+
+  getPublishText = () => {
+    const { article, edit } = this.props
+    const { isPublishing } = edit
+    const isPublished = article.get('published')
+
+    if (isPublishing && isPublished) {
+      return 'Publishing...'
+    } else if (isPublishing) {
+      return 'Unpublishing...'
+    } else if (isPublished) {
+      return 'Unpublish'
+    } else {
+      return 'Publish'
+    }
+  }
+
+  contentIsComplete = () => {
+    const { article } = this.props
+    return article.get('title') && article.get('title').length
+  }
+
+  displayIsComplete = () => {
+    const { article } = this.props
+    return article.get('thumbnail_title') && article.get('thumbnail_image')
+  }
+
+  render () {
+    const { article, actions, channel, user } = this.props
+    const { activeSection, isDeleting } = this.props.edit
+
+    return (
+      <div className='EditHeader'>
+
+        <div className='EditHeader__left'>
+          <div className='EditHeader__tabs'>
+            <button
+              className='avant-garde-button check'
+              onClick={() => this.toggleSection('content')}
+              data-active={activeSection === 'content'}
+            >
+              <span>Content</span>
+              <Icon
+                className='icon'
+                name='check'
+                color={this.contentIsComplete() ? 'limegreen' : '#ccc'}
+              />
+            </button>
+
+            <button
+              className='avant-garde-button check'
+              onClick={() => this.toggleSection('display')}
+              data-active={activeSection === 'display'}
+            >
+              <span>Display</span>
+              <Icon
+                className='icon'
+                name='check'
+                color={this.displayIsComplete() ? 'limegreen' : '#ccc'}
+              />
+            </button>
+
+            {user.type === 'Admin' &&
+              <button
+                className='avant-garde-button'
+                onClick={() => this.toggleSection('admin')}
+                data-active={activeSection === 'admin'}
+              >
+                Admin
+              </button>
+            }
+          </div>
+
+          <div>
+            <button
+              className='avant-garde-button publish'
+              data-disabled={!this.isPublishable()}
+              onClick={this.onPublish}
+            >
+              {this.getPublishText()}
+            </button>
+
+            {channel.get('type') === 'editorial' &&
+              <button
+                className='avant-garde-button autolink'
+              >
+                Auto-link
+              </button>
+            }
+          </div>
+        </div>
+
+        <div className='EditHeader__right'>
+          <button
+            className='avant-garde-button'
+            style={{border: 'none'}}
+            onClick={this.onDelete}
+          >
+            {isDeleting ? 'Deleting...' : 'Delete'}
+          </button>
+
+          <button
+            className='avant-garde-button'
+            style={{color: this.getSaveColor()}}
+            onClick={() => article.get('published')
+              ? article.trigger('savePublished')
+              : actions.saveArticle(article)
+            }>
+            {this.getSaveText()}
+          </button>
+
+          <a href={`${sd.FORCE_URL}/article/${article.get('slug')}`} target='_blank'>
+            <button className='avant-garde-button'>
+              {article.get('published') ? 'View' : 'Preview'}
+            </button>
+          </a>
+        </div>
+
+      </div>
+    )
+  }
+}

--- a/client/apps/edit/components/header2/index.jsx
+++ b/client/apps/edit/components/header2/index.jsx
@@ -1,7 +1,11 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Icon from '@artsy/reaction-force/dist/Components/Icon'
-import { data as sd } from 'sharify'
+import {
+  greenRegular,
+  grayMedium,
+  redMedium
+} from '@artsy/reaction-force/dist/Assets/Colors'
 
 export class EditHeader extends Component {
   static propTypes = {
@@ -18,7 +22,8 @@ export class EditHeader extends Component {
   }
 
   isPublishable = () => {
-    return this.contentIsComplete() && this.displayIsComplete()
+    const { article } = this.props
+    return article.finishedContent() && article.finishedThumbnail()
   }
 
   onPublish = () => {
@@ -44,11 +49,11 @@ export class EditHeader extends Component {
     const { isSaving, isSaved } = this.props.edit
 
     if (isSaving) {
-      return 'limegreen'
+      return greenRegular
     } else if (isSaved) {
       return 'black'
     } else {
-      return '#f7625a'
+      return redMedium
     }
   }
 
@@ -81,16 +86,6 @@ export class EditHeader extends Component {
     }
   }
 
-  contentIsComplete = () => {
-    const { article } = this.props
-    return article.get('title') && article.get('title').length
-  }
-
-  displayIsComplete = () => {
-    const { article } = this.props
-    return article.get('thumbnail_title') && article.get('thumbnail_image')
-  }
-
   render () {
     const { article, actions, channel, user } = this.props
     const { activeSection, isDeleting } = this.props.edit
@@ -109,7 +104,7 @@ export class EditHeader extends Component {
               <Icon
                 className='icon'
                 name='check'
-                color={this.contentIsComplete() ? 'limegreen' : '#ccc'}
+                color={article.finishedContent() ? greenRegular : grayMedium}
               />
             </button>
 
@@ -122,7 +117,7 @@ export class EditHeader extends Component {
               <Icon
                 className='icon'
                 name='check'
-                color={this.displayIsComplete() ? 'limegreen' : '#ccc'}
+                color={article.finishedThumbnail() ? greenRegular : grayMedium}
               />
             </button>
 
@@ -158,8 +153,7 @@ export class EditHeader extends Component {
 
         <div className='EditHeader__right'>
           <button
-            className='avant-garde-button'
-            style={{border: 'none'}}
+            className='avant-garde-button delete'
             onClick={this.onDelete}
           >
             {isDeleting ? 'Deleting...' : 'Delete'}
@@ -175,7 +169,7 @@ export class EditHeader extends Component {
             {this.getSaveText()}
           </button>
 
-          <a href={`${sd.FORCE_URL}/article/${article.get('slug')}`} target='_blank'>
+          <a href={article.getFullSlug()} target='_blank'>
             <button className='avant-garde-button'>
               {article.get('published') ? 'View' : 'Preview'}
             </button>

--- a/client/apps/edit/components/header2/index.styl
+++ b/client/apps/edit/components/header2/index.styl
@@ -20,6 +20,8 @@
     &[data-disabled=false],
     &[data-active=true]
       color black
+    &.delete
+      border none
 
   &__left
     display flex

--- a/client/apps/edit/components/header2/index.styl
+++ b/client/apps/edit/components/header2/index.styl
@@ -1,0 +1,44 @@
+@import '../stylus_lib'
+
+.EditHeader
+  display flex
+  justify-content space-between
+  padding 10px
+  position fixed
+  top 0
+  left 110px
+  right 0
+  background white
+  z-index 100
+
+  button
+    border-radius 0
+    padding 11px 18px
+    &[data-disabled=true]
+      background gray-lighter-color
+      color gray-dark-color
+    &[data-disabled=false],
+    &[data-active=true]
+      color black
+
+  &__left
+    display flex
+    button
+      margin-right 10px
+      color gray-color
+      &:hover
+        color black
+      &.check
+        margin 0
+        border-right 0
+        .icon
+          font-size 10px
+          margin-right 0
+          margin-left 10px
+
+  &__right
+    button
+      margin-left 10px
+
+#edit-content .EditHeader a
+  background-image none

--- a/client/apps/edit/components/header2/test/index.test.js
+++ b/client/apps/edit/components/header2/test/index.test.js
@@ -1,9 +1,15 @@
 import Backbone from 'backbone'
 import React from 'react'
+import Article from '../../../../../models/article'
 import { EditHeader } from '../index'
 import { mount } from 'enzyme'
 import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
 import Icon from '@artsy/reaction-force/dist/Components/Icon'
+import {
+  greenRegular,
+  grayMedium,
+  redMedium
+} from '@artsy/reaction-force/dist/Assets/Colors'
 
 describe('Edit Header Controls', () => {
   let props
@@ -17,7 +23,7 @@ describe('Edit Header Controls', () => {
         publishArticle: jest.fn(),
         saveArticle: jest.fn()
       },
-      article: new Backbone.Model(Fixtures.StandardArticle),
+      article: new Article(Fixtures.StandardArticle),
       channel: new Backbone.Model(),
       edit: {
         isSaved: true,
@@ -59,7 +65,7 @@ describe('Edit Header Controls', () => {
       const component = mount(
         <EditHeader {...props} />
       )
-      expect(component.find(Icon).first().props().color).toBe('limegreen')
+      expect(component.find(Icon).first().props().color).toBe(greenRegular)
     })
 
     it('Content indicates non-completion', () => {
@@ -67,7 +73,7 @@ describe('Edit Header Controls', () => {
       const component = mount(
         <EditHeader {...props} />
       )
-      expect(component.find(Icon).first().props().color).toBe('#ccc')
+      expect(component.find(Icon).first().props().color).toBe(grayMedium)
     })
 
     it('Display indicates completion if complete', () => {
@@ -75,14 +81,14 @@ describe('Edit Header Controls', () => {
       const component = mount(
         <EditHeader {...props} />
       )
-      expect(component.find(Icon).last().props().color).toBe('limegreen')
+      expect(component.find(Icon).last().props().color).toBe(greenRegular)
     })
 
     it('Display indicates non-completion', () => {
       const component = mount(
         <EditHeader {...props} />
       )
-      expect(component.find(Icon).last().props().color).toBe('#ccc')
+      expect(component.find(Icon).last().props().color).toBe(grayMedium)
     })
   })
 
@@ -242,7 +248,7 @@ describe('Edit Header Controls', () => {
       const component = mount(
         <EditHeader {...props} />
       )
-      expect(component.html()).toMatch('color: rgb(247, 98, 90)')
+      expect(component.find('button').at(4).props().style.color).toBe(redMedium)
     })
 
     it('Color is green if isSaving', () => {
@@ -250,7 +256,7 @@ describe('Edit Header Controls', () => {
       const component = mount(
         <EditHeader {...props} />
       )
-      expect(component.find('button').at(4).props().style.color).toBe('limegreen')
+      expect(component.find('button').at(4).props().style.color).toBe(greenRegular)
     })
 
     it('Color is black if isSaved', () => {

--- a/client/apps/edit/components/header2/test/index.test.js
+++ b/client/apps/edit/components/header2/test/index.test.js
@@ -1,0 +1,283 @@
+import Backbone from 'backbone'
+import React from 'react'
+import { EditHeader } from '../index'
+import { mount } from 'enzyme'
+import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
+import Icon from '@artsy/reaction-force/dist/Components/Icon'
+
+describe('Edit Header Controls', () => {
+  let props
+  global.confirm = jest.fn(() => true)
+
+  beforeEach(() => {
+    props = {
+      actions: {
+        changeSection: jest.fn(),
+        deleteArticle: jest.fn(),
+        publishArticle: jest.fn(),
+        saveArticle: jest.fn()
+      },
+      article: new Backbone.Model(Fixtures.StandardArticle),
+      channel: new Backbone.Model(),
+      edit: {
+        isSaved: true,
+        isSaving: false
+      },
+      user: {}
+    }
+  })
+
+  it('renders all buttons for standard user', () => {
+    const component = mount(
+      <EditHeader {...props} />
+    )
+    expect(component.find('button').length).toBe(6)
+  })
+
+  it('renders admin button for admin users', () => {
+    props.user.type = 'Admin'
+
+    const component = mount(
+      <EditHeader {...props} />
+    )
+    expect(component.find('button').length).toBe(7)
+    expect(component.text()).toMatch('Admin')
+  })
+
+  it('renders auto-link button for editorial channel', () => {
+    props.channel.set('type', 'editorial')
+
+    const component = mount(
+      <EditHeader {...props} />
+    )
+    expect(component.find('button').length).toBe(7)
+    expect(component.text()).toMatch('Auto-link')
+  })
+
+  describe('Checkmarks', () => {
+    it('Content indicates completion if complete', () => {
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.find(Icon).first().props().color).toBe('limegreen')
+    })
+
+    it('Content indicates non-completion', () => {
+      delete props.article.attributes.title
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.find(Icon).first().props().color).toBe('#ccc')
+    })
+
+    it('Display indicates completion if complete', () => {
+      props.article.set('thumbnail_image', 'image.jpg')
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.find(Icon).last().props().color).toBe('limegreen')
+    })
+
+    it('Display indicates non-completion', () => {
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.find(Icon).last().props().color).toBe('#ccc')
+    })
+  })
+
+  describe('Actions', () => {
+    it('Changes activeSection on edit-tab click', () => {
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      const button = component.find('button').at(1)
+      button.simulate('click')
+
+      expect(props.actions.changeSection.mock.calls[0][0]).toBe('display')
+    })
+
+    it('Publishes an article on button click', () => {
+      props.article.set('thumbnail_image', 'image.jpg')
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      const button = component.find('button').at(2)
+      button.simulate('click')
+
+      expect(props.actions.publishArticle.mock.calls[0][0]).toBe(props.article)
+      expect(props.actions.publishArticle.mock.calls[0][1]).toBe(true)
+    })
+
+    it('Unpublishes an article on button click', () => {
+      props.article.set({
+        thumbnail_image: 'image.jpg',
+        published: true
+      })
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      const button = component.find('button').at(2)
+      button.simulate('click')
+
+      expect(props.actions.publishArticle.mock.calls[0][0]).toBe(props.article)
+      expect(props.actions.publishArticle.mock.calls[0][1]).toBe(false)
+    })
+
+    xit('Calls auto-link on button click', () => {
+      // TODO - Move auto-link into redux actions
+    })
+
+    it('Deletes an article on button click', () => {
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      const button = component.find('button').at(3)
+      button.simulate('click')
+
+      expect(global.confirm.mock.calls.length).toBe(1)
+      expect(props.actions.deleteArticle.mock.calls.length).toBe(1)
+    })
+
+    it('Saves an article on button click', () => {
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      const button = component.find('button').at(4)
+      button.simulate('click')
+
+      expect(props.actions.saveArticle.mock.calls.length).toBe(1)
+    })
+
+    it('Saves a published article on button click', () => {
+      props.article.trigger = jest.fn()
+      props.article.set('published', true)
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      const button = component.find('button').at(4)
+      button.simulate('click')
+
+      expect(props.actions.saveArticle.mock.calls.length).toBe(0)
+      expect(props.article.trigger.mock.calls[2][0]).toBe('savePublished')
+    })
+  })
+
+  describe('Publish button', () => {
+    beforeEach(() => {
+      props.article.set('thumbnail_image', 'image.jpg')
+    })
+
+    it('Is disabled if content is not complete', () => {
+      delete props.article.attributes.thumbnail_image
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('data-disabled="true"')
+    })
+
+    it('Renders "Publish" if unpublished', () => {
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('data-disabled="false"')
+      expect(component.html()).toMatch('Publish')
+    })
+
+    it('Renders "Publishing..." if publishing and isPublishing', () => {
+      props.edit.isPublishing = true
+      props.article.set('published', true)
+      // set article published because isPublished is set after save
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('Publishing...')
+    })
+
+    it('Renders "Unpublish" if published', () => {
+      props.article.set('published', true)
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('Unpublish')
+    })
+
+    it('Renders "Unpublishing..." if published and isPublishing', () => {
+      props.edit.isPublishing = true
+      props.article.set('published', false)
+      // set article published because isPublished is set after save
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('Unpublishing...')
+    })
+  })
+
+  describe('Save button', () => {
+    it('Renders "Save Draft" if unpublished', () => {
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('Save Draft')
+    })
+
+    it('Renders "Save Article" if published', () => {
+      props.article.set('published', true)
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('Save Article')
+    })
+
+    it('Renders "Saving..." if isSaving', () => {
+      props.edit.isSaving = true
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('Saving...')
+    })
+
+    it('Color is red unless isSaved', () => {
+      props.edit.isSaved = false
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch('color: rgb(247, 98, 90)')
+    })
+
+    it('Color is green if isSaving', () => {
+      props.edit.isSaving = true
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.find('button').at(4).props().style.color).toBe('limegreen')
+    })
+
+    it('Color is black if isSaved', () => {
+      props.edit.isSaved = true
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.find('button').at(4).props().style.color).toBe('black')
+    })
+  })
+
+  describe('Preview button', () => {
+    it('Renders "Preview" if unpublished', () => {
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).toMatch(props.article.get('slug'))
+      expect(component.html()).toMatch('Preview')
+    })
+
+    it('Renders "View" if published', () => {
+      props.article.set('published', true)
+      const component = mount(
+        <EditHeader {...props} />
+      )
+      expect(component.html()).not.toMatch('Preview')
+      expect(component.html()).toMatch('View')
+    })
+  })
+})

--- a/client/apps/edit/index.styl
+++ b/client/apps/edit/index.styl
@@ -1,6 +1,7 @@
 @import './components/stylus_lib'
 @import './components/layout'
 @import './components/header'
+@import './components/header2'
 @import './components/display'
 @import './components/admin'
 @import './components/mobile'

--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -40,7 +40,8 @@ module.exports = class Article extends Backbone.Model
     @get('title')?.length > 0
 
   getSlug: ->
-    ((@get('author')?.name + '-' + @get('thumbnail_title')?.replace(/[.,\/#!$%\^&\?*;:{}=\-_`~()]/g,'')).toLowerCase()).replace(/\ /g,'-')
+    slug = if @get('slug') then @get('slug') else @get('thumbnail_title')
+    _s.slugify(@get('author')?.name + '-' + slug)
 
   getFullSlug: ->
     "https://artsy.net/article/" + @getSlug()


### PR DESCRIPTION
Per suggestion of @damassi, this is the first of a few PRs breaking out a pieces from the [WIP Redux PR](https://github.com/artsy/positron/pull/1464/files). 

This code replaces `edit/header`, using React rather than a Backbone view.  It is set up to accept Redux events as props.  This is not yet used and will be implemented in the Redux PR.