### PR TITLE
@kanaabe => Consolidate placeholder styles

### DIFF
--- a/client/apps/edit/components/content/article_layouts/video.jsx
+++ b/client/apps/edit/components/content/article_layouts/video.jsx
@@ -214,8 +214,6 @@ export const EditVideoContainer = styled.div`
 
   ${VideoCoverContainer}, ${VideoAboutContainer} {
     .public-DraftEditorPlaceholder-root {
-      left: 0;
-      right: 0;
       color: gray;
     }
   }

--- a/client/apps/edit/components/content/section_container/index.styl
+++ b/client/apps/edit/components/content/section_container/index.styl
@@ -71,8 +71,6 @@
       min-width 100%
     .rich-text--paragraph
       position relative
-    .public-DraftEditorPlaceholder-root
-      position absolute
     a
       background-size 1px 1px
 

--- a/client/apps/edit/components/content/sections/footer/index.styl
+++ b/client/apps/edit/components/content/sections/footer/index.styl
@@ -1,7 +1,4 @@
 .SectionFooter
-  .public-DraftEditorPlaceholder-root
-    position absolute
-    color gray-darker-color
   &__postscript
     padding 20px
     .public-DraftEditorPlaceholder-root

--- a/client/apps/edit/components/layout/index.styl
+++ b/client/apps/edit/components/layout/index.styl
@@ -123,9 +123,6 @@
   width body-width
   font-size 20px
   line-height 26px
-  .public-DraftEditorPlaceholder-root
-    color gray-dark-color
-    position absolute
   .public-DraftEditor-content
     div[data-blocK]
       margin-bottom 1em
@@ -146,5 +143,12 @@
   width 100%
   height 100px
 
+// Draft placeholder sit inline with content
+.DraftEditor-root
+  position relative
 .public-DraftEditorPlaceholder-root
   position absolute
+  top 0
+  left 0
+  right 0
+  color gray-dark-color

--- a/client/apps/settings/client/curations/display/index.styl
+++ b/client/apps/settings/client/curations/display/index.styl
@@ -19,9 +19,6 @@
     min-height 4.25em
     p
       font-size 1em
-    .public-DraftEditorPlaceholder-root
-      position absolute
-      color gray-color
   label
     display flex
     justify-content space-between

--- a/client/components/character_limit/index.styl
+++ b/client/components/character_limit/index.styl
@@ -3,10 +3,6 @@
     display flex
     justify-content space-between
 
-  .public-DraftEditorPlaceholder-root
-    color gray-color
-    position absolute
-  
   &[data-type=textarea]
     .DraftEditor-root
       min-height 3em


### PR DESCRIPTION
(Minor)
Most of the draft placeholders are styled the same and we already had a top level class for them -- this adds additional positioning to the top-level class (to prevent placeholders from wrapping text), and removes duplicate css.