### PR TITLE
@kanaabe => Strip unicode spaces

### DIFF
--- a/client/apps/edit/components/content/sections/text/index.coffee
+++ b/client/apps/edit/components/content/sections/text/index.coffee
@@ -156,6 +156,7 @@ module.exports = React.createClass
     { editorState } = @state
     unless html
       html = '<div>' + text + '</div>'
+    html = standardizeSpacing(html)
     html = stripGoogleStyles(html)
     blocksFromHTML = convertFromRichHtml html
     convertedHtml = blocksFromHTML.getBlocksAsArray().map (contentBlock) =>

--- a/client/apps/edit/components/content/sections/text/index.coffee
+++ b/client/apps/edit/components/content/sections/text/index.coffee
@@ -156,7 +156,6 @@ module.exports = React.createClass
     { editorState } = @state
     unless html
       html = '<div>' + text + '</div>'
-    html = standardizeSpacing(html)
     html = stripGoogleStyles(html)
     blocksFromHTML = convertFromRichHtml html
     convertedHtml = blocksFromHTML.getBlocksAsArray().map (contentBlock) =>

--- a/client/apps/edit/components/content/sections/text/test/index.test.coffee
+++ b/client/apps/edit/components/content/sections/text/test/index.test.coffee
@@ -366,7 +366,7 @@ describe 'Section Text', ->
       component = ReactDOM.render React.createElement(@SectionText, @props), (@$el = $ "<div></div>")[0]
       $(ReactDOM.findDOMNode(component)).find('.edit-section--text__input').text().should.containEql 'Erin & Shirreff'
       $(ReactDOM.findDOMNode(component)).find('.edit-section--text__input').html().should.containEql 'Erin &amp; Shirreff'
-      component.state.html.should.containEql 'Erin & Shirreff'
+      component.state.html.should.containEql 'Erin &amp; Shirreff'
 
   describe 'Artist plugin', ->
 

--- a/client/apps/edit/components/content/sections/text/test/index.test.coffee
+++ b/client/apps/edit/components/content/sections/text/test/index.test.coffee
@@ -585,3 +585,9 @@ describe 'Section Text', ->
       @component.setState = sinon.stub()
       @component.onPaste('<b style="font-weight:normal;" id="docs-internal-guid-ce2bb19a-cddb-9e53-cb18-18e71847df4e"><p><span style="font-size:11pt;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre-wrap;">Available at: Espacio Valverde • Galleries Sector, Booth 9F01</span></p>')
       @component.setState.args[0][0].html.should.containEql '<h2>Available at: Espacio Valverde • Galleries Sector, Booth 9F0101 &nbsp;'
+
+    it 'calls standardizeSpacing', ->
+      @SectionText.__set__ 'standardizeSpacing', standardizeSpacing = sinon.stub().returns('<p>hello</p><p>here again.</p>')
+      component = ReactDOM.render React.createElement(@SectionText, @artistProps), (@$el = $ "<div></div>")[0]
+      component.onPaste('hello here again.', '<p>hello</p><p>here again.</p>')
+      standardizeSpacing.called.should.eql true

--- a/client/apps/edit/components/content/sections/text/test/index.test.coffee
+++ b/client/apps/edit/components/content/sections/text/test/index.test.coffee
@@ -366,7 +366,7 @@ describe 'Section Text', ->
       component = ReactDOM.render React.createElement(@SectionText, @props), (@$el = $ "<div></div>")[0]
       $(ReactDOM.findDOMNode(component)).find('.edit-section--text__input').text().should.containEql 'Erin & Shirreff'
       $(ReactDOM.findDOMNode(component)).find('.edit-section--text__input').html().should.containEql 'Erin &amp; Shirreff'
-      component.state.html.should.containEql 'Erin &amp; Shirreff'
+      component.state.html.should.containEql 'Erin & Shirreff'
 
   describe 'Artist plugin', ->
 

--- a/client/components/rich_text/test/components/paragraph.test.coffee
+++ b/client/components/rich_text/test/components/paragraph.test.coffee
@@ -233,7 +233,9 @@ describe 'Rich Text: Paragraph', ->
       @component.onPaste('hello here again.', '<p>hello</p><p>here again.</p>')
       @stripGoogleStyles.called.should.eql true
 
-    xit 'calls standardizeSpacing', ->
-      @component.onChange = sinon.stub()
-      @component.onPaste('hello here again.', '<p>hello</p><p>here again.</p>')
-      @component.standardizeSpacing.called.should.eql true
+    it 'calls standardizeSpacing', ->
+      @Paragraph.__set__ 'standardizeSpacing', standardizeSpacing = sinon.stub().returns('<p>hello</p><p>here again.</p>')
+      component = ReactDOM.render React.createElement(@Paragraph, @props), (@$el = $ "<div></div>")[0]
+      component.onChange = sinon.stub()
+      component.onPaste('hello here again.', '<p>hello</p><p>here again.</p>')
+      standardizeSpacing.called.should.eql true

--- a/client/components/rich_text/test/utils/text_stripping.test.js
+++ b/client/components/rich_text/test/utils/text_stripping.test.js
@@ -1,4 +1,5 @@
 import {
+  replaceUnicodeSpaces,
   standardizeSpacing,
   stripGoogleStyles,
   stripH3Tags
@@ -14,6 +15,11 @@ describe('Draft Utils: Text Stripping', () => {
     it('Removes empty spans', () => {
       const html = standardizeSpacing('<span></span>')
       expect(html).toBe('')
+    })
+
+    it('Can replace unicode spaces', () => {
+      const html = standardizeSpacing('<p>\u2028hello</p>')
+      expect(html).toBe('<p><br></p><p>hello</p>')
     })
 
     it('Replaces consecutive empty paragraphs with one', () => {
@@ -34,6 +40,13 @@ describe('Draft Utils: Text Stripping', () => {
     it('Converts consecutive spaces into nbsp', () => {
       const html = standardizeSpacing('<p>   </p>')
       expect(html).toBe('<p> &nbsp; </p>')
+    })
+  })
+
+  describe('#replaceUnicodeSpaces', () => {
+    it('Replaces unicode linebreaks with and empty paragraph', () => {
+      const html = replaceUnicodeSpaces('<p>\u2028hello\u2029</p>')
+      expect(html).toBe('<p></p><p>hello</p><p></p>')
     })
   })
 

--- a/client/components/rich_text/test/utils/text_stripping.test.js
+++ b/client/components/rich_text/test/utils/text_stripping.test.js
@@ -17,11 +17,6 @@ describe('Draft Utils: Text Stripping', () => {
       expect(html).toBe('')
     })
 
-    it('Can replace unicode spaces', () => {
-      const html = standardizeSpacing('<p>\u2028hello</p>')
-      expect(html).toBe('<p><br></p><p>hello</p>')
-    })
-
     it('Replaces consecutive empty paragraphs with one', () => {
       const html = standardizeSpacing('<p></p><p></p>')
       expect(html).toBe('<p><br></p>')
@@ -81,6 +76,11 @@ describe('Draft Utils: Text Stripping', () => {
       expect(stripGoogleStyles(googleHtmlLong)).toBe(
         '<p><span><strong>Available at: Espacio Valverde • Galleries Sector, Booth 9F01</strong></span></p>'
       )
+    })
+
+    it('Can replace unicode spaces', () => {
+      const html = stripGoogleStyles('<p>\u2028hello</p>')
+      expect(html).toBe('<p></p><p>hello</p>')
     })
 
     it('Replaces italic spans with <em> tags', () => {

--- a/client/components/rich_text/utils/text_stripping.js
+++ b/client/components/rich_text/utils/text_stripping.js
@@ -1,5 +1,7 @@
 export const standardizeSpacing = (html) => {
-  html = html
+  const noUnicode = replaceUnicodeSpaces(html)
+
+  const newHtml = noUnicode
     .replace(/<br>/g, '')
     .replace(/<span><\/span>/g, '')
     .replace(/<h2><\/h2>/g, '<p><br></p>')
@@ -9,8 +11,23 @@ export const standardizeSpacing = (html) => {
     .replace(/<p> <\/p>/g, '<p><br></p>')
     .replace(/<p><br><\/p><p><br><\/p>/g, '<p><br></p>')
     .replace(/  /g, ' &nbsp;')
-    .replace(/[\u{2028}-\u{2028}]/gu, '') // remove unicode spaces
-  return html
+
+  return newHtml
+}
+
+export const replaceUnicodeSpaces = (html) => {
+  // Replace unicode linebreaks with html breaks
+  const doc = document.createElement('div')
+  doc.innerHTML = html
+  const ps = doc.getElementsByTagName('p')
+
+  for (let i = 0; i < ps.length; i++) {
+    const innerP = doc.getElementsByTagName('p')[i].innerHTML
+      .replace(/[\u{2028}-\u{2029}]/gu, '</p><p>')
+    const newP = `<p>${innerP}</p>`
+    $(doc.getElementsByTagName('p')[i]).replaceWith(newP)
+  }
+  return doc.innerHTML
 }
 
 export const stripCharacterStyles = (contentBlock, keepAllowed) => {

--- a/client/components/rich_text/utils/text_stripping.js
+++ b/client/components/rich_text/utils/text_stripping.js
@@ -9,6 +9,7 @@ export const standardizeSpacing = (html) => {
     .replace(/<p> <\/p>/g, '<p><br></p>')
     .replace(/<p><br><\/p><p><br><\/p>/g, '<p><br></p>')
     .replace(/  /g, ' &nbsp;')
+    .replace(/[\u{2028}-\u{2028}]/gu, '') // remove unicode spaces
   return html
 }
 

--- a/client/components/rich_text/utils/text_stripping.js
+++ b/client/components/rich_text/utils/text_stripping.js
@@ -1,7 +1,5 @@
 export const standardizeSpacing = (html) => {
-  const noUnicode = replaceUnicodeSpaces(html)
-
-  const newHtml = noUnicode
+  const newHtml = html
     .replace(/<br>/g, '')
     .replace(/<span><\/span>/g, '')
     .replace(/<h2><\/h2>/g, '<p><br></p>')
@@ -117,6 +115,9 @@ export const stripGoogleStyles = (html) => {
 
   // 3. Replace bold/italic spans with actual strong/em tags
   strippedHtml = replaceGoogleFalseTags(strippedHtml)
+
+  // 4. Replace illegally pasted unicode spaces
+  strippedHtml = replaceUnicodeSpaces(strippedHtml)
 
   return strippedHtml
 }


### PR DESCRIPTION
Json stringify seems to have issues with unicode spaces 2028 and 2029.
 (https://stackoverflow.com/questions/16686687/json-stringify-and-u2028-u2029-check)

This adds a check specifically for those characters and removes them on paste.

Related to https://github.com/artsy/positron/issues/1403