### PR TITLE
@craigspaeth => Add check for empty email_metadata

### DIFF
--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -178,11 +178,11 @@ ImageCollectionSection = (->
       id: @string().objectid().allow(null)
       name: @string().allow('', null)
   ]).default([])
-  email_metadata: @object().keys
-    image_url: @string().allow('',null)
-    headline: @string().allow('',null)
-    author: @string().allow('',null)
-    custom_text: @string().allow('',null)
+  email_metadata: @object().default({}).keys
+    image_url: @string().allow('')
+    headline: @string().allow('')
+    author: @string().allow('')
+    custom_text: @string().allow('')
   is_super_article: @boolean().default(false)
   super_article: @object().keys
     partner_link: @string().allow('',null)

--- a/client/apps/edit/components/display/components/email.jsx
+++ b/client/apps/edit/components/display/components/email.jsx
@@ -13,7 +13,7 @@ export class DisplayEmail extends Component {
 
   onChange = (key, value) => {
     const { article, onChange } = this.props
-    const emailMetadata = article.get('email_metadata')
+    const emailMetadata = article.get('email_metadata') || {}
 
     emailMetadata[key] = value
     onChange('email_metadata', emailMetadata)

--- a/client/apps/edit/components/display/test/email.test.js
+++ b/client/apps/edit/components/display/test/email.test.js
@@ -24,6 +24,7 @@ describe('DisplayEmail', () => {
   })
 
   it('Renders all form fields', () => {
+    props.article.unset('email_metadata')
     const component = mount(
       <DisplayEmail {...props} />
     )
@@ -41,6 +42,16 @@ describe('DisplayEmail', () => {
     expect(component.html()).toMatch(props.article.get('email_metadata').custom_text)
     expect(component.html()).toMatch(props.article.get('email_metadata').headline)
     expect(component.html()).toMatch('El3gm6oiFkOUKhUv79lGQ%252Fd7hftxdivxxvm.cloudfront-6.jpg')
+  })
+
+  it('Can save with empty email_metadata', () => {
+    props.article.unset('email_metadata')
+    const component = mount(
+      <DisplayEmail {...props} />
+    )
+    const input = component.find(CharacterLimit).at(0).node
+    input.props.onChange('data')
+    expect(props.onChange.mock.calls[0][0]).toBe('email_metadata')
   })
 
   it('Can change the email image', () => {


### PR DESCRIPTION
Email metadata form was failing when article has no email_metadata attribute, adds an empty object if this is the case. 

Related convo - https://artsy.slack.com/archives/C04GGGDCM/p1513198964000377