### PR TITLE
@kanaaabe => Autocomplete2 tweaks

### DIFF
--- a/client/components/autocomplete2/index.jsx
+++ b/client/components/autocomplete2/index.jsx
@@ -1,16 +1,18 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { uniq } from 'lodash'
+import { uniq, compact } from 'lodash'
 import Icon from '@artsy/reaction-force/dist/Components/Icon'
 
 export class Autocomplete extends Component {
   static propTypes = {
+    className: PropTypes.string,
     disabled: PropTypes.bool,
     filter: PropTypes.func,
     formatResult: PropTypes.func,
     items: PropTypes.array,
     onSelect: PropTypes.func,
     placeholder: PropTypes.string,
+    resObject: PropTypes.func,
     url: PropTypes.string
   }
 
@@ -66,11 +68,32 @@ export class Autocomplete extends Component {
     })
   }
 
-  onSelect = (item) => {
-    const { onSelect, items } = this.props
-    items.push(item._id)
-    onSelect(uniq(items))
-    this.onBlur()
+  getResItem = async (selected) => {
+    const { resObject } = this.props
+
+    try {
+      if (!resObject) {
+        return selected.id || selected._id
+      } else {
+        return await resObject(selected)
+      }
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  onSelect = async (selected) => {
+    const { items, onSelect } = this.props
+
+    try {
+      const item = await this.getResItem(selected)
+
+      items.push(item)
+      onSelect(uniq(items))
+      this.onBlur()
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   onBlur = () => {
@@ -102,24 +125,27 @@ export class Autocomplete extends Component {
 
   formatResults = () => {
     const { formatResult } = this.props
-    const { loading, results } = this.state
+    const { loading } = this.state
+    const results = compact(this.state.results)
 
     if (results.length) {
-      return results.map((item, i) =>
-        <div
-          key={i}
-          className='Autocomplete__result'
-          onClick={() => this.onSelect(item)}
-        >
-          {formatResult
-            ? <div className='Autocomplete__item'>
-                {formatResult(item)}
-              </div>
+      return results.map((item, i) => {
+        return (
+          <div
+            key={i}
+            className='Autocomplete__result'
+            onClick={() => this.onSelect(item)}
+          >
+            {formatResult
+              ? <div className='Autocomplete__item'>
+                  {formatResult(item)}
+                </div>
 
-            : this.formatResult(item)
-          }
-        </div>
-      )
+              : this.formatResult(item)
+            }
+          </div>
+        )
+      })
     } else if (loading) {
       return (
         <div className='Autocomplete__item Autocomplete__item--loading'>
@@ -149,10 +175,10 @@ export class Autocomplete extends Component {
   }
 
   render () {
-    const { disabled, placeholder } = this.props
+    const { className, disabled, placeholder } = this.props
 
     return (
-      <div className='Autocomplete'>
+      <div className={`Autocomplete ${className}`}>
         <Icon
           name='search'
           color='black'

--- a/client/components/autocomplete2/index.jsx
+++ b/client/components/autocomplete2/index.jsx
@@ -8,16 +8,16 @@ export class Autocomplete extends Component {
     className: PropTypes.string,
     disabled: PropTypes.bool,
     filter: PropTypes.func,
-    formatResult: PropTypes.func,
+    formatSelected: PropTypes.func,
+    formatSearchResult: PropTypes.func,
     items: PropTypes.array,
     onSelect: PropTypes.func,
     placeholder: PropTypes.string,
-    resObject: PropTypes.func,
     url: PropTypes.string
   }
 
   state = {
-    results: [],
+    searchResults: [],
     loading: false
   }
 
@@ -68,14 +68,14 @@ export class Autocomplete extends Component {
     })
   }
 
-  getResItem = async (selected) => {
-    const { resObject } = this.props
+  formatSelected = async (selected) => {
+    const { formatSelected } = this.props
 
     try {
-      if (!resObject) {
+      if (!formatSelected) {
         return selected.id || selected._id
       } else {
-        return await resObject(selected)
+        return await formatSelected(selected)
       }
     } catch (error) {
       console.error(error)
@@ -86,7 +86,7 @@ export class Autocomplete extends Component {
     const { items, onSelect } = this.props
 
     try {
-      const item = await this.getResItem(selected)
+      const item = await this.formatSelected(selected)
 
       items.push(item)
       onSelect(uniq(items))
@@ -101,7 +101,7 @@ export class Autocomplete extends Component {
       this.textInput.blur()
       this.textInput.value = ''
     }
-    this.setState({ results: [] })
+    this.setState({ searchResults: [] })
   }
 
   isFocused = () => {
@@ -123,22 +123,22 @@ export class Autocomplete extends Component {
     )
   }
 
-  formatResults = () => {
-    const { formatResult } = this.props
+  formatSearchResults = () => {
+    const { formatSearchResult } = this.props
     const { loading } = this.state
-    const results = compact(this.state.results)
+    const searchResults = compact(this.state.searchResults)
 
-    if (results.length) {
-      return results.map((item, i) => {
+    if (searchResults.length) {
+      return searchResults.map((item, i) => {
         return (
           <div
             key={i}
             className='Autocomplete__result'
             onClick={() => this.onSelect(item)}
           >
-            {formatResult
+            {formatSearchResult
               ? <div className='Autocomplete__item'>
-                  {formatResult(item)}
+                  {formatSearchResult(item)}
                 </div>
 
               : this.formatResult(item)
@@ -157,13 +157,13 @@ export class Autocomplete extends Component {
     }
   }
 
-  renderResults = () => {
+  renderSearchResults = () => {
     if (this.isFocused()) {
       // display if input is focused
       return (
         <div className='Autocomplete__results'>
           <div className='Autocomplete__results-list'>
-            {this.formatResults()}
+            {this.formatSearchResults()}
           </div>
           <div
             className='Autocomplete__results-bg'
@@ -193,7 +193,7 @@ export class Autocomplete extends Component {
             this.textInput = input
           }}
         />
-        {this.renderResults()}
+        {this.renderSearchResults()}
       </div>
     )
   }

--- a/client/components/autocomplete2/index.styl
+++ b/client/components/autocomplete2/index.styl
@@ -1,6 +1,6 @@
 .Autocomplete
   position relative
-  z-index 10
+  z-index 4
   input
     padding-left 36px
     width 100%
@@ -32,6 +32,7 @@
     align-items center
     garamond l-body
     border-bottom 1px solid gray-lighter-color
+    min-height 50px
     z-index 3
     &:hover
       background gray-lightest-color

--- a/client/components/autocomplete2/test/index.test.js
+++ b/client/components/autocomplete2/test/index.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
+import Article from 'client/models/article.coffee'
 import { Autocomplete } from '../index.jsx'
 require('typeahead.js')
 
@@ -47,12 +48,25 @@ describe('Autocomplete', () => {
     expect(component.instance().engine.get.mock.calls[0][0]).toBe('a title')
   })
 
-  it('OnSelect calls props.onSelect with selected id', () => {
+  it('OnSelect calls props.onSelect with selected id', async () => {
     const component = mount(
       <Autocomplete {...props} />
     )
-    component.instance().onSelect(results[0])
-    expect(props.onSelect.mock.calls[0][0][0]).toBe(results[0]._id)
+    await component.instance().onSelect(results[0])
+    expect(props.onSelect.mock.calls[0][0][0]).toBe(results[0].id)
+  })
+
+  it('Returns a custom resObject on select if provided', async () => {
+    const resObject = (item) => {
+      return new Article(item)
+    }
+
+    props.resObject = resObject
+    const component = mount(
+      <Autocomplete {...props} />
+    )
+    await component.instance().onSelect(results[0])
+    expect(props.onSelect.mock.calls[0][0][0].get('id')).toBe(results[0].id)
   })
 
   it('Disables input if props.disabled', () => {

--- a/client/components/autocomplete2/test/index.test.js
+++ b/client/components/autocomplete2/test/index.test.js
@@ -7,7 +7,7 @@ require('typeahead.js')
 
 describe('Autocomplete', () => {
   let props
-  let results
+  let searchResults
 
   beforeEach(() => {
     props = {
@@ -17,7 +17,7 @@ describe('Autocomplete', () => {
       url: 'artsy.net'
     }
 
-    results = [
+    searchResults = [
       Fixtures.FeatureArticle,
       Fixtures.StandardArticle
     ]
@@ -52,21 +52,21 @@ describe('Autocomplete', () => {
     const component = mount(
       <Autocomplete {...props} />
     )
-    await component.instance().onSelect(results[0])
-    expect(props.onSelect.mock.calls[0][0][0]).toBe(results[0].id)
+    await component.instance().onSelect(searchResults[0])
+    expect(props.onSelect.mock.calls[0][0][0]).toBe(searchResults[0].id)
   })
 
   it('Returns a custom resObject on select if provided', async () => {
-    const resObject = (item) => {
+    const formatSelected = (item) => {
       return new Article(item)
     }
 
-    props.resObject = resObject
+    props.formatSelected = formatSelected
     const component = mount(
       <Autocomplete {...props} />
     )
-    await component.instance().onSelect(results[0])
-    expect(props.onSelect.mock.calls[0][0][0].get('id')).toBe(results[0].id)
+    await component.instance().onSelect(searchResults[0])
+    expect(props.onSelect.mock.calls[0][0][0].get('id')).toBe(searchResults[0].id)
   })
 
   it('Disables input if props.disabled', () => {
@@ -94,7 +94,9 @@ describe('Autocomplete', () => {
       <Autocomplete {...props} />
     )
     expect(component.instance().engine.remote.filter).toBe(props.filter)
-    expect(component.instance().engine.remote.filter({ results })[0].slug).toBe(results[0].slug)
+    expect(
+      component.instance().engine.remote.filter({ results: searchResults })[0].slug
+    ).toBe(searchResults[0].slug)
   })
 
   it('Displays a list of results if present', () => {
@@ -102,9 +104,9 @@ describe('Autocomplete', () => {
       <Autocomplete {...props} />
     )
     component.instance().isFocused = jest.fn().mockReturnValue(true)
-    component.setState({ results })
-    expect(component.find('.Autocomplete__item').length).toBe(results.length)
-    expect(component.html()).toMatch(results[0].title)
+    component.setState({ searchResults })
+    expect(component.find('.Autocomplete__item').length).toBe(searchResults.length)
+    expect(component.html()).toMatch(searchResults[0].title)
   })
 
   it('Displays "No Results" if focused and no results', () => {
@@ -112,21 +114,21 @@ describe('Autocomplete', () => {
       <Autocomplete {...props} />
     )
     component.instance().isFocused = jest.fn().mockReturnValue(true)
-    component.setState({results: []})
+    component.setState({searchResults: []})
     expect(component.find('.Autocomplete__item').length).toBe(1)
     expect(component.html()).toMatch('No results')
   })
 
   it('Uses a custom format for results if provided', () => {
-    const formatResult = (item) => {
+    const formatSearchResult = (item) => {
       return <div>Child: {item.title}</div>
     }
-    props.formatResult = formatResult
+    props.formatSearchResult = formatSearchResult
     const component = mount(
       <Autocomplete {...props} />
     )
     component.instance().isFocused = jest.fn().mockReturnValue(true)
-    component.setState({ results })
-    expect(component.text()).toMatch(`Child: ${results[0].title}`)
+    component.setState({ searchResults })
+    expect(component.text()).toMatch(`Child: ${searchResults[0].title}`)
   })
 })


### PR DESCRIPTION
Some changes to the new autocomplete component:

- Adds a `formatSelected` prop to return a custom object on select
- Use async when returning selected item to allow fetches in parent
- Adds a className prop
- Better loading display on results list

Use case: 
For some uses, we store a list of `ids` which was already supported.  In others, we want to push something else to our items list -- for example, a backbone object in the case of article artworks.
  
  