### PR TITLE
@eessex => Adds resolver for series article

### DIFF
--- a/api/apps/graphql/index.js
+++ b/api/apps/graphql/index.js
@@ -36,6 +36,10 @@ const metaFields = {
   }),
   authors: array().items(object(Author.schema)).meta({
     resolve: resolvers.relatedAuthors
+  }),
+  seriesArticle: object(Article.inputSchema).meta({
+    name: 'SeriesArticle',
+    resolve: resolvers.seriesArticle
   })
 }
 

--- a/api/apps/graphql/resolvers.js
+++ b/api/apps/graphql/resolvers.js
@@ -186,7 +186,7 @@ export const relatedArticles = (root) => {
 
 export const relatedArticlesPanel = (root) => {
   const omittedIds = [ObjectId(root.id)]
-  if (root.related_articles_ids) {
+  if (root.related_article_ids) {
     omittedIds.concat(root.related_article_ids)
   }
   const tags = (root.tags && root.tags.length > 0) ? root.tags : null
@@ -254,6 +254,25 @@ export const relatedArticlesCanvas = (root) => {
     } else {
       resolve(null)
     }
+  })
+}
+
+export const seriesArticle = (root) => {
+  return new Promise(async (resolve, reject) => {
+    const seriesArticles = await promisedMongoFetch({
+      layout: 'series',
+      published: true
+    }).catch((e) => reject(e))
+
+    seriesArticles.results.map((article) => {
+      const stringifiedArticleIds = article.related_article_ids.map((id) => {
+        return id.toString()
+      })
+      if (_.contains(stringifiedArticleIds, root.id)) {
+        resolve(present(article))
+      }
+    })
+    resolve(null)
   })
 }
 

--- a/api/apps/graphql/test/resolvers.test.js
+++ b/api/apps/graphql/test/resolvers.test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon'
 const app = require('api/index.coffee')
 const { fixtures, fabricate, empty } = require('api/test/helpers/db.coffee')
 const resolvers = rewire('../resolvers.js')
+const { ObjectId } = require('mongojs')
 
 describe('resolvers', () => {
   let article, articles, server, promisedMongoFetch
@@ -417,6 +418,40 @@ describe('resolvers', () => {
       results[0].slug.should.equal('artsy-editorial-slug')
       results[1].slug.should.equal('slug-1')
       results[0].updated_at.should.containEql('2017-01-01')
+    })
+  })
+
+  describe('seriesArticle', () => {
+    it('can find a series article', async () => {
+      const seriesArticle = {
+        results: [
+          _.extend({}, fixtures.article, {
+            title: 'Series Article',
+            related_article_ids: [ObjectId('54276766fd4f50996aeca2b8')]
+          })
+        ]
+      }
+      promisedMongoFetch.onFirstCall().resolves(seriesArticle)
+      const results = await resolvers.seriesArticle({
+        id: '54276766fd4f50996aeca2b8'
+      })
+      results.title.should.equal('Series Article')
+    })
+
+    it('returns null if no series article is found', async () => {
+      const seriesArticle = {
+        results: [
+          _.extend({}, fixtures.article, {
+            title: 'Series Article',
+            related_article_ids: []
+          })
+        ]
+      }
+      promisedMongoFetch.onFirstCall().resolves(seriesArticle)
+      const results = await resolvers.seriesArticle({
+        id: '54276766fd4f50996aeca2b8'
+      })
+      _.isNull(results).should.be.true()
     })
   })
 


### PR DESCRIPTION
This lets us query the seriesArticle within the initial article fetch. Note that the rendering on the Reaction side will have to pull the `seriesArticle` from `article` like: 

```
<Article article={article} seriesArticle={article.seriesArticle} />
```

So we might want to push the `seriesArticle` prop one level down but from a query perspective this should reduce the number of round trips we need to make to render.

![image](https://user-images.githubusercontent.com/2236794/34163327-6c3e55b0-e4a4-11e7-9b7e-a79531b162b0.png)
