### PR TITLE
@craigspaeth => Exclude non standard or feature articles from instant articles

### DIFF
--- a/api/apps/articles/model/distribute.coffee
+++ b/api/apps/articles/model/distribute.coffee
@@ -50,7 +50,7 @@ cleanArticlesInSailthru = (slugs = []) =>
 
 postFacebookAPI = (article, cb) ->
   article = new Article cloneDeep article
-  return cb() unless article.isFeatured()
+  return cb() unless article.hasInstantArticle()
 
   article.prepForInstant ->
     jade.renderFile 'api/apps/articles/components/instant_articles/index.jade',

--- a/api/apps/articles/test/model/distribute.test.coffee
+++ b/api/apps/articles/test/model/distribute.test.coffee
@@ -163,6 +163,7 @@ describe 'Save', ->
           author_id: '5086df098523e60002000018'
           published: true
           featured: true
+          layout: 'standard'
           slugs: ['artsy-editorial-test']
           sections: [
             {
@@ -181,6 +182,7 @@ describe 'Save', ->
           author_id: '5086df098523e60002000018'
           published: true
           featured: true
+          layout: 'standard'
           slugs: ['artsy-editorial-test']
           sections: [
             {

--- a/api/models/article.coffee
+++ b/api/models/article.coffee
@@ -38,6 +38,9 @@ module.exports = class Article extends Backbone.Model
   isFeatured: ->
     @get('featured')
 
+  hasInstantArticle: ->
+    @get('featured') and @get('layout') in ['standard', 'feature']
+
   isEditorial: ->
     @get('channel_id')?.toString() is EDITORIAL_CHANNEL
 

--- a/api/test/models/article.test.coffee
+++ b/api/test/models/article.test.coffee
@@ -38,6 +38,28 @@ describe "Article", ->
         @article.get('sections')[0].images[0].caption.should.equal '<h1>A place for credit</h1>'
         cb()
 
+  describe '#hasInstantArticle', ->
+
+    it 'returns true if it is featured and the right layout', ->
+      @article.set({
+        featured: true
+        layout: 'standard'
+      })
+      @article.hasInstantArticle().should.be.true()
+
+    it 'returns false if it is not featured', ->
+      @article.set({
+        featured: false
+      })
+      @article.hasInstantArticle().should.be.false()
+    
+    it 'returns false if not the right layout', ->
+      @article.set({
+        featured: true
+        layout: 'video'
+      })
+      @article.hasInstantArticle().should.be.false()
+
   describe '#isFeature', ->
 
     it 'returns true for featured articles', ->


### PR DESCRIPTION
We don't want to send `layout: video` or `layout: series` to Instant Articles since they aren't supported yet.