### PR TITLE
@kanaabe => Use actual slug to construct full slug

### DIFF
--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -35,12 +35,8 @@ module.exports = class Article extends Backbone.Model
   finishedContent: ->
     @get('title')?.length > 0
 
-  getSlug: ->
-    slug = if @get('slug') then @get('slug') else @get('thumbnail_title')
-    _s.slugify(@get('author')?.name + '-' + slug)
-
   getFullSlug: ->
-    "https://artsy.net/article/" + @getSlug()
+    "#{sd.FORCE_URL}/article/#{@get('slug')}"
 
   getByline: ->
     return _s.toSentence(_.pluck(@get('contributing_authors'), 'name')) if @hasContributingAuthors()

--- a/client/test/models/article.test.coffee
+++ b/client/test/models/article.test.coffee
@@ -1,6 +1,8 @@
 _ = require 'underscore'
 Backbone = require 'backbone'
-Article = require '../../models/article.coffee'
+fixtures = require '../../../test/helpers/fixtures'
+rewire = require 'rewire'
+Article = rewire '../../models/article.coffee'
 sinon = require 'sinon'
 { fabricate } = require 'antigravity'
 fixtures = require '../../../test/helpers/fixtures'
@@ -10,6 +12,7 @@ describe "Article", ->
 
   beforeEach ->
     sinon.stub Backbone, 'sync'
+    Article.__set__ 'sd', {FORCE_URL: 'https://artsy.net'}
     @article = new Article fixtures().articles
 
   afterEach ->
@@ -112,7 +115,7 @@ describe "Article", ->
   describe '#getFullSlug', ->
 
     it 'returns a slug with the artsy url', ->
-      @article.getFullSlug().should.equal 'https://artsy.net/article/undefined-top-ten-booths-at-miart-2014'
+      @article.getFullSlug().should.equal 'https://artsy.net/article/artsy-editorial-top-ten-booths-at-miart-2014'
 
   describe '#getByline', ->
 

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -111,6 +111,7 @@ module.exports = ->
       image_url: 'http://img.png'
       headline: 'Foo'
       author: 'Craig Spaeth'
+    slug: 'artsy-editorial-top-ten-booths-at-miart-2014'
     super_article:
       partner_link: 'http://partnerlink.com'
       partner_logo: 'http://partnerlink.com/logo.jpg'


### PR DESCRIPTION
The getFullSlug on the article model was not constructing URLs correctly, which is why users were having trouble previewing. (Currently the method is only used in the preview button). 

This opts to use the article's existing slug rather than constructing one. 

We can also at some point transition to this - https://github.com/artsy/reaction/pull/415/files#diff-01463a493f089d969a5da6fe564bf93eR31
