### PR TITLE
@l2succes => Section Actions

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -7,6 +7,7 @@ export const actions = keyMirror(
   'EDIT_SECTION',
   'ERROR',
   'NEW_SECTION',
+  'ON_CHANGE_SECTION',
   'PUBLISH_ARTICLE',
   'REMOVE_SECTION',
   'SAVE_ARTICLE'
@@ -60,6 +61,16 @@ export const newSection = (type, sectionIndex) => {
     payload: {
       section,
       sectionIndex
+    }
+  }
+}
+
+export const onChangeSection = (key, value) => {
+  return {
+    type: actions.ON_CHANGE_SECTION,
+    payload: {
+      key,
+      value
     }
   }
 }

--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -8,6 +8,7 @@ export const actions = keyMirror(
   'ERROR',
   'NEW_SECTION',
   'PUBLISH_ARTICLE',
+  'REMOVE_SECTION',
   'SAVE_ARTICLE'
 )
 
@@ -75,6 +76,13 @@ export const publishArticle = (article, published) => {
     }
   }
 }
+
+export const removeSection = (sectionIndex) => ({
+  type: actions.REMOVE_SECTION,
+  payload: {
+    sectionIndex
+  }
+})
 
 export const saveArticle = (article) => {
   article.save()

--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -4,13 +4,13 @@ export const actions = keyMirror(
   'CHANGE_SAVED_STATUS',
   'CHANGE_VIEW',
   'DELETE_ARTICLE',
-  'EDIT_SECTION',
   'ERROR',
   'NEW_SECTION',
   'ON_CHANGE_SECTION',
   'PUBLISH_ARTICLE',
   'REMOVE_SECTION',
-  'SAVE_ARTICLE'
+  'SAVE_ARTICLE',
+  'SET_SECTION'
 )
 
 export const changeSavedStatus = (article, isSaved) => ({
@@ -45,9 +45,9 @@ export const deleteArticle = (article) => {
   }
 }
 
-export const editSection = (sectionIndex) => ({
+export const setSection = (sectionIndex) => ({
   // Index of article section currently editing
-  type: actions.EDIT_SECTION,
+  type: actions.SET_SECTION,
   payload: {
     sectionIndex
   }

--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -43,21 +43,22 @@ export const deleteArticle = (article) => {
   }
 }
 
-export const editSection = (activeSection) => ({
-  // Index of active article section
+export const editSection = (sectionIndex) => ({
+  // Index of article section currently editing
   type: actions.EDIT_SECTION,
   payload: {
-    activeSection
+    sectionIndex
   }
 })
 
-export const newSection = (type) => {
+export const newSection = (type, sectionIndex) => {
   const section = setupSection(type)
 
   return {
     type: actions.NEW_SECTION,
     payload: {
-      section
+      section,
+      sectionIndex
     }
   }
 }
@@ -101,7 +102,7 @@ export const resetError = () => ({
   }
 })
 
-// UTILS
+// ACTION UTILS
 export function setupSection (type) {
   // set initial state of new section
   switch (type) {

--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -2,10 +2,11 @@ import keyMirror from 'client/lib/keyMirror'
 
 export const actions = keyMirror(
   'CHANGE_SAVED_STATUS',
-  'CHANGE_SECTION',
   'CHANGE_VIEW',
   'DELETE_ARTICLE',
+  'EDIT_SECTION',
   'ERROR',
+  'NEW_SECTION',
   'PUBLISH_ARTICLE',
   'SAVE_ARTICLE'
 )
@@ -16,14 +17,6 @@ export const changeSavedStatus = (article, isSaved) => ({
     article,
     isSaved,
     lastUpdated: new Date()
-  }
-})
-
-export const changeSection = (activeSection) => ({
-  // Index of active article section
-  type: actions.CHANGE_SECTION,
-  payload: {
-    activeSection
   }
 })
 
@@ -46,6 +39,25 @@ export const deleteArticle = (article) => {
     type: actions.DELETE_ARTICLE,
     payload: {
       isDeleting: true
+    }
+  }
+}
+
+export const editSection = (activeSection) => ({
+  // Index of active article section
+  type: actions.EDIT_SECTION,
+  payload: {
+    activeSection
+  }
+})
+
+export const newSection = (type) => {
+  const section = setupSection(type)
+
+  return {
+    type: actions.NEW_SECTION,
+    payload: {
+      section
     }
   }
 }
@@ -88,3 +100,34 @@ export const resetError = () => ({
     error: null
   }
 })
+
+// UTILS
+export function setupSection (type) {
+  // set initial state of new section
+  switch (type) {
+    case 'video':
+      return {
+        type: 'video',
+        url: '',
+        layout: 'column_width'
+      }
+    case 'image_collection':
+      return {
+        type: 'image_collection',
+        layout: 'overflow_fillwidth',
+        images: []
+      }
+    case 'embed':
+      return {
+        type: 'embed',
+        url: '',
+        layout: 'column_width',
+        height: ''
+      }
+    case 'text':
+      return {
+        type: 'text',
+        body: ''
+      }
+  }
+}

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -21,11 +21,11 @@ describe('editActions', () => {
     expect(changeSavedStatus.payload.article.title).toBe('Cool article')
   })
 
-  it('#changeSection sets activeSection to arg', () => {
-    const changeSection = editActions.changeSection(6)
+  it('#editSection sets activeSection to index and sets state.section', () => {
+    const editSection = editActions.editSection(6)
 
-    expect(changeSection.type).toBe('CHANGE_SECTION')
-    expect(changeSection.payload.activeSection).toBe(6)
+    expect(editSection.type).toBe('EDIT_SECTION')
+    expect(editSection.payload.activeSection).toBe(6)
   })
 
   it('#changeView sets the activeView to arg', () => {
@@ -57,6 +57,48 @@ describe('editActions', () => {
     expect(saveArticle.type).toBe('SAVE_ARTICLE')
     expect(saveArticle.payload.isSaving).toBe(true)
     expect(article.save.mock.calls.length).toBe(1)
+  })
+
+  describe('#newSection', () => {
+    it('Can create an embed section', () => {
+      const newSection = editActions.newSection('embed')
+      const { section } = newSection.payload
+
+      expect(newSection.type).toBe('NEW_SECTION')
+      expect(section.type).toBe('embed')
+      expect(section.url).toBe('')
+      expect(section.layout).toBe('column_width')
+      expect(section.height).toBe('')
+    })
+
+    it('Can create an image_collection section', () => {
+      const newSection = editActions.newSection('image_collection')
+      const { section } = newSection.payload
+
+      expect(newSection.type).toBe('NEW_SECTION')
+      expect(section.type).toBe('image_collection')
+      expect(section.images.length).toBe(0)
+      expect(section.layout).toBe('overflow_fillwidth')
+    })
+
+    it('Can create a text section', () => {
+      const newSection = editActions.newSection('text')
+      const { section } = newSection.payload
+
+      expect(newSection.type).toBe('NEW_SECTION')
+      expect(section.type).toBe('text')
+      expect(section.body).toBe('')
+    })
+
+    it('Can create a video section', () => {
+      const newSection = editActions.newSection('video')
+      const { section } = newSection.payload
+
+      expect(newSection.type).toBe('NEW_SECTION')
+      expect(section.type).toBe('video')
+      expect(section.url).toBe('')
+      expect(section.layout).toBe('column_width')
+    })
   })
 
   describe('Editing errors', () => {

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -21,7 +21,7 @@ describe('editActions', () => {
     expect(changeSavedStatus.payload.article.title).toBe('Cool article')
   })
 
-  it('#editSection sets sectionIndex to index and sets state.section', () => {
+  it('#editSection sets sectionIndex to index', () => {
     const editSection = editActions.editSection(6)
 
     expect(editSection.type).toBe('EDIT_SECTION')
@@ -99,6 +99,13 @@ describe('editActions', () => {
       expect(section.url).toBe('')
       expect(section.layout).toBe('column_width')
     })
+  })
+
+  it('#removeSection sets sectionIndex to index', () => {
+    const editSection = editActions.removeSection(6)
+
+    expect(editSection.type).toBe('REMOVE_SECTION')
+    expect(editSection.payload.sectionIndex).toBe(6)
   })
 
   describe('Editing errors', () => {

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -21,11 +21,11 @@ describe('editActions', () => {
     expect(changeSavedStatus.payload.article.title).toBe('Cool article')
   })
 
-  it('#editSection sets activeSection to index and sets state.section', () => {
+  it('#editSection sets sectionIndex to index and sets state.section', () => {
     const editSection = editActions.editSection(6)
 
     expect(editSection.type).toBe('EDIT_SECTION')
-    expect(editSection.payload.activeSection).toBe(6)
+    expect(editSection.payload.sectionIndex).toBe(6)
   })
 
   it('#changeView sets the activeView to arg', () => {

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -14,57 +14,57 @@ describe('editActions', () => {
 
   it('#changeSavedStatus updates article and sets isSaved to arg', () => {
     article.set('title', 'Cool article')
-    const changeSavedStatus = editActions.changeSavedStatus(article.attributes, true)
+    const action = editActions.changeSavedStatus(article.attributes, true)
 
-    expect(changeSavedStatus.type).toBe('CHANGE_SAVED_STATUS')
-    expect(changeSavedStatus.payload.isSaved).toBe(true)
-    expect(changeSavedStatus.payload.article.title).toBe('Cool article')
+    expect(action.type).toBe('CHANGE_SAVED_STATUS')
+    expect(action.payload.isSaved).toBe(true)
+    expect(action.payload.article.title).toBe('Cool article')
   })
 
-  it('#editSection sets sectionIndex to index', () => {
-    const editSection = editActions.editSection(6)
+  it('#setSection sets sectionIndex to arg', () => {
+    const action = editActions.setSection(6)
 
-    expect(editSection.type).toBe('EDIT_SECTION')
-    expect(editSection.payload.sectionIndex).toBe(6)
+    expect(action.type).toBe('SET_SECTION')
+    expect(action.payload.sectionIndex).toBe(6)
   })
 
   it('#changeView sets the activeView to arg', () => {
-    const changeView = editActions.changeView('display')
+    const action = editActions.changeView('display')
 
-    expect(changeView.type).toBe('CHANGE_VIEW')
-    expect(changeView.payload.activeView).toBe('display')
+    expect(action.type).toBe('CHANGE_VIEW')
+    expect(action.payload.activeView).toBe('display')
   })
 
   it('#deleteArticle destroys the article and sets isDeleting', () => {
-    const deleteArticle = editActions.deleteArticle(article)
+    const action = editActions.deleteArticle(article)
 
-    expect(deleteArticle.type).toBe('DELETE_ARTICLE')
-    expect(deleteArticle.payload.isDeleting).toBe(true)
+    expect(action.type).toBe('DELETE_ARTICLE')
+    expect(action.payload.isDeleting).toBe(true)
     expect(article.destroy.mock.calls.length).toBe(1)
   })
 
   it('#publishArticle changes the publish status and saves the article', () => {
-    const publishArticle = editActions.publishArticle(article)
+    const action = editActions.publishArticle(article)
 
-    expect(publishArticle.type).toBe('PUBLISH_ARTICLE')
-    expect(publishArticle.payload.isPublishing).toBe(!article.get('published'))
+    expect(action.type).toBe('PUBLISH_ARTICLE')
+    expect(action.payload.isPublishing).toBe(!article.get('published'))
     expect(article.save.mock.calls.length).toBe(1)
   })
 
   it('#saveArticle sets isSaving to true and saves the article', () => {
-    const saveArticle = editActions.saveArticle(article)
+    const action = editActions.saveArticle(article)
 
-    expect(saveArticle.type).toBe('SAVE_ARTICLE')
-    expect(saveArticle.payload.isSaving).toBe(true)
+    expect(action.type).toBe('SAVE_ARTICLE')
+    expect(action.payload.isSaving).toBe(true)
     expect(article.save.mock.calls.length).toBe(1)
   })
 
   describe('#newSection', () => {
     it('Can create an embed section', () => {
-      const newSection = editActions.newSection('embed')
-      const { section } = newSection.payload
+      const action = editActions.newSection('embed')
+      const { section } = action.payload
 
-      expect(newSection.type).toBe('NEW_SECTION')
+      expect(action.type).toBe('NEW_SECTION')
       expect(section.type).toBe('embed')
       expect(section.url).toBe('')
       expect(section.layout).toBe('column_width')
@@ -72,29 +72,29 @@ describe('editActions', () => {
     })
 
     it('Can create an image_collection section', () => {
-      const newSection = editActions.newSection('image_collection')
-      const { section } = newSection.payload
+      const action = editActions.newSection('image_collection')
+      const { section } = action.payload
 
-      expect(newSection.type).toBe('NEW_SECTION')
+      expect(action.type).toBe('NEW_SECTION')
       expect(section.type).toBe('image_collection')
       expect(section.images.length).toBe(0)
       expect(section.layout).toBe('overflow_fillwidth')
     })
 
     it('Can create a text section', () => {
-      const newSection = editActions.newSection('text')
-      const { section } = newSection.payload
+      const action = editActions.newSection('text')
+      const { section } = action.payload
 
-      expect(newSection.type).toBe('NEW_SECTION')
+      expect(action.type).toBe('NEW_SECTION')
       expect(section.type).toBe('text')
       expect(section.body).toBe('')
     })
 
     it('Can create a video section', () => {
-      const newSection = editActions.newSection('video')
-      const { section } = newSection.payload
+      const action = editActions.newSection('video')
+      const { section } = action.payload
 
-      expect(newSection.type).toBe('NEW_SECTION')
+      expect(action.type).toBe('NEW_SECTION')
       expect(section.type).toBe('video')
       expect(section.url).toBe('')
       expect(section.layout).toBe('column_width')
@@ -102,27 +102,27 @@ describe('editActions', () => {
   })
 
   it('#removeSection sets sectionIndex to index', () => {
-    const editSection = editActions.removeSection(6)
+    const action = editActions.removeSection(6)
 
-    expect(editSection.type).toBe('REMOVE_SECTION')
-    expect(editSection.payload.sectionIndex).toBe(6)
+    expect(action.type).toBe('REMOVE_SECTION')
+    expect(action.payload.sectionIndex).toBe(6)
   })
 
   describe('Editing errors', () => {
     it('#logError sets error to arg', () => {
       const message = 'Error message'
-      const logError = editActions.logError({ message })
+      const action = editActions.logError({ message })
 
-      expect(logError.type).toBe('ERROR')
-      expect(logError.payload.error.message).toBe(message)
+      expect(action.type).toBe('ERROR')
+      expect(action.payload.error.message).toBe(message)
     })
 
     it('#resetError sets error to null', () => {
       const message = 'Error message'
-      const resetError = editActions.resetError({ message })
+      const action = editActions.resetError({ message })
 
-      expect(resetError.type).toBe('ERROR')
-      expect(resetError.payload.error).toBe(null)
+      expect(action.type).toBe('ERROR')
+      expect(action.payload.error).toBe(null)
     })
   })
 })

--- a/client/apps/edit/components/content/section_list/index.jsx
+++ b/client/apps/edit/components/content/section_list/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { changeSection } from 'client/actions/editActions'
+import { editSection } from 'client/actions/editActions'
 import SectionContainer from '../section_container'
 import { SectionTool } from '../section_tool'
 import DragContainer from 'client/components/drag_drop/index.coffee'
@@ -9,7 +9,7 @@ import DragContainer from 'client/components/drag_drop/index.coffee'
 export class SectionList extends Component {
   static propTypes = {
     activeSection: PropTypes.any,
-    changeSectionAction: PropTypes.func,
+    editSectionAction: PropTypes.func,
     sections: PropTypes.object.isRequired
   }
 
@@ -24,10 +24,10 @@ export class SectionList extends Component {
   }
 
   onNewSection = (section) => {
-    const { changeSectionAction, sections } = this.props
+    const { editSectionAction, sections } = this.props
     const newActiveSection = sections.indexOf(section)
 
-    changeSectionAction(newActiveSection)
+    editSectionAction(newActiveSection)
   }
 
   onDragEnd = (newSections) => {
@@ -45,7 +45,7 @@ export class SectionList extends Component {
   renderSectionList = () => {
     const {
       activeSection,
-      changeSectionAction,
+      editSectionAction,
       sections
     } = this.props
 
@@ -59,7 +59,7 @@ export class SectionList extends Component {
               index={index}
               isDraggable
               editing={activeSection === index}
-              onSetEditing={(i) => changeSectionAction(i)}
+              onSetEditing={(i) => editSectionAction(i)}
             />
             <SectionTool
               sections={sections}
@@ -110,7 +110,7 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = {
-  changeSectionAction: changeSection
+  editSectionAction: editSection
 }
 
 export default connect(

--- a/client/apps/edit/components/content/section_list/index.jsx
+++ b/client/apps/edit/components/content/section_list/index.jsx
@@ -8,7 +8,7 @@ import DragContainer from 'client/components/drag_drop/index.coffee'
 
 export class SectionList extends Component {
   static propTypes = {
-    activeSection: PropTypes.any,
+    sectionIndex: PropTypes.any,
     editSectionAction: PropTypes.func,
     sections: PropTypes.object.isRequired
   }
@@ -25,9 +25,9 @@ export class SectionList extends Component {
 
   onNewSection = (section) => {
     const { editSectionAction, sections } = this.props
-    const newActiveSection = sections.indexOf(section)
+    const newSectionIndex = sections.indexOf(section)
 
-    editSectionAction(newActiveSection)
+    editSectionAction(newSectionIndex)
   }
 
   onDragEnd = (newSections) => {
@@ -44,7 +44,7 @@ export class SectionList extends Component {
 
   renderSectionList = () => {
     const {
-      activeSection,
+      sectionIndex,
       editSectionAction,
       sections
     } = this.props
@@ -58,13 +58,13 @@ export class SectionList extends Component {
               section={section}
               index={index}
               isDraggable
-              editing={activeSection === index}
+              editing={sectionIndex === index}
               onSetEditing={(i) => editSectionAction(i)}
             />
             <SectionTool
               sections={sections}
               index={index}
-              editing={activeSection !== 0}
+              editing={sectionIndex !== 0}
             />
           </div>
         )
@@ -74,7 +74,7 @@ export class SectionList extends Component {
 
   render () {
     const {
-      activeSection,
+      sectionIndex,
       sections
     } = this.props
 
@@ -83,7 +83,7 @@ export class SectionList extends Component {
         <SectionTool
           sections={sections}
           index={-1}
-          isEditing={activeSection !== null}
+          isEditing={sectionIndex !== null}
           firstSection
           isDraggable={false}
         />
@@ -91,7 +91,7 @@ export class SectionList extends Component {
           ? <DragContainer
               items={sections.models}
               onDragEnd={this.onDragEnd}
-              isDraggable={activeSection === null}
+              isDraggable={sectionIndex === null}
               layout='vertical'
             >
               {this.renderSectionList()}
@@ -106,7 +106,7 @@ export class SectionList extends Component {
 }
 
 const mapStateToProps = (state) => ({
-  activeSection: state.edit.activeSection
+  sectionIndex: state.edit.sectionIndex
 })
 
 const mapDispatchToProps = {

--- a/client/apps/edit/components/content/section_list/index.jsx
+++ b/client/apps/edit/components/content/section_list/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { editSection } from 'client/actions/editActions'
+import { setSection } from 'client/actions/editActions'
 import SectionContainer from '../section_container'
 import { SectionTool } from '../section_tool'
 import DragContainer from 'client/components/drag_drop/index.coffee'
@@ -9,7 +9,7 @@ import DragContainer from 'client/components/drag_drop/index.coffee'
 export class SectionList extends Component {
   static propTypes = {
     sectionIndex: PropTypes.any,
-    editSectionAction: PropTypes.func,
+    setSectionAction: PropTypes.func,
     sections: PropTypes.object.isRequired
   }
 
@@ -24,10 +24,10 @@ export class SectionList extends Component {
   }
 
   onNewSection = (section) => {
-    const { editSectionAction, sections } = this.props
+    const { setSectionAction, sections } = this.props
     const newSectionIndex = sections.indexOf(section)
 
-    editSectionAction(newSectionIndex)
+    setSectionAction(newSectionIndex)
   }
 
   onDragEnd = (newSections) => {
@@ -45,7 +45,7 @@ export class SectionList extends Component {
   renderSectionList = () => {
     const {
       sectionIndex,
-      editSectionAction,
+      setSectionAction,
       sections
     } = this.props
 
@@ -59,7 +59,7 @@ export class SectionList extends Component {
               index={index}
               isDraggable
               editing={sectionIndex === index}
-              onSetEditing={(i) => editSectionAction(i)}
+              onSetEditing={(i) => setSectionAction(i)}
             />
             <SectionTool
               sections={sections}
@@ -110,7 +110,7 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = {
-  editSectionAction: editSection
+  setSectionAction: setSection
 }
 
 export default connect(

--- a/client/apps/edit/components/content/section_list/test/index.test.jsx
+++ b/client/apps/edit/components/content/section_list/test/index.test.jsx
@@ -36,7 +36,7 @@ describe('SectionList', () => {
 
     props = {
       sectionIndex: null,
-      editSectionAction: jest.fn(),
+      setSectionAction: jest.fn(),
       sections: new Sections(article.sections)
     }
   })
@@ -71,7 +71,7 @@ describe('SectionList', () => {
     expect(component.find(SectionContainer).length).toBe(props.sections.length)
   })
 
-  it('Listens for a new section and dispatches editSection with index', () => {
+  it('Listens for a new section and dispatches setSection with index', () => {
     const component = getWrapper(props).find(SectionList)
 
     component.instance().onNewSection({type: 'embed'})
@@ -79,6 +79,6 @@ describe('SectionList', () => {
       {type: 'embed'},
       {at: 3}
     )
-    expect(component.props().editSectionAction.mock.calls[1][0]).toBe(3)
+    expect(component.props().setSectionAction.mock.calls[1][0]).toBe(3)
   })
 })

--- a/client/apps/edit/components/content/section_list/test/index.test.jsx
+++ b/client/apps/edit/components/content/section_list/test/index.test.jsx
@@ -35,7 +35,7 @@ describe('SectionList', () => {
     article = Fixtures.StandardArticle
 
     props = {
-      activeSection: null,
+      sectionIndex: null,
       editSectionAction: jest.fn(),
       sections: new Sections(article.sections)
     }

--- a/client/apps/edit/components/content/section_list/test/index.test.jsx
+++ b/client/apps/edit/components/content/section_list/test/index.test.jsx
@@ -36,7 +36,7 @@ describe('SectionList', () => {
 
     props = {
       activeSection: null,
-      changeSectionAction: jest.fn(),
+      editSectionAction: jest.fn(),
       sections: new Sections(article.sections)
     }
   })
@@ -71,7 +71,7 @@ describe('SectionList', () => {
     expect(component.find(SectionContainer).length).toBe(props.sections.length)
   })
 
-  it('Listens for a new section and dispatches changeSection with index', () => {
+  it('Listens for a new section and dispatches editSection with index', () => {
     const component = getWrapper(props).find(SectionList)
 
     component.instance().onNewSection({type: 'embed'})
@@ -79,6 +79,6 @@ describe('SectionList', () => {
       {type: 'embed'},
       {at: 3}
     )
-    expect(component.props().changeSectionAction.mock.calls[1][0]).toBe(3)
+    expect(component.props().editSectionAction.mock.calls[1][0]).toBe(3)
   })
 })

--- a/client/apps/edit/components/content/section_tool/index.jsx
+++ b/client/apps/edit/components/content/section_tool/index.jsx
@@ -126,7 +126,13 @@ export class SectionTool extends Component {
   }
 
   render () {
-    const { firstSection, index, isEditing, isHero, sections } = this.props
+    const {
+      firstSection,
+      index,
+      isEditing,
+      isHero,
+      sections
+    } = this.props
     const isFirstSection = sections && firstSection && sections.length === 0
     const isLastSection = sections && index === sections.length - 1
     return (

--- a/client/apps/edit/components/content/section_tool/index.jsx
+++ b/client/apps/edit/components/content/section_tool/index.jsx
@@ -126,13 +126,7 @@ export class SectionTool extends Component {
   }
 
   render () {
-    const {
-      firstSection,
-      index,
-      isEditing,
-      isHero,
-      sections
-    } = this.props
+    const { firstSection, index, isEditing, isHero, sections } = this.props
     const isFirstSection = sections && firstSection && sections.length === 0
     const isLastSection = sections && index === sections.length - 1
     return (

--- a/client/apps/edit/components/header/test/index.test.js
+++ b/client/apps/edit/components/header/test/index.test.js
@@ -86,7 +86,7 @@ describe('Edit Header Controls', () => {
   })
 
   describe('Actions', () => {
-    it('Changes activeSection on edit-tab click', () => {
+    it('Changes activeView on edit-tab click', () => {
       const component = getWrapper(props)
       const button = component.find('button').at(1)
       button.simulate('click')

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -53,33 +53,49 @@ export function editReducer (state = initialState, action) {
         activeView: action.payload.activeView
       }, state)
     }
+
     case actions.DELETE_ARTICLE: {
       return u({
         isDeleting: action.payload.isDeleting
       }, state)
     }
+
     case actions.ERROR: {
       return u({
         error: action.payload.error
       }, state)
     }
+
     case actions.NEW_SECTION: {
       const { section, sectionIndex } = action.payload
       const article = cloneDeep(state.article)
 
       article.sections.splice(sectionIndex, 0, section)
-
       return u({
         article,
         sectionIndex,
         section
       }, state)
     }
+
     case actions.PUBLISH_ARTICLE: {
       return u({
         isPublishing: action.payload.isPublishing
       }, state)
     }
+
+    case actions.REMOVE_SECTION: {
+      const { sectionIndex } = action.payload
+      const article = cloneDeep(state.article)
+
+      article.sections.splice(sectionIndex, 1)
+      return u({
+        article,
+        sectionIndex: null,
+        section: null
+      }, state)
+    }
+
     case actions.SAVE_ARTICLE: {
       return u({
         isSaving: true

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -78,6 +78,21 @@ export function editReducer (state = initialState, action) {
       }, state)
     }
 
+    case actions.ON_CHANGE_SECTION: {
+      const { key, value } = action.payload
+      const { sectionIndex } = state
+      const article = cloneDeep(state.article)
+      const section = cloneDeep(state.section)
+
+      section[key] = value
+      article.sections.splice(sectionIndex, 1, section)
+
+      return u({
+        article,
+        section
+      }, state)
+    }
+
     case actions.PUBLISH_ARTICLE: {
       return u({
         isPublishing: action.payload.isPublishing

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -1,6 +1,6 @@
 import u from 'updeep'
 import { data as sd } from 'sharify'
-import { extend, pick } from 'lodash'
+import { clone, cloneDeep, extend, pick } from 'lodash'
 import { actions } from 'client/actions/editActions'
 
 const setupArticle = () => {
@@ -13,7 +13,7 @@ const setupArticle = () => {
 
 export const initialState = {
   article: setupArticle(),
-  activeSection: null,
+  sectionIndex: null,
   activeView: 'content',
   error: null,
   isDeleting: false,
@@ -38,12 +38,12 @@ export function editReducer (state = initialState, action) {
     }
 
     case actions.EDIT_SECTION: {
-      const { activeSection } = action.payload
+      const { sectionIndex } = action.payload
       const { sections } = state.article
-      const section = sections[activeSection] || null
+      const section = clone(sections[sectionIndex]) || null
 
       return u({
-        activeSection,
+        sectionIndex,
         section
       }, state)
     }
@@ -64,9 +64,15 @@ export function editReducer (state = initialState, action) {
       }, state)
     }
     case actions.NEW_SECTION: {
+      const { section, sectionIndex } = action.payload
+      const article = cloneDeep(state.article)
+
+      article.sections.splice(sectionIndex, 0, section)
+
       return u({
-        activeSection: state.article.sections.length,
-        section: action.payload.section
+        article,
+        sectionIndex,
+        section
       }, state)
     }
     case actions.PUBLISH_ARTICLE: {

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -37,7 +37,7 @@ export function editReducer (state = initialState, action) {
       }, state)
     }
 
-    case actions.EDIT_SECTION: {
+    case actions.SET_SECTION: {
       const { sectionIndex } = action.payload
       const { sections } = state.article
       const section = clone(sections[sectionIndex]) || null

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -5,6 +5,7 @@ import { actions } from 'client/actions/editActions'
 
 const setupArticle = () => {
   const article = sd.ARTICLE
+  // strip deprecated handles from author
   const author = pick(article.author, 'id', 'name')
 
   return extend(article, { author })
@@ -19,7 +20,8 @@ export const initialState = {
   isPublishing: false,
   isSaving: false,
   isSaved: true,
-  lastUpdated: null
+  lastUpdated: null,
+  section: null
 }
 
 export function editReducer (state = initialState, action) {
@@ -34,11 +36,18 @@ export function editReducer (state = initialState, action) {
         lastUpdated: action.payload.lastUpdated
       }, state)
     }
-    case actions.CHANGE_SECTION: {
+
+    case actions.EDIT_SECTION: {
+      const { activeSection } = action.payload
+      const { sections } = state.article
+      const section = sections[activeSection] || null
+
       return u({
-        activeSection: action.payload.activeSection
+        activeSection,
+        section
       }, state)
     }
+
     case actions.CHANGE_VIEW: {
       return u({
         activeView: action.payload.activeView
@@ -52,6 +61,12 @@ export function editReducer (state = initialState, action) {
     case actions.ERROR: {
       return u({
         error: action.payload.error
+      }, state)
+    }
+    case actions.NEW_SECTION: {
+      return u({
+        activeSection: state.article.sections.length,
+        section: action.payload.section
       }, state)
     }
     case actions.PUBLISH_ARTICLE: {

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -27,39 +27,59 @@ describe('editReducer', () => {
     expect(initialState.sectionIndex).toBe(null)
   })
 
-  it('EDIT_SECTION adds editing section and sectionIndex to state', () => {
-    const sectionIndex = 2
-    const updatedState = editReducer(initialState, {
-      type: actions.EDIT_SECTION,
-      payload: {
-        sectionIndex
-      }
-    })
-    expect(updatedState.sectionIndex).toBe(sectionIndex)
-    expect(updatedState.section).toEqual(initialSections[2])
-  })
-
-  it('NEW_SECTION should insert a section into article.sections', () => {
-    const section = setupSection('text')
-    const sectionIndex = 2
-
-    const updatedState = editReducer(initialState, {
-      type: actions.NEW_SECTION,
-      payload: {
-        section,
-        sectionIndex
-      }
+  describe('Sections', () => {
+    it('EDIT_SECTION adds editing section and sectionIndex to state', () => {
+      const sectionIndex = 2
+      const updatedState = editReducer(initialState, {
+        type: actions.EDIT_SECTION,
+        payload: {
+          sectionIndex
+        }
+      })
+      expect(updatedState.sectionIndex).toBe(sectionIndex)
+      expect(updatedState.section).toEqual(initialSections[sectionIndex])
     })
 
-    expect(updatedState.sectionIndex).toBe(sectionIndex)
-    expect(updatedState.section.type).toBe(section.type)
-    expect(updatedState.section.body).toBe(section.body)
-    expect(updatedState.article.sections[2]).toBe(section)
-    expect(updatedState.article.sections[3]).toEqual(
-      initialSections[2]
-    )
-    expect(updatedState.article.sections.length).toBe(
-      initialSections.length + 1
-    )
+    it('NEW_SECTION should insert a section into article.sections', () => {
+      const section = setupSection('text')
+      const sectionIndex = 2
+
+      const updatedState = editReducer(initialState, {
+        type: actions.NEW_SECTION,
+        payload: {
+          section,
+          sectionIndex
+        }
+      })
+
+      expect(updatedState.sectionIndex).toBe(sectionIndex)
+      expect(updatedState.section.type).toBe(section.type)
+      expect(updatedState.section.body).toBe(section.body)
+      expect(updatedState.article.sections[sectionIndex]).toBe(section)
+      expect(updatedState.article.sections[3]).toEqual(
+        initialSections[2]
+      )
+      expect(updatedState.article.sections.length).toBe(
+        initialSections.length + 1
+      )
+    })
+
+    it('REMOVE_SECTION should remove a section by index', () => {
+      const sectionIndex = 2
+      const updatedState = editReducer(initialState, {
+        type: actions.REMOVE_SECTION,
+        payload: {
+          sectionIndex
+        }
+      })
+      expect(updatedState.section).toBe(null)
+      expect(updatedState.sectionIndex).toBe(null)
+      expect(updatedState.article.sections.length).toBe(
+        initialSections.length - 1
+      )
+      expect(updatedState.article.sections[2]).not.toEqual(
+        initialSections[2]
+      )
+    })
   })
 })

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -1,14 +1,21 @@
+import { clone } from 'lodash'
 import { editReducer } from '../editReducer'
+import { actions, setupSection } from '../../actions/editActions'
 import {
   FeatureArticle
 } from '@artsy/reaction-force/dist/Components/Publishing/Fixtures/Articles'
 
 describe('editReducer', () => {
-  it('should return the initial state', () => {
-    const initialState = editReducer(undefined, {})
+  let initialState
+  let initialSections
 
-    expect(initialState.article).toBe(FeatureArticle)
-    expect(initialState.activeSection).toBe(null)
+  beforeEach(() => {
+    initialState = editReducer(undefined, {})
+    initialSections = clone(FeatureArticle.sections)
+  })
+
+  it('should return the initial state', () => {
+    expect(initialState.article).toEqual(FeatureArticle)
     expect(initialState.activeView).toBe('content')
     expect(initialState.error).toBe(null)
     expect(initialState.isDeleting).toBe(false)
@@ -17,5 +24,42 @@ describe('editReducer', () => {
     expect(initialState.isSaved).toBe(true)
     expect(initialState.lastUpdated).toBe(null)
     expect(initialState.section).toBe(null)
+    expect(initialState.sectionIndex).toBe(null)
+  })
+
+  it('EDIT_SECTION adds editing section and sectionIndex to state', () => {
+    const sectionIndex = 2
+    const updatedState = editReducer(initialState, {
+      type: actions.EDIT_SECTION,
+      payload: {
+        sectionIndex
+      }
+    })
+    expect(updatedState.sectionIndex).toBe(sectionIndex)
+    expect(updatedState.section).toEqual(initialSections[2])
+  })
+
+  it('NEW_SECTION should insert a section into article.sections', () => {
+    const section = setupSection('text')
+    const sectionIndex = 2
+
+    const updatedState = editReducer(initialState, {
+      type: actions.NEW_SECTION,
+      payload: {
+        section,
+        sectionIndex
+      }
+    })
+
+    expect(updatedState.sectionIndex).toBe(sectionIndex)
+    expect(updatedState.section.type).toBe(section.type)
+    expect(updatedState.section.body).toBe(section.body)
+    expect(updatedState.article.sections[2]).toBe(section)
+    expect(updatedState.article.sections[3]).toEqual(
+      initialSections[2]
+    )
+    expect(updatedState.article.sections.length).toBe(
+      initialSections.length + 1
+    )
   })
 })

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -28,10 +28,10 @@ describe('editReducer', () => {
   })
 
   describe('Sections', () => {
-    it('EDIT_SECTION adds editing section and sectionIndex to state', () => {
+    it('SET_SECTION adds editing section and sectionIndex to state', () => {
       const sectionIndex = 2
       const updatedState = editReducer(initialState, {
-        type: actions.EDIT_SECTION,
+        type: actions.SET_SECTION,
         payload: {
           sectionIndex
         }

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -16,5 +16,6 @@ describe('editReducer', () => {
     expect(initialState.isSaving).toBe(false)
     expect(initialState.isSaved).toBe(true)
     expect(initialState.lastUpdated).toBe(null)
+    expect(initialState.section).toBe(null)
   })
 })

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -1,4 +1,4 @@
-import { clone } from 'lodash'
+import { clone, extend } from 'lodash'
 import { editReducer } from '../editReducer'
 import { actions, setupSection } from '../../actions/editActions'
 import {
@@ -62,6 +62,26 @@ describe('editReducer', () => {
       expect(updatedState.article.sections.length).toBe(
         initialSections.length + 1
       )
+    })
+
+    it('ON_CHANGE_SECTION should update section keys and reset article.sections', () => {
+      const stateWithSection = extend(initialState, {
+        section: initialSections[0],
+        sectionIndex: 0
+      })
+      const key = 'body'
+      const value = '<p>A new piece of text.</p>'
+
+      const updatedState = editReducer(stateWithSection, {
+        type: actions.ON_CHANGE_SECTION,
+        payload: {
+          key,
+          value
+        }
+      })
+
+      expect(updatedState.section.body).toBe(value)
+      expect(updatedState.article.sections[0].body).toBe(value)
     })
 
     it('REMOVE_SECTION should remove a section by index', () => {


### PR DESCRIPTION
Sets up actions for editing article sections:

- `setSection` (was `activeSection`) sets currently editing section to store.section from index arg
- `newSection` inserts a section with keys of type at specified article.sections index, and sets it as the editing section
- `removeSection` removes a section from article.sections based on index
- `onChangeSection` updates section and article.sections 
