### PR TITLE
@l2succes => Don't call change events unless content changes

### DIFF
--- a/client/components/rich_text/components/paragraph.coffee
+++ b/client/components/rich_text/components/paragraph.coffee
@@ -65,8 +65,12 @@ module.exports = React.createClass
 
   onChange: (editorState) ->
     html = @convertToHtml editorState
+    currentContentState = @state.editorState.getCurrentContent()
+    newContentState = editorState.getCurrentContent()
+
+    if currentContentState != newContentState
+      @props.onChange(html)
     @setState editorState: editorState, html: html
-    @props.onChange(html)
 
   focus: ->
     @setState focus: true

--- a/client/components/rich_text/test/components/paragraph.test.coffee
+++ b/client/components/rich_text/test/components/paragraph.test.coffee
@@ -95,6 +95,24 @@ describe 'Rich Text: Paragraph', ->
     it 'Renders existing link entities', ->
       $(ReactDOM.findDOMNode(@component)).html().should.containEql '<a href="http://artsy.net/">'
 
+  describe 'On change', ->
+    it 'Sets the editorState and html on change', ->
+      @component.setState = sinon.stub()
+      r.simulate.click r.find @component, 'rich-text--paragraph__input'
+      @component.setState.args[1][0].editorState.should.be.ok
+      @component.setState.args[1][0].html.should.be.ok
+
+    it 'Calls props.onChange if content has changed', ->
+      @component.setState = sinon.stub()
+      @component.handleKeyCommand('italic')
+      @component.props.onChange.called.should.eql true
+
+    it 'Does not call props.onChange if content has not changed', ->
+      @component.setState = sinon.stub()
+      r.simulate.click r.find @component, 'rich-text--paragraph__input'
+      @component.props.onChange.called.should.eql false
+      @component.setState.called.should.eql true
+
   describe 'Key commands', ->
 
     it 'Can toggle bold styles', ->


### PR DESCRIPTION
A small tweak to the Draft paragraph component ... Checks to see if content has changed before calling props.onChange.

This prevents auto-saving from occurring when the editorState is updated, but content does not actually change -- for example, when the editor focus changes.
