### PR TITLE
@kanaabe => Partner draft redirect bug

### DIFF
--- a/api/apps/users/model.coffee
+++ b/api/apps/users/model.coffee
@@ -72,9 +72,9 @@ save = (user, accessToken, callback) ->
 # Utility
 #
 @hasChannelAccess = (user, channel_id) ->
-  return false unless user and channel_id
+  return false unless user
 
-  channel_id = channel_id.toString()
+  channel_id = channel_id.toString() if channel_id
   @channels = _.find user.channel_ids, (id) ->
     id.toString() is channel_id
   @partners = _.find user.partner_ids, (id) ->

--- a/api/apps/users/test/model.test.coffee
+++ b/api/apps/users/test/model.test.coffee
@@ -112,6 +112,11 @@ describe 'User', ->
       User.hasChannelAccess(user, '5086df098523e60002000012').should.be.true()
       done()
 
+    it 'returns true for a non-partner or non-channel member but admin when no channel_id', (done) ->
+      user = _.extend fixtures().users, { channel_ids: [], partner_ids: [], type: 'Admin' }
+      User.hasChannelAccess(user).should.be.true()
+      done()
+
     it 'returns false for a non-partner or non-channel member', (done) ->
       user = _.extend fixtures().users, { channel_ids: [], partner_ids: [], type: 'User' }
       User.hasChannelAccess(user, '5086df098523e60002000012').should.be.false()


### PR DESCRIPTION
Drafts for partner channels were still erroring, despite having an updated URL -- turns out this was because force is not passing a 'channel_id' when requesting partner drafts. 

hasChannelAccess has been updated not to return false when channel_id is missing. 