### PR TITLE
@l2succes => Add article to store, don't use backbone article in sections

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -10,9 +10,10 @@ export const actions = keyMirror(
   'SAVE_ARTICLE'
 )
 
-export const changeSavedStatus = (isSaved) => ({
+export const changeSavedStatus = (article, isSaved) => ({
   type: actions.CHANGE_SAVED_STATUS,
   payload: {
+    article,
     isSaved,
     lastUpdated: new Date()
   }

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -12,11 +12,13 @@ describe('editActions', () => {
     article.save = jest.fn()
   })
 
-  it('#changeSavedStatus sets isSaved to arg', () => {
-    const changeSavedStatus = editActions.changeSavedStatus(true)
+  it('#changeSavedStatus updates article and sets isSaved to arg', () => {
+    article.set('title', 'Cool article')
+    const changeSavedStatus = editActions.changeSavedStatus(article.attributes, true)
 
     expect(changeSavedStatus.type).toBe('CHANGE_SAVED_STATUS')
     expect(changeSavedStatus.payload.isSaved).toBe(true)
+    expect(changeSavedStatus.payload.article.title).toBe('Cool article')
   })
 
   it('#changeSection sets activeSection to arg', () => {

--- a/client/apps/edit/client.js
+++ b/client/apps/edit/client.js
@@ -24,7 +24,9 @@ export function init () {
 
   const store = createReduxStore(reducers, initialState)
 
-  article.on('sync', () => store.dispatch(editActions.changeSavedStatus(true)))
+  article.on('sync', () => {
+    store.dispatch(editActions.changeSavedStatus(article.attributes, true))
+  })
 
   ReactDOM.render(
     <Provider store={store}>

--- a/client/apps/edit/components/content/section_container/index.jsx
+++ b/client/apps/edit/components/content/section_container/index.jsx
@@ -143,6 +143,7 @@ export class SectionContainer extends Component {
 }
 
 const mapStateToProps = (state) => ({
+  article: state.edit.article,
   channel: state.app.channel
 })
 

--- a/client/apps/edit/components/content/section_controls/index.jsx
+++ b/client/apps/edit/components/content/section_controls/index.jsx
@@ -167,6 +167,7 @@ export class SectionControls extends Component {
   }
 }
 const mapStateToProps = (state) => ({
+  article: state.edit.article,
   channel: state.app.channel
 })
 

--- a/client/apps/edit/components/content/section_list/index.jsx
+++ b/client/apps/edit/components/content/section_list/index.jsx
@@ -9,7 +9,6 @@ import DragContainer from 'client/components/drag_drop/index.coffee'
 export class SectionList extends Component {
   static propTypes = {
     activeSection: PropTypes.any,
-    article: PropTypes.object.isRequired,
     changeSectionAction: PropTypes.func,
     sections: PropTypes.object.isRequired
   }
@@ -46,7 +45,6 @@ export class SectionList extends Component {
   renderSectionList = () => {
     const {
       activeSection,
-      article,
       changeSectionAction,
       sections
     } = this.props
@@ -62,7 +60,6 @@ export class SectionList extends Component {
               isDraggable
               editing={activeSection === index}
               onSetEditing={(i) => changeSectionAction(i)}
-              article={article}
             />
             <SectionTool
               sections={sections}
@@ -77,7 +74,6 @@ export class SectionList extends Component {
 
   render () {
     const {
-      article,
       activeSection,
       sections
     } = this.props
@@ -97,7 +93,6 @@ export class SectionList extends Component {
               onDragEnd={this.onDragEnd}
               isDraggable={activeSection === null}
               layout='vertical'
-              article={article}
             >
               {this.renderSectionList()}
             </DragContainer>

--- a/client/apps/edit/components/content/section_list/test/index.test.jsx
+++ b/client/apps/edit/components/content/section_list/test/index.test.jsx
@@ -3,7 +3,7 @@ import configureStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
-import Article from 'client/models/article.coffee'
+import Sections from 'client/collections/sections.coffee'
 import DragContainer from 'client/components/drag_drop/index.coffee'
 import { SectionContainer } from '../../section_container'
 import { SectionTool } from '../../section_tool'
@@ -18,6 +18,9 @@ describe('SectionList', () => {
     const store = mockStore({
       app: {
         channel: {}
+      },
+      edit: {
+        article: Fixtures.StandardArticle
       }
     })
 
@@ -29,24 +32,23 @@ describe('SectionList', () => {
   }
 
   beforeEach(() => {
-    article = new Article(Fixtures.StandardArticle)
+    article = Fixtures.StandardArticle
 
     props = {
       activeSection: null,
-      article,
       changeSectionAction: jest.fn(),
-      sections: article.sections
+      sections: new Sections(article.sections)
     }
   })
 
   it('Renders the sections', () => {
     const component = getWrapper(props)
-    expect(component.find(SectionContainer).length).toBe(props.article.sections.length)
+    expect(component.find(SectionContainer).length).toBe(article.sections.length)
   })
 
   it('Renders the section tools', () => {
     const component = getWrapper(props)
-    expect(component.find(SectionTool).length).toBe(props.article.sections.length + 1)
+    expect(component.find(SectionTool).length).toBe(article.sections.length + 1)
   })
 
   it('Renders drag container more than 1 section', () => {
@@ -66,7 +68,7 @@ describe('SectionList', () => {
     const component = getWrapper(props)
 
     expect(component.find(DragContainer).exists()).toBe(false)
-    expect(component.find(SectionContainer).length).toBe(props.article.sections.length)
+    expect(component.find(SectionContainer).length).toBe(props.sections.length)
   })
 
   it('Listens for a new section and dispatches changeSection with index', () => {

--- a/client/apps/edit/components/content/sections/embed/index.jsx
+++ b/client/apps/edit/components/content/sections/embed/index.jsx
@@ -45,7 +45,7 @@ export class SectionEmbed extends Component {
       <section className='SectionEmbed'>
         {editing &&
           <EmbedControls
-            articleLayout={article.get('layout')}
+            articleLayout={article.layout}
             section={section}
           />
         }

--- a/client/apps/edit/components/content/sections/embed/test/controls.test.js
+++ b/client/apps/edit/components/content/sections/embed/test/controls.test.js
@@ -26,6 +26,9 @@ describe('EmbedControls', () => {
     const store = mockStore({
       app: {
         channel: {}
+      },
+      edit: {
+        article: StandardArticle
       }
     })
 

--- a/client/apps/edit/components/content/sections/embed/test/index.test.js
+++ b/client/apps/edit/components/content/sections/embed/test/index.test.js
@@ -3,7 +3,6 @@ import configureStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 import { Embed, Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
-import Article from '/client/models/article.coffee'
 import Section from '/client/models/section.coffee'
 import { SectionEmbed } from '../index'
 import { EmbedControls } from '../controls'
@@ -15,7 +14,7 @@ describe('Section Embed', () => {
 
   beforeEach(() => {
     props = {
-      article: new Article({layout: 'standard'}),
+      article: StandardArticle,
       section: new Section(StandardArticle.sections[10])
     }
   })
@@ -31,6 +30,9 @@ describe('Section Embed', () => {
     const store = mockStore({
       app: {
         channel: {}
+      },
+      edit: {
+        article: StandardArticle
       }
     })
 
@@ -41,34 +43,32 @@ describe('Section Embed', () => {
     )
   }
 
-  describe('Section Embed', () => {
-    it('Renders saved data', () => {
-      const component = getWrapper(props)
-      expect(component.find(Embed).exists()).toBe(true)
-    })
+  it('Renders saved data', () => {
+    const component = getWrapper(props)
+    expect(component.find(Embed).exists()).toBe(true)
+  })
 
-    it('Renders placeholder if empty', () => {
-      props.section = new Section()
-      const component = getWrapper(props)
+  it('Renders placeholder if empty', () => {
+    props.section = new Section()
+    const component = getWrapper(props)
 
-      expect(component.find(Embed).exists()).toBe(false)
-      expect(component.text()).toBe('Add URL above')
-    })
+    expect(component.find(Embed).exists()).toBe(false)
+    expect(component.text()).toBe('Add URL above')
+  })
 
-    it('Renders controls if editing', () => {
-      props.editing = true
-      const component = getConnectedWrapper(props)
+  it('Renders controls if editing', () => {
+    props.editing = true
+    const component = getConnectedWrapper(props)
 
-      expect(component.find(EmbedControls).exists()).toBe(true)
-    })
+    expect(component.find(EmbedControls).exists()).toBe(true)
+  })
 
-    it('Destroys section on unmount if URL is empty', () => {
-      props.section = new Section()
-      const spy = jest.spyOn(props.section, 'destroy')
-      const component = getWrapper(props)
+  it('Destroys section on unmount if URL is empty', () => {
+    props.section = new Section()
+    const spy = jest.spyOn(props.section, 'destroy')
+    const component = getWrapper(props)
 
-      component.instance().componentWillUnmount()
-      expect(spy).toHaveBeenCalled()
-    })
+    component.instance().componentWillUnmount()
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/client/apps/edit/components/content/sections/header/controls/test/controls.test.js
+++ b/client/apps/edit/components/content/sections/header/controls/test/controls.test.js
@@ -63,7 +63,10 @@ describe('Feature Header Controls', () => {
 
     const getWrapper = (props) => {
       const mockStore = configureStore([])
-      const store = mockStore({app: { channel: {} }})
+      const store = mockStore({
+        app: { channel: {} },
+        edit: { article: {} }
+      })
 
       return mount(
         <Provider store={store}>

--- a/client/apps/edit/components/content/sections/hero/index.jsx
+++ b/client/apps/edit/components/content/sections/hero/index.jsx
@@ -44,13 +44,12 @@ export class SectionHero extends Component {
   }
 
   render () {
-    const { article } = this.props
     const { editing, hero } = this.state
+
     return (
       <div className='edit-section--hero'>
         {hero && hero.keys().length
           ? <SectionContainer
-              article={article}
               section={hero}
               onSetEditing={this.onSetEditing}
               isHero

--- a/client/apps/edit/components/content/sections/hero/test/index.test.js
+++ b/client/apps/edit/components/content/sections/hero/test/index.test.js
@@ -18,6 +18,9 @@ describe('SectionHero', () => {
     const store = mockStore({
       app: {
         channel: {}
+      },
+      edit: {
+        article: {}
       }
     })
 

--- a/client/apps/edit/components/content/sections/images/index.jsx
+++ b/client/apps/edit/components/content/sections/images/index.jsx
@@ -60,7 +60,7 @@ export class SectionImages extends Component {
 
   getContainerSizes = () => {
     const { article, section } = this.props
-    const articleLayout = article.get('layout')
+    const articleLayout = article.layout
     const sectionLayout = section.get('layout')
 
     let containerSize = sectionLayout === 'column_width' ? 680 : 780
@@ -111,7 +111,7 @@ export class SectionImages extends Component {
   renderImages = (images) => {
     return images.map((image, index) => {
       const { article, editing, section } = this.props
-      const articleLayout = article.get('layout')
+      const articleLayout = article.layout
       const width = this.getImageWidth(index)
 
       const props = {
@@ -161,7 +161,7 @@ export class SectionImages extends Component {
         {editing &&
           <ImagesControls
             section={section}
-            articleLayout={article.get('layout')}
+            articleLayout={article.layout}
             editing={editing}
             images={images}
             isHero={isHero}
@@ -178,7 +178,7 @@ export class SectionImages extends Component {
           {images.length > 0
             ? section.get('type') === 'image_set' && !editing
               ? <ImageSet
-                  articleLayout={article.get('layout')}
+                  articleLayout={article.layout}
                   section={section}
                 />
 

--- a/client/apps/edit/components/content/sections/images/test/controls.test.js
+++ b/client/apps/edit/components/content/sections/images/test/controls.test.js
@@ -20,6 +20,9 @@ describe('ImagesControls', () => {
     const store = mockStore({
       app: {
         channel: { type: 'editorial' }
+      },
+      edit: {
+        article: StandardArticle
       }
     })
     return mount(

--- a/client/apps/edit/components/content/sections/images/test/index.test.js
+++ b/client/apps/edit/components/content/sections/images/test/index.test.js
@@ -19,12 +19,16 @@ require('typeahead.js')
 
 describe('SectionImageCollection', () => {
   let props
+  let article
 
   const getWrapper = (props) => {
     const mockStore = configureStore([])
     const store = mockStore({
       app: {
         channel: {}
+      },
+      edit: {
+        article
       }
     })
 
@@ -48,7 +52,7 @@ describe('SectionImageCollection', () => {
 
   beforeEach(() => {
     props = {
-      article: new Article({layout: 'standard'}),
+      article: {layout: 'standard'},
       editing: false,
       isHero: false,
       section: new Section(imageSection)
@@ -71,7 +75,7 @@ describe('SectionImageCollection', () => {
     })
 
     it('Renders a preview for classic image_set', () => {
-      props.article.set('layout', 'classic')
+      props.article.layout = 'classic'
       props.section = new Section(imageSetSection)
       const component = getWrapper(props)
 
@@ -151,7 +155,7 @@ describe('SectionImageCollection', () => {
       })
 
       it('#getContainerSizes returns sizes for overflow section in classic articles', () => {
-        props.article.set('layout', 'classic')
+        props.article.layout = 'classic'
         const component = getShallowWrapper(props)
         const sizes = component.instance().getContainerSizes()
 
@@ -160,7 +164,7 @@ describe('SectionImageCollection', () => {
       })
 
       it('#getContainerSizes returns sizes for column section in classic articles', () => {
-        props.article.set('layout', 'classic')
+        props.article.layout = 'classic'
         props.section.set('layout', 'column_width')
         const component = getShallowWrapper(props)
         const sizes = component.instance().getContainerSizes()
@@ -178,7 +182,7 @@ describe('SectionImageCollection', () => {
       })
 
       it('#getContainerSizes returns correct sizes for large image_sets in classic articles', () => {
-        props.article.set('layout', 'classic')
+        props.article.layout = 'classic'
         props.section = new Section(largeImageSetSection)
         const component = getShallowWrapper(props)
         const sizes = component.instance().getContainerSizes()

--- a/client/apps/edit/components/content/sections/text/index.coffee
+++ b/client/apps/edit/components/content/sections/text/index.coffee
@@ -36,7 +36,7 @@ module.exports = React.createClass
   getInitialState: ->
     editorState: EditorState.createEmpty(
       new CompositeDecorator(
-        Config.decorators(@props.article.get('layout'))
+        Config.decorators(@props.article.layout)
       )
     )
     focus: false
@@ -56,10 +56,10 @@ module.exports = React.createClass
 
   editorStateFromProps: ->
     html = standardizeSpacing @props.section.get('body')
-    unless @props.article.get('layout') is 'classic'
+    unless @props.article.layout is 'classic'
       html = setContentEnd(html, @props.isContentEnd)
     blocksFromHTML = convertFromRichHtml html
-    editorState = EditorState.createWithContent(blocksFromHTML, new CompositeDecorator(Config.decorators(@props.article.get('layout'))))
+    editorState = EditorState.createWithContent(blocksFromHTML, new CompositeDecorator(Config.decorators(@props.article.layout)))
     editorState = setSelectionToStart(editorState) if @props.editing
     @setState
       html: html
@@ -67,7 +67,7 @@ module.exports = React.createClass
 
   componentDidUpdate: (prevProps) ->
     if @props.isContentEnd isnt prevProps.isContentEnd
-      unless @props.article.get('layout') is 'classic'
+      unless @props.article.layout is 'classic'
         html = setContentEnd(@props.section.get('body'), @props.isContentEnd)
       @props.section.set('body', html)
     if @props.editing and @props.editing isnt prevProps.editing
@@ -76,7 +76,7 @@ module.exports = React.createClass
       @refs.editor.blur()
 
   onChange: (editorState) ->
-    html = convertToRichHtml editorState, @props.article.get('layout')
+    html = convertToRichHtml editorState, @props.article.layout
     @setState editorState: editorState, html: html
     @props.section.set('body', html)
 
@@ -180,7 +180,7 @@ module.exports = React.createClass
       @onChange EditorState.push(editorState, newState, null)
 
   availableBlocks: ->
-    blockMap = Config.blockRenderMap(@props.article.get('layout'), @props.hasFeatures)
+    blockMap = Config.blockRenderMap(@props.article.layout, @props.hasFeatures)
     available = Object.keys(blockMap.toObject())
     return Array.from(available)
 
@@ -192,7 +192,7 @@ module.exports = React.createClass
     else if e is 'backspace'
       @handleBackspace e
     else if e in ['italic', 'bold']
-      if @props.article.get('layout') is 'classic' and
+      if @props.article.layout is 'classic' and
       getSelectionDetails(@state.editorState).anchorType is 'header-three'
         return 'handled'
       newState = RichUtils.handleKeyCommand @state.editorState, e
@@ -232,7 +232,7 @@ module.exports = React.createClass
 
   toggleInlineStyle: (inlineStyle) ->
     selection = getSelectionDetails(@state.editorState)
-    if selection.anchorType is 'header-three' and @props.article.get('layout') is 'classic'
+    if selection.anchorType is 'header-three' and @props.article.layout is 'classic'
       block = @state.editorState.getCurrentContent().getBlockForKey(selection.anchorKey)
       stripCharacterStyles block
     else
@@ -296,16 +296,16 @@ module.exports = React.createClass
       'data-editing': @props.editing
     },
       Text {
-        layout: @props.article.get 'layout'
+        layout: @props.article.layout
         isContentStart: showDropCaps
       },
         if @state.showMenu
           React.createElement(
             TextNav, {
               hasFeatures: @props.hasFeatures
-              blocks: Config.blockTypes @props.article.get('layout'), @props.hasFeatures
+              blocks: Config.blockTypes @props.article.layout, @props.hasFeatures
               toggleBlock: @toggleBlockType
-              styles: Config.inlineStyles @props.article.get('layout'), @props.hasFeatures
+              styles: Config.inlineStyles @props.article.layout, @props.hasFeatures
               toggleStyle: @toggleInlineStyle
               promptForLink: @promptForLink
               makePlainText: @makePlainText
@@ -326,7 +326,7 @@ module.exports = React.createClass
             handleKeyCommand: @handleKeyCommand
             keyBindingFn: keyBindingFnFull
             handlePastedText: @onPaste
-            blockRenderMap: Config.blockRenderMap @props.article.get('layout'), @props.hasFeatures
+            blockRenderMap: Config.blockRenderMap @props.article.layout, @props.hasFeatures
             handleReturn: @handleReturn
             onTab: @handleTab
             onLeftArrow: @handleChangeSection

--- a/client/apps/edit/components/content/sections/text/test/index.test.coffee
+++ b/client/apps/edit/components/content/sections/text/test/index.test.coffee
@@ -65,7 +65,7 @@ describe 'Section Text', ->
           type: 'text'
         }
       ]
-      article = new Backbone.Model {layout: 'classic'}
+      article = {layout: 'classic'}
 
       @props = {
         editing: false
@@ -140,7 +140,7 @@ describe 'Section Text', ->
   describe '#availableBlocks', ->
 
     it 'Returns the correct blocks for a feature article', ->
-      @shortComponent.props.article.set 'layout', 'feature'
+      @shortComponent.props.article.layout = 'feature'
       availableBlocks = @shortComponent.availableBlocks()
       availableBlocks.should.eql [
         'header-one',
@@ -153,7 +153,7 @@ describe 'Section Text', ->
       ]
 
     it 'Returns the correct blocks for a standard article', ->
-      @shortComponent.props.article.set 'layout', 'standard'
+      @shortComponent.props.article.layout = 'standard'
       availableBlocks = @shortComponent.availableBlocks()
       availableBlocks.should.eql [
         'header-two',
@@ -190,12 +190,12 @@ describe 'Section Text', ->
   describe 'Editorial Features', ->
 
     it 'Adds end-marker to a feature article', ->
-      @altProps.article.set 'layout', 'feature'
+      @altProps.article.layout = 'feature'
       component = ReactDOM.render React.createElement(@SectionText, @altProps), (@$el = $ "<div></div>")[0]
       component.state.html.should.containEql '<span class="content-end"> </span>'
 
     it 'Adds end-marker to a standard article', ->
-      @altProps.article.set 'layout', 'standard'
+      @altProps.article.layout = 'standard'
       component = ReactDOM.render React.createElement(@SectionText, @altProps), (@$el = $ "<div></div>")[0]
       component.state.html.should.containEql '<span class="content-end"> </span>'
 
@@ -214,7 +214,7 @@ describe 'Section Text', ->
       @shortComponent.setState.args[0][0].html.should.eql '<h2><strong>A <em>short</em> piece of text</strong></h2>'
 
     it 'Can create strikethrough entities', ->
-      @shortComponent.props.article.set 'layout', 'standard'
+      @shortComponent.props.article.layout = 'standard'
       @shortComponent.render()
       r.simulate.mouseUp r.find @shortComponent, 'edit-section--text__input'
       @shortComponent.setState = sinon.stub()
@@ -222,7 +222,7 @@ describe 'Section Text', ->
       @shortComponent.setState.args[0][0].html.should.eql '<h2><span style="text-decoration:line-through">A <em>short</em> piece of <strong>text</strong></span></h2>'
 
     it 'Can toggle h1 block changes (feature)', ->
-      @shortComponent.props.article.set 'layout', 'feature'
+      @shortComponent.props.article.layout = 'feature'
       @shortComponent.render()
       r.simulate.mouseUp r.find @shortComponent, 'edit-section--text__input'
       @shortComponent.setState = sinon.stub()
@@ -242,7 +242,7 @@ describe 'Section Text', ->
       @shortComponent.setState.args[0][0].html.should.eql '<h3>A short piece of text</h3>'
 
     it 'Can toggle h3 block changes without stripping styles (standard/feature)', ->
-      @shortComponent.props.article.set 'layout', 'standard'
+      @shortComponent.props.article.layout = 'standard'
       @shortComponent.render()
       r.simulate.mouseUp r.find @shortComponent, 'edit-section--text__input'
       @shortComponent.setState = sinon.stub()
@@ -292,7 +292,7 @@ describe 'Section Text', ->
       @shortComponent.setState.args[0][0].html.should.eql '<h2><span style="text-decoration:line-through">A <em>short</em> piece of <strong>text</strong></span></h2>'
 
     it 'Can toggle H1 entities (feature)', ->
-      @shortComponent.props.article.set 'layout', 'feature'
+      @shortComponent.props.article.layout = 'feature'
       @shortComponent.render()
       @shortComponent.setState = sinon.stub()
       @shortComponent.handleKeyCommand('header-one')

--- a/client/apps/edit/components/content/sections/video/controls.jsx
+++ b/client/apps/edit/components/content/sections/video/controls.jsx
@@ -68,8 +68,8 @@ export class Controls extends Component {
         section={section}
         isHero={isHero}
         sectionLayouts={sectionLayouts}
-        articleLayout={articleLayout}>
-
+        articleLayout={articleLayout}
+      >
         <h2>Video</h2>
         <input
           className='bordered-input bordered-input-dark'

--- a/client/apps/edit/components/content/sections/video/index.jsx
+++ b/client/apps/edit/components/content/sections/video/index.jsx
@@ -48,11 +48,10 @@ export class SectionVideo extends Component {
 
       return (
         <Controls
-          article={article}
           section={section}
           isHero={isHero}
           sectionLayouts={showSectionLayouts}
-          articleLayout={article.get('layout')}
+          articleLayout={article.layout}
           onProgress={this.onProgress}
         />
       )
@@ -82,7 +81,7 @@ export class SectionVideo extends Component {
     if (hasUrl) {
       return (
         <Video
-          layout={article.get('layout')}
+          layout={article.layout}
           section={section.attributes}
         >
           {editing && this.renderRemoveButton()}
@@ -92,7 +91,7 @@ export class SectionVideo extends Component {
             html={section.get('caption')}
             onChange={(html) => section.set('caption', html)}
             stripLinebreaks
-            layout={article.get('layout')}
+            layout={article.layout}
           />
         </Video>
       )

--- a/client/apps/edit/components/content/sections/video/test/index.test.js
+++ b/client/apps/edit/components/content/sections/video/test/index.test.js
@@ -12,9 +12,11 @@ describe('Video', () => {
     const mockStore = configureStore([])
     const store = mockStore({
       app: {
-        channel: {hasFeature: jest.fn().mockReturnThis()}
+        channel: {}
       },
-      edit: { lastUpdated: new Date() }
+      edit: {
+        lastUpdated: new Date()
+      }
     })
     return mount(
       <Provider store={store}>
@@ -31,7 +33,7 @@ describe('Video', () => {
         cover_image_url: 'http://image.jpg',
         caption: 'A video caption.'
       }),
-      article: new Backbone.Model({layout: 'standard'})
+      article: {layout: 'standard'}
     }
   })
 
@@ -70,7 +72,7 @@ describe('Video', () => {
 
   it('renders fullscreen controls if article is feature', () => {
     props.editing = true
-    props.article.set('layout', 'feature')
+    props.article.layout = 'feature'
     const component = getWrapper(props)
 
     expect(component.find('a.layout').length).toEqual(3)

--- a/client/apps/edit/components/content/test/index.test.js
+++ b/client/apps/edit/components/content/test/index.test.js
@@ -19,7 +19,10 @@ describe('EditContent', () => {
       app: {
         channel: {hasFeature: jest.fn().mockReturnThis()}
       },
-      edit: { lastUpdated: new Date() }
+      edit: {
+        article: Fixtures.StandardArticle,
+        lastUpdated: new Date()
+      }
     })
     return mount(
       <Provider store={store}>

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -55,11 +55,10 @@ class EditContainer extends Component {
     } = this.props
 
     if (article.get('published')) {
-      changeSavedStatusAction(false)
+      changeSavedStatusAction(article.attributes, false)
     } else {
       saveArticleAction(article)
     }
-    this.setState({ lastUpdated: new Date() })
   }
 
   getActiveView = () => {
@@ -102,7 +101,8 @@ class EditContainer extends Component {
 const mapStateToProps = (state) => ({
   activeView: state.edit.activeView,
   channel: state.app.channel,
-  error: state.edit.error
+  error: state.edit.error,
+  lastUpdated: state.edit.lastUpdated
 })
 
 const mapDispatchToProps = {

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -25,8 +25,10 @@ export const initialState = {
 export function editReducer (state = initialState, action) {
   switch (action.type) {
     case actions.CHANGE_SAVED_STATUS: {
+      const article = extend(state.article, action.payload.article)
+
       return u({
-        article: action.payload.article,
+        article,
         isSaving: false,
         isSaved: action.payload.isSaved,
         lastUpdated: action.payload.lastUpdated

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -1,7 +1,17 @@
 import u from 'updeep'
+import { data as sd } from 'sharify'
+import { extend, pick } from 'lodash'
 import { actions } from 'client/actions/editActions'
 
+const setupArticle = () => {
+  const article = sd.ARTICLE
+  const author = pick(article.author, 'id', 'name')
+
+  return extend(article, { author })
+}
+
 export const initialState = {
+  article: setupArticle(),
   activeSection: null,
   activeView: 'content',
   error: null,

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -26,6 +26,7 @@ export function editReducer (state = initialState, action) {
   switch (action.type) {
     case actions.CHANGE_SAVED_STATUS: {
       return u({
+        article: action.payload.article,
         isSaving: false,
         isSaved: action.payload.isSaved,
         lastUpdated: action.payload.lastUpdated

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -1,0 +1,20 @@
+import { editReducer } from '../editReducer'
+import {
+  FeatureArticle
+} from '@artsy/reaction-force/dist/Components/Publishing/Fixtures/Articles'
+
+describe('editReducer', () => {
+  it('should return the initial state', () => {
+    const initialState = editReducer(undefined, {})
+
+    expect(initialState.article).toBe(FeatureArticle)
+    expect(initialState.activeSection).toBe(null)
+    expect(initialState.activeView).toBe('content')
+    expect(initialState.error).toBe(null)
+    expect(initialState.isDeleting).toBe(false)
+    expect(initialState.isPublishing).toBe(false)
+    expect(initialState.isSaving).toBe(false)
+    expect(initialState.isSaved).toBe(true)
+    expect(initialState.lastUpdated).toBe(null)
+  })
+})

--- a/test/jest-setup.js
+++ b/test/jest-setup.js
@@ -5,6 +5,8 @@ import Enzyme from 'enzyme'
 import React from 'react'
 import DOM from 'react-dom-factories'
 import createClass from 'create-react-class'
+import sd from 'sharify'
+import { FeatureArticle } from '@artsy/reaction-force/dist/Components/Publishing/Fixtures/Articles'
 
 // Patch React 16 with deprecated helpers
 React.DOM = DOM
@@ -24,4 +26,10 @@ window.matchMedia = window.matchMedia || function () {
     addListener: function () {},
     removeListener: function () {}
   }
+}
+
+sd.data = {
+  ARTICLE: FeatureArticle,
+  CHANNEL: {},
+  USER: {}
 }


### PR DESCRIPTION
Small steps towards eliminating backbone methods `get` and `set`...

- Adds article to store as plain object at `store.edit.article`
- Passes article attributes to `changeSavedStatus` action to keep store and backbone article in sync
- Use `store.edit.article` in section components rather `get`-ing attributes from backbone model
- Adds `sd` to jest config
- Adds a test to confirm article is setup correctly in the `editReducer`'s initial state