### PR TITLE
@kanaabe => Query related articles for series

### DIFF
--- a/api/apps/graphql/index.js
+++ b/api/apps/graphql/index.js
@@ -26,6 +26,10 @@ const metaFields = {
     name: 'RelatedArticlesPanel',
     resolve: resolvers.relatedArticlesPanel
   }),
+  relatedArticles: array().items(object(Article.inputSchema)).meta({
+    name: 'RelatedArticles',
+    resolve: resolvers.relatedArticles
+  }),
   display: Display.schema.meta({
     args: Display.querySchema,
     resolve: resolvers.display

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -160,6 +160,30 @@ export const display = (root, args, req, ast) => {
   })
 }
 
+export const relatedArticles = (root) => {
+  const { related_article_ids } = root
+
+  return new Promise(async (resolve, reject) => {
+    let relatedArticles = []
+
+    if (related_article_ids && related_article_ids.length) {
+      const relatedArticleResults = await promisedMongoFetch({
+        ids: root.related_article_ids,
+        published: true
+      })
+      .catch((e) => reject(e))
+
+      relatedArticles = presentCollection(relatedArticleResults).results
+    }
+
+    if (relatedArticles.length) {
+      resolve(relatedArticles)
+    } else {
+      resolve(null)
+    }
+  })
+}
+
 export const relatedArticlesPanel = (root) => {
   const omittedIds = [ObjectId(root.id)]
   if (root.related_articles_ids) {

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -296,6 +296,25 @@ describe('resolvers', () => {
     })
   })
 
+  describe('relatedArticles', () => {
+    it('can find related articles for the series', async () => {
+      promisedMongoFetch.onFirstCall().resolves(articles)
+      const results = await resolvers.relatedArticles({
+        id: '54276766fd4f50996aeca2b8',
+        related_article_ids: ['54276766fd4f50996aeca2b9']
+      })
+      results.length.should.equal(1)
+    })
+
+    it('resolves null if it does not have related articles', async () => {
+      promisedMongoFetch.onFirstCall().resolves({ results: [] })
+      const results = await resolvers.relatedArticles({
+        id: '54276766fd4f50996aeca2b8'
+      })
+      _.isNull(results).should.be.true()
+    })
+  })
+
   describe('relatedArticlesCanvas', () => {
     it('can find related articles for the canvas', async () => {
       promisedMongoFetch.onFirstCall().resolves(articles)


### PR DESCRIPTION
Adds api support for querying all related articles attached to an article.