### PR TITLE
@craigspaeth => Header dates, section icons

### DIFF
--- a/client/apps/edit/components/content/section_container/index.coffee
+++ b/client/apps/edit/components/content/section_container/index.coffee
@@ -11,8 +11,9 @@ Text = React.createFactory require '../sections/text/index.coffee'
 Slideshow = React.createFactory require '../sections/slideshow/index.coffee'
 Embed = React.createFactory require '../sections/embed/index.coffee'
 ImageCollection = React.createFactory require '../sections/image_collection/index.coffee'
+IconDrag = require('@artsy/reaction-force/dist/Components/Publishing').IconDrag
+IconRemove = require('@artsy/reaction-force/dist/Components/Publishing').IconRemove
 { div, nav, button } = React.DOM
-icons = -> require('../../icons.jade') arguments...
 
 module.exports = React.createClass
   displayName: 'SectionContainer'
@@ -68,13 +69,14 @@ module.exports = React.createClass
         unless @props.isHero
           button {
             className: "edit-section__drag button-reset"
-            dangerouslySetInnerHTML: __html: $(icons()).filter('.draggable').html()
-          }
+          },
+            React.createElement(IconDrag, {background: '#ccc'})
         button {
           className: "edit-section__remove button-reset"
           onClick: @removeSection
-          dangerouslySetInnerHTML: __html: $(icons()).filter('.remove').html()
-        }
+        },
+          React.createElement(IconRemove, {background: '#ccc'})
+
       if @props.section.get('type') is 'video'
         React.createElement(
           SectionVideo, @sectionProps()

--- a/client/apps/edit/components/content/section_container/test/index.test.coffee
+++ b/client/apps/edit/components/content/section_container/test/index.test.coffee
@@ -29,9 +29,7 @@ describe 'SectionContainer', ->
           removeListener: sinon.stub()
         }
       )
-      @SectionContainer = benv.requireWithJadeify(
-        resolve(__dirname, '../index'), ['icons']
-      )
+      @SectionContainer = benv.require resolve(__dirname, '../index')
       section1 = new Section { body: 'Foo to the bar', type: 'text' }
       section2 = new Section { body: 'Bar to the foo', type: 'text' }
       section3 = new Section { type: 'image_collection' }
@@ -46,7 +44,8 @@ describe 'SectionContainer', ->
         article: new Article
       }
       @SectionContainer.__set__ 'Text', ->
-      @component = ReactDOM.render React.createElement(@SectionContainer, @props
+      @component = ReactDOM.render React.createElement(
+        @SectionContainer, @props
       ), $("<div></div>")[0], => setTimeout =>
         @component.setState = sinon.stub()
         done()

--- a/client/apps/edit/components/content/section_list/test/index.test.coffee
+++ b/client/apps/edit/components/content/section_list/test/index.test.coffee
@@ -33,9 +33,7 @@ describe 'SectionList', ->
         __dirname, '../../../../../../components/rich_text/components/paragraph.coffee'
       )
       @SectionList.__set__ 'SectionTool', @SectionTool
-      @SectionContainer = benv.requireWithJadeify(
-        resolve(__dirname, '../../section_container/index'), ['icons']
-      )
+      @SectionContainer = benv.require resolve(__dirname, '../../section_container/index')
       @ImageCollection = benv.require(
         resolve(__dirname, '../../sections/image_collection/index')
       )

--- a/client/apps/edit/components/content/sections/header/index.jsx
+++ b/client/apps/edit/components/content/sections/header/index.jsx
@@ -127,7 +127,7 @@ export default class SectionHeader extends Component {
     if (isClassic) {
       return (
         <div className='edit-header'>
-          <Header article={article.attributes}>
+          <Header article={article.attributes} date={article.getPublishDate()}>
             {this.renderTitle(article)}
             {this.renderLeadParagraph(article)}
           </Header>
@@ -145,7 +145,7 @@ export default class SectionHeader extends Component {
             />
           }
 
-          <Header article={article.attributes}>
+          <Header article={article.attributes} date={article.getPublishDate()}>
             <span>Missing Vertical</span>
             {this.renderTitle(article)}
             {isFeature && this.renderFeatureDeck(article)}

--- a/client/components/drag_drop/test/index.test.coffee
+++ b/client/components/drag_drop/test/index.test.coffee
@@ -22,6 +22,7 @@ describe 'DragDropContainer Default', ->
       benv.expose
         $: benv.require 'jquery'
       global.HTMLElement = () -> {}
+      global.Image = () => {}
       window.matchMedia = sinon.stub().returns(
         {
           matches: false
@@ -145,6 +146,7 @@ describe 'DragDropContainer Vertical', ->
     benv.setup =>
       benv.expose
         $: benv.require 'jquery'
+      global.Image = () => {}
       @DragDropContainer = benv.require resolve(__dirname, '../index.coffee')
       DragTarget = benv.require resolve __dirname, '../drag_target.coffee'
       DragSource = benv.require resolve __dirname, '../drag_source.coffee'
@@ -153,9 +155,8 @@ describe 'DragDropContainer Vertical', ->
       SectionTool = benv.require(
         resolve __dirname, '../../../apps/edit/components/content/section_tool/index.jsx'
       )
-      SectionContainer = benv.requireWithJadeify(
+      SectionContainer = benv.require(
         resolve __dirname, '../../../apps/edit/components/content/section_container/index.coffee'
-        ['icons']
       )
       ImageCollection = benv.require(
         resolve __dirname, '../../../apps/edit/components/content/sections/image_collection/index.coffee'

--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -56,7 +56,7 @@ module.exports = class Article extends Backbone.Model
       date = @get('published_at')
     else if @get('scheduled_publish_at')
       date = @get('scheduled_publish_at')
-    return moment(date).local().format('MMM D, YYYY h:mm a')
+    return moment(date).local().toISOString()
 
   date: (attr) ->
     if @get(attr)

--- a/client/test/models/article.test.coffee
+++ b/client/test/models/article.test.coffee
@@ -95,20 +95,20 @@ describe "Article", ->
 
     it 'returns the current date if unpublished and no scheduled_publish_at', ->
       @article.set published: false
-      now = moment().format('MMM D, YYYY')
+      now = moment().toISOString()
       @article.getPublishDate().should.containEql now
 
     it 'returns scheduled_publish_at if unpublished and scheduled', ->
       @article.set published: false
       scheduled = moment().add(1, 'years')
       @article.set('scheduled_publish_at', scheduled.toISOString())
-      @article.getPublishDate().should.containEql scheduled.format('MMM D, YYYY')
+      @article.getPublishDate().should.containEql scheduled.toISOString()
 
     it 'returns published_at if published', ->
       @article.set published: true
       published = moment().subtract(1, 'years')
       @article.set published_at: published.toISOString()
-      @article.getPublishDate().should.containEql published.format('MMM D, YYYY')
+      @article.getPublishDate().should.containEql published.toISOString()
 
   describe '#getObjectAttribute', ->
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.1.0",
-    "@artsy/reaction-force": "^0.12.8",
+    "@artsy/reaction-force": "^0.13.1",
     "airtable": "^0.4.5",
     "artsy-backbone-mixins": "artsy/artsy-backbone-mixins",
     "artsy-ezel-components": "artsy/artsy-ezel-components",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@^0.12.8":
-  version "0.12.8"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.12.8.tgz#90a7dc8fa5ced0c4aa29d4c9310a5dea159037f2"
+"@artsy/reaction-force@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.13.1.tgz#6dc12af88ec7fad3a5307398ea038085466c6331"
   dependencies:
     "@storybook/addon-options" "^3.2.1"
     "@storybook/react" "^3.2.12"


### PR DESCRIPTION
Incorporates some recent changes from Reaction -- 

- Updates Reaction to 0.13.1
- Show current date or scheduled at date in SectionHeader (was showing 'invalid date' unless published - https://artsy.slack.com/files/U6P29FL5S/F7XTF76BG/screen_shot_2017-11-08_at_11.09.20_am.png)
- Use Reaction icons in SectionContainer
- Also includes some minor changes to the article model's getPublishDate method, but it wasn't being used anywhere until this PR.