### PR TITLE
@kanaabe => [Article Display] Email preview bug

### DIFF
--- a/api/apps/articles/model/distribute.coffee
+++ b/api/apps/articles/model/distribute.coffee
@@ -98,8 +98,6 @@ postSailthruAPI = (article, cb) ->
   images: images
   spider: 0
   vars:
-    credit_line: article.email_metadata?.credit_line
-    credit_url: article.email_metadata?.credit_url
     html: html
     custom_text: article.email_metadata?.custom_text
     daily_email: article.daily_email

--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -182,8 +182,6 @@ ImageCollectionSection = (->
     image_url: @string().allow('',null)
     headline: @string().allow('',null)
     author: @string().allow('',null)
-    credit_line: @string().allow('',null)
-    credit_url: @string().allow('',null)
     custom_text: @string().allow('',null)
   is_super_article: @boolean().default(false)
   super_article: @object().keys

--- a/api/apps/articles/test/model/distribute.test.coffee
+++ b/api/apps/articles/test/model/distribute.test.coffee
@@ -108,15 +108,11 @@ describe 'Save', ->
           author_id: '5086df098523e60002000018'
           published: true
           email_metadata:
-            credit_url: 'artsy.net'
-            credit_line: 'Artsy Credit'
             headline: 'Article Email Title'
             author: 'Kana Abe'
             image_url: 'imageurl.com/image.jpg'
         }, (err, article) =>
           @sailthru.apiPost.args[0][1].title.should.containEql 'Article Email Title'
-          @sailthru.apiPost.args[0][1].vars.credit_line.should.containEql 'Artsy Credit'
-          @sailthru.apiPost.args[0][1].vars.credit_url.should.containEql 'artsy.net'
           @sailthru.apiPost.args[0][1].author.should.containEql 'Kana Abe'
           @sailthru.apiPost.args[0][1].images.full.url.should.containEql '&width=1200&height=706&quality=95&src=imageurl.com%2Fimage.jpg'
           @sailthru.apiPost.args[0][1].images.thumb.url.should.containEql '&width=900&height=530&quality=95&src=imageurl.com%2Fimage.jpg'

--- a/api/apps/articles/test/model/save.test.coffee
+++ b/api/apps/articles/test/model/save.test.coffee
@@ -235,8 +235,6 @@ describe 'Save', ->
           article.email_metadata.image_url.should.containEql 'bar.png'
           article.email_metadata.author.should.containEql 'Artsy Editorial'
           article.email_metadata.headline.should.containEql 'Custom Headline'
-          article.email_metadata.credit_url.should.containEql 'https://guggenheim.org'
-          article.email_metadata.credit_line.should.containEql 'Guggenheim'
           done()
       )(null, {
         _id: ObjectId '5086df098523e60002000011'
@@ -246,8 +244,6 @@ describe 'Save', ->
           image_url: 'bar.png'
           author: 'Artsy Editorial'
           headline: 'Custom Headline'
-          credit_line: 'Guggenheim'
-          credit_url: 'https://guggenheim.org'
         scheduled_publish_at: '123'
       })
 

--- a/client/apps/edit/components/display/components/email.jsx
+++ b/client/apps/edit/components/display/components/email.jsx
@@ -24,8 +24,6 @@ export class DisplayEmail extends Component {
     const emailMetadata = article.get('email_metadata') || {}
     const {
       author,
-      credit_line,
-      credit_url,
       custom_text,
       headline,
       image_url

--- a/client/apps/edit/components/display/components/email.jsx
+++ b/client/apps/edit/components/display/components/email.jsx
@@ -68,7 +68,7 @@ export class DisplayEmail extends Component {
             <label>Author</label>
             <input
               onChange={(e) => this.onChange(e.target.name, e.target.value)}
-              defaultValue={author}
+              defaultValue={author || ''}
               className='bordered-input'
               name='author'
             />
@@ -78,28 +78,6 @@ export class DisplayEmail extends Component {
 
         <Col xs={8} className='col--right'>
           <EmailPreview article={article} />
-
-          <div className='field-group--inline'>
-            <div className='field-group'>
-              <label>Credit Line</label>
-              <input
-                onChange={(e) => this.onChange('credit_line', e.target.value)}
-                defaultValue={credit_line}
-                name='credit_line'
-                className='bordered-input'
-              />
-            </div>
-
-            <div className='field-group'>
-              <label>Credit Url</label>
-              <input
-                onChange={(e) => this.onChange('credit_url', e.target.value)}
-                defaultValue={credit_url}
-                name='credit_url'
-                className='bordered-input'
-              />
-            </div>
-          </div>
         </Col>
 
         <Col xs={12}>

--- a/client/apps/edit/components/display/components/preview/email_preview.jsx
+++ b/client/apps/edit/components/display/components/preview/email_preview.jsx
@@ -4,7 +4,8 @@ import { crop } from '../../../../../../components/resizer/index.coffee'
 
 export const EmailPreview = (props) => {
   const { article } = props
-  const { author, headline, image_url } = article.get('email_metadata')
+  const email_metadata = article.get('email_metadata') || {}
+  const { author, headline, image_url } = email_metadata
   const image = image_url || article.get('thumbnail_image')
 
   return (

--- a/client/apps/edit/components/display/test/email.test.js
+++ b/client/apps/edit/components/display/test/email.test.js
@@ -10,8 +10,6 @@ describe('DisplayEmail', () => {
   let props
   let email_metadata = {
     author: 'Molly Gottschalk',
-    credit_line: 'A credit line',
-    credit_url: 'http://credit-url.com',
     custom_text: 'To create a total experience that will create a feeling that is qualitatively new: That is ultimately the most radical thing.',
     headline: 'Virtual Reality Is the Most Powerful Artistic Medium of Our Time',
     image_url: 'https://artsy-media-uploads.s3.amazonaws.com/-El3gm6oiFkOUKhUv79lGQ%2Fd7hftxdivxxvm.cloudfront-6.jpg'
@@ -30,7 +28,7 @@ describe('DisplayEmail', () => {
       <DisplayEmail {...props} />
     )
     expect(component.find(CharacterLimit).length).toBe(2)
-    expect(component.find('input').length).toBe(5)
+    expect(component.find('input').length).toBe(3)
     expect(component.find(ImageUpload).length).toBe(1)
     expect(component.find('input[type="checkbox"]').length).toBe(1)
   })
@@ -40,8 +38,6 @@ describe('DisplayEmail', () => {
       <DisplayEmail {...props} />
     )
     expect(component.html()).toMatch(props.article.get('email_metadata').author)
-    expect(component.html()).toMatch(props.article.get('email_metadata').credit_line)
-    expect(component.html()).toMatch(props.article.get('email_metadata').credit_url)
     expect(component.html()).toMatch(props.article.get('email_metadata').custom_text)
     expect(component.html()).toMatch(props.article.get('email_metadata').headline)
     expect(component.html()).toMatch('El3gm6oiFkOUKhUv79lGQ%252Fd7hftxdivxxvm.cloudfront-6.jpg')
@@ -89,28 +85,6 @@ describe('DisplayEmail', () => {
 
     expect(props.onChange.mock.calls[0][0]).toBe('email_metadata')
     expect(props.onChange.mock.calls[0][1].author).toBe('New Author')
-  })
-
-  it('Can change the credit line', () => {
-    const component = mount(
-      <DisplayEmail {...props} />
-    )
-    const input = component.find('input[name="credit_line"]').at(0)
-    input.simulate('change', { target: { name: 'credit_line', value: 'New Credit Line' } })
-
-    expect(props.onChange.mock.calls[0][0]).toBe('email_metadata')
-    expect(props.onChange.mock.calls[0][1].credit_line).toBe('New Credit Line')
-  })
-
-  it('Can change the credit url', () => {
-    const component = mount(
-      <DisplayEmail {...props} />
-    )
-    const input = component.find('input[name="credit_url"]').at(0)
-    input.simulate('change', { target: { name: 'credit_url', value: 'http://new-url.com' } })
-
-    expect(props.onChange.mock.calls[0][0]).toBe('email_metadata')
-    expect(props.onChange.mock.calls[0][1].credit_url).toBe('http://new-url.com')
   })
 
   it('Can change the send to sailthru checkbox', () => {

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -110,8 +110,6 @@ module.exports = ->
     email_metadata:
       image_url: 'http://img.png'
       headline: 'Foo'
-      credit_line: 'Credit Where Credit Needed'
-      credit_url: 'http://credit'
       author: 'Craig Spaeth'
     super_article:
       partner_link: 'http://partnerlink.com'


### PR DESCRIPTION
Fixes bug email panel did not display for articles without `email_metatdata` object 
https://sentry.io/artsynet/positron-production/issues/416672960/

Also deprecates email `credit_url` and `credit_line` fields.