### PR TITLE
@eessex => Denormalize credit line on artwork (and two more small updates)

### DIFF
--- a/api/apps/articles/model/schema.coffee
+++ b/api/apps/articles/model/schema.coffee
@@ -75,6 +75,7 @@ denormalizedArtwork = (->
       slug: @string().allow('', null)
     width: @number().allow(null)
     height: @number().allow(null)
+    credit: @string().allow('')
 ).call Joi
 
 ImageCollectionSection = (->

--- a/api/apps/articles/test/model/index/persistence.test.coffee
+++ b/api/apps/articles/test/model/index/persistence.test.coffee
@@ -516,6 +516,7 @@ describe 'Article Persistence', ->
                 title: 'The Piece'
                 date: '2015-04-01'
                 image: 'http://image.png'
+                credit: 'Credit Line'
               }
             ]
           }
@@ -530,6 +531,7 @@ describe 'Article Persistence', ->
         article.sections[0].images[1].type.should.equal 'artwork'
         article.sections[0].images[1].id.should.equal '123'
         article.sections[0].images[1].slug.should.equal 'andy-warhol'
+        article.sections[0].images[1].credit.should.equal 'Credit Line'
         done()
 
     it 'saves layouts', (done) ->

--- a/client/apps/display/client.jsx
+++ b/client/apps/display/client.jsx
@@ -5,7 +5,7 @@ import track from 'react-tracking'
 const sd = require('sharify').data
 
 @track(
-  { page: 'Instant Article Display Panel' },
+  { is_instant_article: true },
   { dispatch: (data) => {
     const { action, ...rest } = data
     window.analytics.track(action, rest)

--- a/client/apps/edit/components/content/sections/image_collection/components/controls.jsx
+++ b/client/apps/edit/components/content/sections/image_collection/components/controls.jsx
@@ -119,7 +119,7 @@ export default class Controls extends Component {
           channel={channel}
           articleLayout={article.get('layout')}
           onChange={onChange}
-          sectionLayouts={isHero}
+          sectionLayouts={!isHero}
           isHero={isHero}
           disabledAlert={this.fillwidthAlert}>
 

--- a/client/apps/edit/components/content/sections/image_collection/components/controls.jsx
+++ b/client/apps/edit/components/content/sections/image_collection/components/controls.jsx
@@ -1,23 +1,29 @@
 import React, { Component } from 'react'
-const gemup = require('gemup')
-const sd = require('sharify').data
 import { clone, defer } from 'lodash'
 import Artwork from '/client/models/artwork.coffee'
 import Autocomplete from '/client/components/autocomplete/index.coffee'
 import FileInput from '/client/components/file_input/index.jsx'
 import SectionControls from '../../../section_controls/index.jsx'
 import UrlArtworkInput from './url_artwork_input.coffee'
+import PropTypes from 'prop-types'
+const sd = require('sharify').data
 
 export default class Controls extends Component {
-  constructor (props) {
-    super(props)
+  static propTypes = {
+    article: PropTypes.object,
+    channel: PropTypes.object,
+    images: PropTypes.array,
+    isHero: PropTypes.bool,
+    onChange: PropTypes.func,
+    section: PropTypes.object,
+    setProgress: PropTypes.func
   }
 
-  componentDidMount() {
+  componentDidMount () {
     this.setupAutocomplete()
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     this.autocomplete.remove()
   }
 
@@ -26,12 +32,12 @@ export default class Controls extends Component {
     this.props.onChange()
   }
 
-  setupAutocomplete() {
+  setupAutocomplete () {
     const $el = $(this.refs.autocomplete)
     this.autocomplete = new Autocomplete({
       url: `${sd.ARTSY_URL}/api/search?q=%QUERY`,
       el: $el,
-      filter(res) {
+      filter (res) {
         const vals = []
         for (let r of Array.from(res._embedded.results)) {
           if ((r.type != null ? r.type.toLowerCase() : undefined) === 'artwork') {
@@ -46,7 +52,7 @@ export default class Controls extends Component {
         return vals
       },
       templates: {
-        suggestion(data) {
+        suggestion (data) {
           return `<div class='autocomplete-suggestion' style='background-image: url(${data.thumbnail})'></div>${data.value}`
         }
       },
@@ -87,16 +93,24 @@ export default class Controls extends Component {
     this.props.section.set('layout', layout)
   }
 
-  inputsAreDisabled(section) {
+  inputsAreDisabled (section) {
     return section.get('layout') === 'fillwidth' && section.get('images').length > 0
   }
 
-  fillwidthAlert() {
+  fillwidthAlert () {
     alert('Fullscreen layouts accept one asset, please remove extra images.')
   }
 
-  render() {
-    const { article, channel, images, isHero, section, setProgress, onChange } = this.props
+  render () {
+    const {
+      article,
+      channel,
+      images,
+      isHero,
+      section,
+      setProgress,
+      onChange
+    } = this.props
     const inputsAreDisabled = this.inputsAreDisabled(section)
 
     return (
@@ -105,7 +119,7 @@ export default class Controls extends Component {
           channel={channel}
           articleLayout={article.get('layout')}
           onChange={onChange}
-          sectionLayouts={isHero ? false : true}
+          sectionLayouts={isHero}
           isHero={isHero}
           disabledAlert={this.fillwidthAlert}>
 
@@ -150,16 +164,16 @@ export default class Controls extends Component {
                   <div
                     className='radio-input'
                     onClick={() => this.toggleImagesetLayout('mini')}
-                    data-active={section.get('layout') !== 'full'} >
-                  </div>
+                    data-active={section.get('layout') !== 'full'}
+                  />
                   Mini
                 </div>
                 <div className='input-group'>
                   <div
                     className='radio-input'
                     onClick={() => this.toggleImagesetLayout('full')}
-                    data-active={section.get('layout') === 'full'} >
-                  </div>
+                    data-active={section.get('layout') === 'full'}
+                  />
                   Full
                 </div>
               </div>

--- a/client/components/autocomplete_channels/index.coffee
+++ b/client/components/autocomplete_channels/index.coffee
@@ -30,7 +30,7 @@ module.exports = class AutocompleteChannels extends Backbone.View
       datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value')
       queryTokenizer: Bloodhound.tokenizers.whitespace
       remote:
-        url: "#{sd.API_URL}/channels?user_id=#{sd.USER.id}&q=%QUERY"
+        url: "#{sd.API_URL}/channels?user_id=#{sd.USER.id}&q=%QUERY&sort=name"
         filter: (channels) -> for channel in channels.results
           { id: channel.id, value: channel.name }
         ajax:

--- a/client/models/artwork.coffee
+++ b/client/models/artwork.coffee
@@ -33,6 +33,7 @@ module.exports = class Artwork extends Backbone.Model
     artist: @getArtists()[0]
     width: parseInt(@defaultImage().get('original_width'))
     height: parseInt(@defaultImage().get('original_height'))
+    credit: @get('image_rights') || ''
 
   getArtists: ->
     artists = []

--- a/client/test/models/artwork.test.coffee
+++ b/client/test/models/artwork.test.coffee
@@ -8,16 +8,38 @@ describe "Artwork", ->
 
   beforeEach ->
     sinon.stub Backbone, 'sync'
-    @artwork = new Artwork fabricate 'artwork'
+    @artwork = new Artwork _.extend {}, fabricate 'artwork',
+      title: 'Foo'
+      date: '1/1/2017'
+      id: 'foo'
+      artists: [
+        name: 'Andy Warhol'
+        id: 'andy-warhol'
+      ]
+      partner: {
+        name: 'MOMA'
+        default_profile_public: true
+        default_profile_id: 'moma'
+      }
 
   afterEach ->
     Backbone.sync.restore()
 
-  describe '#truncatedLabel', ->
+  it 'creates a nice short label for the artwork', ->
+    @artwork.truncatedLabel().should.equal 'A.W. Foo, 1/1/2017'
 
-    it 'creates a nice short label for the artwork', ->
-      @artwork.set
-        title: 'Foo'
-        date: 'Monday'
-        artist: name: 'Andy Warhol'
-      @artwork.truncatedLabel().should.equal 'A.W. Foo, Monday'
+  it 'denormalizes artworks', ->
+    denormalized = @artwork.denormalized()
+    denormalized.type.should.equal 'artwork'
+    denormalized.id.should.equal '564be09ab202a319e90000e2'
+    denormalized.slug.should.equal 'foo'
+    denormalized.date.should.equal '1/1/2017'
+    denormalized.title.should.equal 'Foo'
+    denormalized.image.should.equal '/local/additional_images/4e7cb83e1c80dd00010038e2/1/larger.jpg'
+    denormalized.partner.name.should.equal 'MOMA'
+    denormalized.partner.slug.should.equal 'moma'
+    denormalized.artists[0].name.should.equal 'Andy Warhol'
+    denormalized.artists[0].slug.should.equal 'andy-warhol'
+    denormalized.width.should.equal 1000
+    denormalized.height.should.equal 585
+    denormalized.credit.should.equal 'Sourced from ARS'


### PR DESCRIPTION
- Adds a parameter for tracking IA display ads (https://waffle.io/artsy/publishing/cards/5a591373a9d8c00057c88ad5)
- Denormalize credit line on artworks (Addresses Positron side of https://waffle.io/artsy/publishing/cards/5a57c23e3789680030dfd470)
- Sort query in AutocompleteChannels (https://waffle.io/artsy/publishing/cards/5a2f15b093d503001b4370a2)
- Fixes a couple eslint errors