### PR TITLE
@kanabe => Can save multiple sponsor images

### DIFF
--- a/client/apps/edit/components/admin/components/sponsor.jsx
+++ b/client/apps/edit/components/admin/components/sponsor.jsx
@@ -11,7 +11,8 @@ export class AdminSponsor extends Component {
 
   onChange = (key, value) => {
     const { article, onChange } = this.props
-    const sponsor = article.sponsor || {}
+    const sponsor = article.get('sponsor') || {}
+
     sponsor[key] = value
     onChange('sponsor', sponsor)
   }
@@ -46,7 +47,7 @@ export class AdminSponsor extends Component {
           <ImageUpload
             onChange={this.onChange}
             src={sponsor.partner_condensed_logo}
-            name='partner_dark_logo'
+            name='partner_condensed_logo'
           />
         </Col>
 

--- a/client/apps/edit/components/admin/test/sponsor.test.js
+++ b/client/apps/edit/components/admin/test/sponsor.test.js
@@ -42,7 +42,7 @@ describe('EditAdmin', () => {
       expect(component.html()).toMatch('partner_condensed_logo.jpg')
     })
 
-    it('Calls props.onChange when fileInput changes', () => {
+    it('Can add a light logo', () => {
       const component = mount(
         <AdminSponsor {...props} />
       )
@@ -51,6 +51,28 @@ describe('EditAdmin', () => {
 
       expect(props.onChange.mock.calls[0][0]).toBe('sponsor')
       expect(props.onChange.mock.calls[0][1].partner_light_logo).toBe('http://new-image.jpg')
+    })
+
+    it('Can add a dark logo', () => {
+      const component = mount(
+        <AdminSponsor {...props} />
+      )
+      const input = component.find(ImageUpload).at(1).node
+      input.props.onChange(input.props.name, 'http://new-image.jpg')
+
+      expect(props.onChange.mock.calls[0][0]).toBe('sponsor')
+      expect(props.onChange.mock.calls[0][1].partner_dark_logo).toBe('http://new-image.jpg')
+    })
+
+    it('Can add a condensed logo', () => {
+      const component = mount(
+        <AdminSponsor {...props} />
+      )
+      const input = component.find(ImageUpload).last().node
+      input.props.onChange(input.props.name, 'http://new-image.jpg')
+
+      expect(props.onChange.mock.calls[0][0]).toBe('sponsor')
+      expect(props.onChange.mock.calls[0][1].partner_condensed_logo).toBe('http://new-image.jpg')
     })
   })
 


### PR DESCRIPTION
Minor fixes to save multiple sponsor images, plus a few more tests.