### PR TITLE
@craigspaeth => Move postscript into footer section

### DIFF
--- a/client/apps/edit/components/content/index.coffee
+++ b/client/apps/edit/components/content/index.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore'
+{ SectionFooter } = require './sections/footer/index.jsx'
 Header = require './sections/header/index.jsx'
 Hero = require './sections/hero/index.jsx'
 React = require 'react'
@@ -32,7 +33,10 @@ EditContent = React.createClass
     @setState lastUpdate: Date.now()
 
   render: ->
-    div {className: 'edit-section-layout ' + @props.article.get('layout')},
+    div {
+      className: 'edit-section-layout ' + @props.article.get('layout')
+      'data-layout': @props.article.get('layout')
+    },
       if @props.article.get('layout') is 'classic' and
        (@props.article.get('hero_section') != null or @props.channel.hasFeature('hero'))
         React.createElement(
@@ -54,9 +58,15 @@ EditContent = React.createClass
       )
       SectionList {
         sections: @props.article.sections
-        saveArticle: @saveArticle
         article: @props.article
         channel: @props.channel
       }
+      React.createElement(
+        SectionFooter, {
+          article: @props.article
+          channel: @props.channel
+          onChange: @saveArticle
+        }
+      )
 
 module.exports = EditContent

--- a/client/apps/edit/components/content/section_list/index.coffee
+++ b/client/apps/edit/components/content/section_list/index.coffee
@@ -38,11 +38,6 @@ module.exports = React.createClass
   isDraggable: ->
     if @state.editingIndex or @state.editingIndex is 0 then false else true
 
-  setPostscript: (html) ->
-    html = null unless html.length
-    @props.article.set('postscript', html)
-    @props.saveArticle()
-
   render: ->
     div {
       className: 'edit-sections__list'
@@ -92,17 +87,4 @@ module.exports = React.createClass
                   }
                 )
               ]
-      if @props.channel.isEditorial()
-        div {
-          className: 'edit-sections__postscript'
-          'data-layout': 'column_width'
-        },
-          Paragraph {
-            html: @props.article.get('postscript') or ''
-            onChange: @setPostscript
-            placeholder: 'Postscript (optional)'
-            type: 'postscript'
-            linked: true
-            layout: @props.article.get('layout')
-          }
-      # TODO - Author Preview
+

--- a/client/apps/edit/components/content/section_list/test/index.test.coffee
+++ b/client/apps/edit/components/content/section_list/test/index.test.coffee
@@ -29,9 +29,6 @@ describe 'SectionList', ->
       @SectionList = benv.require resolve(__dirname, '../index')
       @SectionTool = benv.require resolve(__dirname, '../../section_tool/index.jsx')
       DragContainer = benv.require resolve(__dirname, '../../../../../../components/drag_drop/index')
-      Paragraph = benv.require resolve(
-        __dirname, '../../../../../../components/rich_text/components/paragraph.coffee'
-      )
       @SectionList.__set__ 'SectionTool', @SectionTool
       @SectionContainer = benv.requireWithJadeify(
         resolve(__dirname, '../../section_container/index'), ['icons']
@@ -44,7 +41,6 @@ describe 'SectionList', ->
       @SectionContainer.__set__ 'ImageCollection', React.createFactory @ImageCollection
       @SectionList.__set__ 'SectionContainer', React.createFactory @SectionContainer
       @SectionList.__set__ 'DragContainer', React.createFactory DragContainer
-      @SectionList.__set__ 'Paragraph', React.createFactory Paragraph
       @props = {
         sections: @sections = new Sections [
           { body: 'Foo to the bar', type: 'text' }
@@ -98,16 +94,6 @@ describe 'SectionList', ->
     @component.render()
     $(ReactDOM.findDOMNode(@component)).html().should.containEql 'The Four Hedgehogs'
 
-  it 'renders the postscript on editorial channels', ->
-    @component.render()
-    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Postscript (optional)'
-
-  it 'does not render the postscript on non-editorial channels', ->
-    @props.channel.set 'type', 'partner'
-    component = ReactDOM.render React.createElement(@SectionList, @props), ($el = $ "<div></div>")[0], =>
-    component.render()
-    $(ReactDOM.findDOMNode(component)).html().should.not.containEql 'Postscript (optional)'
-
   it 'opens editing mode in the last added section', ->
     @component.setState = sinon.stub()
     @component.onNewSection @component.props.sections.last()
@@ -138,13 +124,3 @@ describe 'SectionList', ->
     component.render()
     r.simulate.click r.find(component, 'edit-section__remove')[0]
     @props.article.get('sections').length.should.eql 0
-
-  it '#setPostscript sets the postscript and saves article', ->
-    @component.setPostscript '<p>Here is a new postscript.</p>'
-    @component.props.article.get('postscript').should.eql '<p>Here is a new postscript.</p>'
-    @saveArticle.called.should.eql true
-
-  it '#setPostscript does not save empty html', ->
-    @component.setPostscript '<p></p>'
-    @saveArticle.called.should.eql true
-    $(ReactDOM.findDOMNode(@component)).html().should.containEql 'Postscript (optional)'

--- a/client/apps/edit/components/content/sections/footer/index.jsx
+++ b/client/apps/edit/components/content/sections/footer/index.jsx
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import Paragraph from '../../../../../../components/rich_text/components/paragraph.coffee'
+
+export const SectionFooter = (props) => {
+  const { article, channel } = props
+
+  return (
+    <div className='SectionFooter'>
+
+      {channel.hasFeature('postscript') &&
+        <div
+          className='SectionFooter__postscript'
+          data-layout='column_width'
+        >
+          <Paragraph
+            html={article.get('postscript') || ''}
+            layout={article.get('layout')}
+            linked
+            onChange={(html) => article.set('postscript', html)}
+            placeholder='Postscript (optional)'
+            type='postscript'
+          />
+        </div>
+      }
+
+    </div>
+  )
+}
+
+SectionFooter.propTypes = {
+  article: PropTypes.object.isRequired,
+  channel: PropTypes.object.isRequired,
+  onChange: PropTypes.func
+}

--- a/client/apps/edit/components/content/sections/footer/index.styl
+++ b/client/apps/edit/components/content/sections/footer/index.styl
@@ -1,0 +1,16 @@
+.SectionFooter
+  .public-DraftEditorPlaceholder-root
+    position absolute
+    color gray-darker-color
+  &__postscript
+    padding 20px
+    .public-DraftEditorPlaceholder-root
+      Garamond s23
+      font-style italic
+
+[data-layout=standard]
+  .SectionFooter
+    max-width 820px
+    margin-left 0
+    .public-DraftEditorPlaceholder-root
+      Garamond s19

--- a/client/apps/edit/components/content/sections/footer/test/index.test.js
+++ b/client/apps/edit/components/content/sections/footer/test/index.test.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import Backbone from 'backbone'
+import { mount } from 'enzyme'
+import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
+import Paragraph from '../../../../../../../components/rich_text/components/paragraph.coffee'
+import { SectionFooter } from '../index.jsx'
+const { FeatureArticle } = Fixtures
+
+describe('SectionFooter', () => {
+  let props
+
+  beforeEach(() => {
+    props = {
+      article: new Backbone.Model(FeatureArticle),
+      channel: {
+        hasFeature: jest.fn().mockReturnValue(true)
+      },
+      onChange: jest.fn()
+    }
+  })
+
+  it('Shows a postscript field if channel hasFeature', () => {
+    props.article.unset('postscript')
+    const component = mount(
+      <SectionFooter {...props} />
+    )
+
+    expect(component.find(Paragraph).length).toBe(1)
+    expect(component.text()).toMatch('Postscript (optional)')
+  })
+
+  it('Does not a postscript field if channel does not hasFeature', () => {
+    props.channel.hasFeature.mockReturnValue(false)
+    const component = mount(
+      <SectionFooter {...props} />
+    )
+
+    expect(component.find(Paragraph).length).toBe(0)
+    expect(component.text()).not.toMatch('Postscript (optional)')
+  })
+
+  it('Can render a saved postscript', () => {
+    const component = mount(
+      <SectionFooter {...props} />
+    )
+    const expectedPostscript = FeatureArticle.postscript
+      .replace('<p>', '')
+      .replace('</p>', '')
+    expect(component.html()).toMatch(expectedPostscript)
+  })
+})

--- a/client/apps/edit/components/content/test/index.test.coffee
+++ b/client/apps/edit/components/content/test/index.test.coffee
@@ -32,6 +32,8 @@ describe 'EditContent', ->
       HeroSection = benv.require resolve(__dirname, '../sections/hero/index.jsx')
       SectionList = @SectionList = sinon.stub()
       Header = benv.require resolve(__dirname, '../sections/header')
+      Footer = benv.require resolve(__dirname, '../sections/footer')
+      @EditContent.__set__ 'Footer', Footer
       @EditContent.__set__ 'HeroSection', HeroSection
       @EditContent.__set__ 'Header', Header
       @EditContent.__set__ 'SectionList', SectionList
@@ -75,6 +77,10 @@ describe 'EditContent', ->
 
     it 'renders the section list', ->
       @SectionList.called.should.eql true
+
+    it 'renders the footer section', ->
+      $(ReactDOM.findDOMNode(@component)).html().should.containEql '<div class="SectionFooter">'
+
 
   describe '#saveArticle', ->
 

--- a/client/apps/edit/index.styl
+++ b/client/apps/edit/index.styl
@@ -11,6 +11,7 @@
 @import './components/content/section_tool'
 @import './components/content/sections/embed'
 @import './components/content/sections/header'
+@import './components/content/sections/footer'
 @import './components/content/sections/image_collection'
 @import './components/content/sections/slideshow'
 @import './components/content/sections/text'

--- a/client/models/channel.coffee
+++ b/client/models/channel.coffee
@@ -33,7 +33,7 @@ module.exports = class Channel extends Backbone.Model
         'callout'
         'follow'
         'layout'
-        'hero'
+        'postscript'
       ], feature
     else if type is 'team'
       _.contains [


### PR DESCRIPTION
One of a few PRs broken out from [WIP redux pr](https://github.com/artsy/positron/pull/1464/files) -- 

A new section footer removes non-section related fields out of the section-list into a separate component.  This anticipates additional footer fields for the forthcoming new article layouts. 