### PR TITLE
@l2succes => Actions bug in mapDispatchToProps

### DIFF
--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -105,10 +105,10 @@ const mapStateToProps = (state) => ({
   error: state.edit.error
 })
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = {
   changeSavedStatusAction: changeSavedStatus,
   saveArticleAction: saveArticle
-})
+}
 
 export default connect(
   mapStateToProps,

--- a/client/apps/edit/components/error/index.jsx
+++ b/client/apps/edit/components/error/index.jsx
@@ -28,9 +28,9 @@ const mapStateToProps = (state) => ({
   error: state.edit.error
 })
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = {
   resetErrorAction: resetError
-})
+}
 
 export default connect(
   mapStateToProps,


### PR DESCRIPTION
Fixes a bug introduced in the last PR, where actions were called, but not connected to the dispatch. 

By using a plain object for `mapDispatchToProps`, connect binds the dispatch and actions.

The function method could work, but not without wrapping the action in dispatch a la `saveArticleAction: () => dispatch(saveArticle())`. 
