### PR TITLE
@damassi => Connect Header, SectionList

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -2,7 +2,7 @@ import keyMirror from 'client/lib/keyMirror'
 
 export const actions = keyMirror(
   'CHANGE_SAVED_STATUS',
-  'CHANGE_SECTION',
+  'CHANGE_VIEW',
   'DELETE_ARTICLE',
   'ERROR',
   'PUBLISH_ARTICLE',
@@ -16,10 +16,11 @@ export const changeSavedStatus = (isSaved) => ({
   }
 })
 
-export const changeSection = (activeSection) => ({
-  type: actions.CHANGE_SECTION,
+export const changeView = (activeView) => ({
+  // Content, Admin, Display
+  type: actions.CHANGE_VIEW,
   payload: {
-    activeSection
+    activeView
   }
 })
 

--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -2,6 +2,7 @@ import keyMirror from 'client/lib/keyMirror'
 
 export const actions = keyMirror(
   'CHANGE_SAVED_STATUS',
+  'CHANGE_SECTION',
   'CHANGE_VIEW',
   'DELETE_ARTICLE',
   'ERROR',
@@ -13,6 +14,14 @@ export const changeSavedStatus = (isSaved) => ({
   type: actions.CHANGE_SAVED_STATUS,
   payload: {
     isSaved
+  }
+})
+
+export const changeSection = (activeSection) => ({
+  // Index of active article section
+  type: actions.CHANGE_SECTION,
+  payload: {
+    activeSection
   }
 })
 

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -19,11 +19,11 @@ describe('editActions', () => {
     expect(changeSavedStatus.payload.isSaved).toBe(true)
   })
 
-  it('#changeSection sets the activeSection to arg', () => {
-    const changeSection = editActions.changeSection('display')
+  it('#changeView sets the activeSection to arg', () => {
+    const changeView = editActions.changeView('display')
 
-    expect(changeSection.type).toBe('CHANGE_SECTION')
-    expect(changeSection.payload.activeSection).toBe('display')
+    expect(changeView.type).toBe('CHANGE_VIEW')
+    expect(changeView.payload.activeView).toBe('display')
   })
 
   it('#deleteArticle destroys the article and sets isDeleting', () => {

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -19,7 +19,14 @@ describe('editActions', () => {
     expect(changeSavedStatus.payload.isSaved).toBe(true)
   })
 
-  it('#changeView sets the activeSection to arg', () => {
+  it('#changeSection sets activeSection to arg', () => {
+    const changeSection = editActions.changeSection(6)
+
+    expect(changeSection.type).toBe('CHANGE_SECTION')
+    expect(changeSection.payload.activeSection).toBe(6)
+  })
+
+  it('#changeView sets the activeView to arg', () => {
     const changeView = editActions.changeView('display')
 
     expect(changeView.type).toBe('CHANGE_VIEW')

--- a/client/apps/edit/components/content/article_layouts/article.jsx
+++ b/client/apps/edit/components/content/article_layouts/article.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import { SectionFooter } from '../sections/footer/index'
 import { SectionHeader } from '../sections/header/index'
 import { SectionHero } from '../sections/hero/index'
-import { SectionList } from '../section_list/index'
+import SectionList from '../section_list/index'
 
 export class EditArticle extends Component {
   static propTypes = {

--- a/client/apps/edit/components/content/article_layouts/test/article.test.js
+++ b/client/apps/edit/components/content/article_layouts/test/article.test.js
@@ -1,15 +1,21 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
 import Article from '../../../../../../models/article'
 import { SectionFooter } from '../../sections/footer/index'
 import { SectionHeader } from '../../sections/header/index'
 import { SectionHero } from '../../sections/hero/index'
-import { SectionList } from '../../section_list/index'
+import SectionList from '../../section_list/index'
 import { EditArticle } from '../article'
 
 describe('EditArticle', () => {
   let props
+
+  const getWrapper = (props) => {
+    return shallow(
+      <EditArticle {...props} />
+    )
+  }
 
   beforeEach(() => {
     props = {
@@ -23,38 +29,28 @@ describe('EditArticle', () => {
   })
 
   it('Does not render SectionHero if channel does not have feature', () => {
-    const component = mount(
-      <EditArticle {...props} />
-    )
+    const component = getWrapper(props)
     expect(component.find(SectionHero).length).toBe(0)
   })
 
   it('Renders SectionHero if channel has feature', () => {
     props.channel.hasFeature = jest.fn().mockReturnValueOnce(true)
-    const component = mount(
-      <EditArticle {...props} />
-    )
+    const component = getWrapper(props)
     expect(component.find(SectionHero).length).toBe(1)
   })
 
   it('Renders SectionHeader', () => {
-    const component = mount(
-      <EditArticle {...props} />
-    )
+    const component = getWrapper(props)
     expect(component.find(SectionHeader).length).toBe(1)
   })
 
   it('Renders SectionList', () => {
-    const component = mount(
-      <EditArticle {...props} />
-    )
+    const component = getWrapper(props)
     expect(component.find(SectionList).length).toBe(1)
   })
 
   it('Renders SectionFooter', () => {
-    const component = mount(
-      <EditArticle {...props} />
-    )
+    const component = getWrapper(props)
     expect(component.find(SectionFooter).length).toBe(1)
   })
 })

--- a/client/apps/edit/components/content/section_list/test/index.test.jsx
+++ b/client/apps/edit/components/content/section_list/test/index.test.jsx
@@ -16,14 +16,10 @@ describe('SectionList', () => {
     article = new Article(Fixtures.StandardArticle)
 
     props = {
-      actions: {
-        changeSection: jest.fn()
-      },
+      activeSection: null,
       article,
+      changeSectionAction: jest.fn(),
       channel: new Channel(),
-      edit: {
-        activeSection: null
-      },
       sections: article.sections
     }
   })
@@ -75,6 +71,6 @@ describe('SectionList', () => {
       {type: 'embed'},
       {at: 3}
     )
-    expect(component.props().actions.changeSection.mock.calls[1][0]).toBe(3)
+    expect(component.props().changeSectionAction.mock.calls[1][0]).toBe(3)
   })
 })

--- a/client/apps/edit/components/content/section_list/test/index.test.jsx
+++ b/client/apps/edit/components/content/section_list/test/index.test.jsx
@@ -16,8 +16,14 @@ describe('SectionList', () => {
     article = new Article(Fixtures.StandardArticle)
 
     props = {
+      actions: {
+        changeSection: jest.fn()
+      },
       article,
       channel: new Channel(),
+      edit: {
+        activeSection: null
+      },
       sections: article.sections
     }
   })
@@ -60,7 +66,7 @@ describe('SectionList', () => {
     expect(component.find(SectionContainer).length).toBe(props.article.sections.length)
   })
 
-  it('Listens for a new section and set state to editing', () => {
+  it('Listens for a new section and dispatches changeSection with index', () => {
     const component = mount(
       <SectionList {...props} />
     )
@@ -69,6 +75,6 @@ describe('SectionList', () => {
       {type: 'embed'},
       {at: 3}
     )
-    expect(component.state().editingIndex).toBe(3)
+    expect(component.props().actions.changeSection.mock.calls[1][0]).toBe(3)
   })
 })

--- a/client/apps/edit/components/content/test/index.test.js
+++ b/client/apps/edit/components/content/test/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
 import Article from '../../../../../models/article'
 import { EditArticle } from '../article_layouts/article'
@@ -9,6 +9,12 @@ require('typeahead.js')
 
 describe('EditContent', () => {
   let props
+
+  const getWrapper = (props) => {
+    return shallow(
+      <EditContent {...props} />
+    )
+  }
 
   beforeEach(() => {
     props = {
@@ -22,18 +28,14 @@ describe('EditContent', () => {
   })
 
   it('Renders EditArticle if article layout is not series', () => {
-    const component = mount(
-      <EditContent {...props} />
-    )
+    const component = getWrapper(props)
     expect(component.find(EditArticle).length).toBe(1)
     expect(component.find(EditSeries).length).toBe(0)
   })
 
   it('Renders EditSeries if article layout is series', () => {
     props.article.set('layout', 'series')
-    const component = mount(
-      <EditContent {...props} />
-    )
+    const component = getWrapper(props)
     expect(component.find(EditSeries).length).toBe(1)
     expect(component.find(EditArticle).length).toBe(0)
   })

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -61,7 +61,7 @@ class EditContainer extends Component {
 
   getActiveSection = () => {
     const { article, channel, edit } = this.props
-    const { activeSection } = edit
+    const { activeView } = edit
 
     const props = {
       article,
@@ -70,7 +70,7 @@ class EditContainer extends Component {
       onChangeHero: this.onChangeHero
     }
 
-    switch (activeSection) {
+    switch (activeView) {
       case 'admin':
         return <EditAdmin {...props} />
       case 'content':

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -59,7 +59,7 @@ class EditContainer extends Component {
     this.setState({ lastUpdated: new Date() })
   }
 
-  getActiveSection = () => {
+  getActiveView = () => {
     const { article, channel, edit } = this.props
     const { activeView } = edit
 
@@ -90,7 +90,7 @@ class EditContainer extends Component {
 
         {error && <EditError />}
 
-        {this.getActiveSection()}
+        {this.getActiveView()}
 
       </div>
     )

--- a/client/apps/edit/components/header/index.jsx
+++ b/client/apps/edit/components/header/index.jsx
@@ -12,9 +12,9 @@ export class EditHeader extends Component {
     user: PropTypes.object
   }
 
-  toggleSection = (activeSection) => {
+  toggleSection = (activeView) => {
     // TODO - connect component to use redux actions directly
-    this.props.actions.changeSection(activeSection)
+    this.props.actions.changeView(activeView)
   }
 
   isPublishable = () => {

--- a/client/apps/edit/components/header/index.jsx
+++ b/client/apps/edit/components/header/index.jsx
@@ -178,7 +178,7 @@ export class EditHeader extends Component {
 }
 
 const mapStateToProps = (state) => ({
-  ...state
+  edit: state.edit
 })
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/apps/edit/components/header/index.jsx
+++ b/client/apps/edit/components/header/index.jsx
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import * as Actions from 'client/actions/editActions'
 import Icon from '@artsy/reaction-force/dist/Components/Icon'
 import colors from '@artsy/reaction-force/dist/Assets/Colors'
 
@@ -10,11 +13,6 @@ export class EditHeader extends Component {
     channel: PropTypes.object,
     edit: PropTypes.object,
     user: PropTypes.object
-  }
-
-  toggleSection = (activeView) => {
-    // TODO - connect component to use redux actions directly
-    this.props.actions.changeView(activeView)
   }
 
   isPublishable = () => {
@@ -83,8 +81,9 @@ export class EditHeader extends Component {
   }
 
   render () {
-    const { article, actions, channel, user } = this.props
-    const { activeSection, isDeleting } = this.props.edit
+    const { article, actions, channel, edit, user } = this.props
+    const { changeView } = actions
+    const { activeView, isDeleting } = edit
     const { grayMedium, greenRegular } = colors
 
     return (
@@ -94,8 +93,8 @@ export class EditHeader extends Component {
           <div className='EditHeader__tabs'>
             <button
               className='avant-garde-button check'
-              onClick={() => this.toggleSection('content')}
-              data-active={activeSection === 'content'}
+              onClick={() => changeView('content')}
+              data-active={activeView === 'content'}
             >
               <span>Content</span>
               <Icon
@@ -107,8 +106,8 @@ export class EditHeader extends Component {
 
             <button
               className='avant-garde-button check'
-              onClick={() => this.toggleSection('display')}
-              data-active={activeSection === 'display'}
+              onClick={() => changeView('display')}
+              data-active={activeView === 'display'}
             >
               <span>Display</span>
               <Icon
@@ -121,8 +120,8 @@ export class EditHeader extends Component {
             {user.type === 'Admin' &&
               <button
                 className='avant-garde-button'
-                onClick={() => this.toggleSection('admin')}
-                data-active={activeSection === 'admin'}
+                onClick={() => changeView('admin')}
+                data-active={activeView === 'admin'}
               >
                 Admin
               </button>
@@ -177,3 +176,16 @@ export class EditHeader extends Component {
     )
   }
 }
+
+const mapStateToProps = (state) => ({
+  ...state
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  actions: bindActionCreators(Actions, dispatch)
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EditHeader)

--- a/client/apps/edit/components/header/test/index.test.js
+++ b/client/apps/edit/components/header/test/index.test.js
@@ -14,7 +14,7 @@ describe('Edit Header Controls', () => {
   beforeEach(() => {
     props = {
       actions: {
-        changeSection: jest.fn(),
+        changeView: jest.fn(),
         deleteArticle: jest.fn(),
         publishArticle: jest.fn(),
         saveArticle: jest.fn()
@@ -97,7 +97,7 @@ describe('Edit Header Controls', () => {
       const button = component.find('button').at(1)
       button.simulate('click')
 
-      expect(props.actions.changeSection.mock.calls[0][0]).toBe('display')
+      expect(props.actions.changeView.mock.calls[0][0]).toBe('display')
     })
 
     it('Publishes an article on button click', () => {

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -2,6 +2,7 @@ import u from 'updeep'
 import { actions } from 'client/actions/editActions'
 
 export const initialState = {
+  activeSection: null,
   activeView: 'content',
   error: null,
   isDeleting: false,
@@ -16,6 +17,11 @@ export function editReducer (state = initialState, action) {
       return u({
         isSaving: false,
         isSaved: action.payload.isSaved
+      }, state)
+    }
+    case actions.CHANGE_SECTION: {
+      return u({
+        activeSection: action.payload.activeSection
       }, state)
     }
     case actions.CHANGE_VIEW: {

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -2,7 +2,7 @@ import u from 'updeep'
 import { actions } from 'client/actions/editActions'
 
 export const initialState = {
-  activeSection: 'content',
+  activeView: 'content',
   error: null,
   isDeleting: false,
   isPublishing: false,
@@ -18,9 +18,9 @@ export function editReducer (state = initialState, action) {
         isSaved: action.payload.isSaved
       }, state)
     }
-    case actions.CHANGE_SECTION: {
+    case actions.CHANGE_VIEW: {
       return u({
-        activeSection: action.payload.activeSection
+        activeView: action.payload.activeView
       }, state)
     }
     case actions.DELETE_ARTICLE: {


### PR DESCRIPTION
- Adds new `changeSection` reducer and action for managing an article's `activeSection` index. 
- Renames old `changeSection` action (for navigating tabs) to `changeView` (to avoid confusing with article sections)

- Connect section list and use new `changeSection` action
- Connect EditHeader and use `changeView` action for tab navigation