### PR TITLE
@kanaabe => Redux errors

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -4,6 +4,7 @@ export const actions = keyMirror(
   'CHANGE_SAVED_STATUS',
   'CHANGE_SECTION',
   'DELETE_ARTICLE',
+  'ERROR',
   'PUBLISH_ARTICLE',
   'SAVE_ARTICLE'
 )
@@ -60,3 +61,18 @@ export const saveArticle = (article) => {
     }
   }
 }
+
+// EDITING ERRORS
+export const logError = (error) => ({
+  type: actions.ERROR,
+  payload: {
+    error
+  }
+})
+
+export const resetError = () => ({
+  type: actions.ERROR,
+  payload: {
+    error: null
+  }
+})

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -49,4 +49,22 @@ describe('editActions', () => {
     expect(saveArticle.payload.isSaving).toBe(true)
     expect(article.save.mock.calls.length).toBe(1)
   })
+
+  describe('Editing errors', () => {
+    it('#logError sets error to arg', () => {
+      const message = 'Error message'
+      const logError = editActions.logError({ message })
+
+      expect(logError.type).toBe('ERROR')
+      expect(logError.payload.error.message).toBe(message)
+    })
+
+    it('#resetError sets error to null', () => {
+      const message = 'Error message'
+      const resetError = editActions.resetError({ message })
+
+      expect(resetError.type).toBe('ERROR')
+      expect(resetError.payload.error).toBe(null)
+    })
+  })
 })

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -4,10 +4,11 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import * as Actions from 'client/actions/editActions'
 
+import { EditAdmin } from './admin/index.jsx'
 import { EditContent } from './content/index.jsx'
 import { EditDisplay } from './display/index.jsx'
 import { EditHeader } from './header/index.jsx'
-import { EditAdmin } from './admin/index.jsx'
+import EditError from './error/index.jsx'
 
 class EditContainer extends Component {
   static propTypes = {
@@ -15,6 +16,7 @@ class EditContainer extends Component {
     actions: PropTypes.object,
     channel: PropTypes.object,
     edit: PropTypes.object,
+    error: PropTypes.object,
     user: PropTypes.object
   }
 
@@ -79,10 +81,14 @@ class EditContainer extends Component {
   }
 
   render () {
+    const { error } = this.props
+
     return (
       <div className='EditContainer'>
 
         <EditHeader {...this.props} />
+
+        {error && <EditError />}
 
         {this.getActiveSection()}
 

--- a/client/apps/edit/components/error/index.jsx
+++ b/client/apps/edit/components/error/index.jsx
@@ -1,0 +1,39 @@
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import * as Actions from 'client/actions/editActions'
+
+export class EditError extends Component {
+  static propTypes = {
+    actions: PropTypes.object.isRequired,
+    error: PropTypes.object.isRequired
+  }
+
+  render () {
+    const { resetError } = this.props.actions
+    const { message } = this.props.error
+
+    return (
+      <div
+        className='EditError flash-error'
+        onClick={resetError}
+      >
+        {message}
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state) => ({
+  ...state
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  actions: bindActionCreators(Actions, dispatch)
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EditError)

--- a/client/apps/edit/components/error/tests/index.test.js
+++ b/client/apps/edit/components/error/tests/index.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { EditError } from '../index'
+import { mount } from 'enzyme'
+
+describe('EditError', () => {
+  let props
+
+  beforeEach(() => {
+    props = {
+      actions: {
+        resetError: jest.fn()
+      },
+      error: {
+        message: 'Error Message'
+      }
+    }
+  })
+
+  it('Displays an error message', () => {
+    const component = mount(
+      <EditError {...props} />
+    )
+    expect(component.text()).toMatch(props.error.message)
+  })
+
+  it('Resets the error state on click', () => {
+    const component = mount(
+      <EditError {...props} />
+    )
+    component.simulate('click')
+    expect(props.actions.resetError.mock.calls.length).toBe(1)
+  })
+})

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -3,6 +3,7 @@ import { actions } from 'client/actions/editActions'
 
 export const initialState = {
   activeSection: 'content',
+  error: null,
   isDeleting: false,
   isPublishing: false,
   isSaving: false,
@@ -25,6 +26,11 @@ export function editReducer (state = initialState, action) {
     case actions.DELETE_ARTICLE: {
       return u({
         isDeleting: action.payload.isDeleting
+      }, state)
+    }
+    case actions.ERROR: {
+      return u({
+        error: action.payload.error
       }, state)
     }
     case actions.PUBLISH_ARTICLE: {


### PR DESCRIPTION
Actions, reducers and a component to display client side errors for articles. 

Errors can be set from anywhere in the `/content` directory by calling the redux action `logError(err)` -- they display as a flash message in the `EditContainer` component. 


  