### PR TITLE
@kanaabe => [Minor] Fix column image alignment

### DIFF
--- a/client/apps/edit/components/content/sections/images/index.styl
+++ b/client/apps/edit/components/content/sections/images/index.styl
@@ -109,10 +109,12 @@
       z-index 2 !important
 
 .SectionContainer[data-layout=column_width]
+  .SectionImages__list,
   .SectionImages__list .drag-container
     flex-direction column
   .EditImage
     width 100%
+    margin-right 0
 
 [data-layout='standard']
   .SectionContainer[data-type=image_set][data-editing=true]


### PR DESCRIPTION
Fixes css bug that caused `column_width` image sections to display images inline. 