### PR TITLE
@l2succes => Move EditLayout save functions to redux

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -7,10 +7,13 @@ export const actions = keyMirror(
   'ERROR',
   'NEW_SECTION',
   'ON_CHANGE_SECTION',
+  'ON_FIRST_SAVE',
   'PUBLISH_ARTICLE',
+  'REDIRECT_TO_LIST',
   'REMOVE_SECTION',
   'SAVE_ARTICLE',
-  'SET_SECTION'
+  'SET_SECTION',
+  'TOGGLE_SPINNER'
 )
 
 export const changeSavedStatus = (article, isSaved) => ({
@@ -75,16 +78,35 @@ export const onChangeSection = (key, value) => {
   }
 }
 
+export const onFirstSave = (id) => {
+  location.assign(`/articles/${id}/edit`)
+
+  return {
+    type: actions.ON_FIRST_SAVE
+  }
+}
+
 export const publishArticle = (article, published) => {
+  if (published) {
+    setSeoKeyword(article)
+  }
   article.set('published', published)
   article.save()
-  article.trigger('finished')
+  redirectToList(published)
 
   return {
     type: actions.PUBLISH_ARTICLE,
     payload: {
       isPublishing: true
     }
+  }
+}
+
+export const redirectToList = (published) => {
+  location.assign(`/articles?published=${published}`)
+
+  return {
+    type: actions.REDIRECT_TO_LIST
   }
 }
 
@@ -96,13 +118,29 @@ export const removeSection = (sectionIndex) => ({
 })
 
 export const saveArticle = (article) => {
+  setSeoKeyword(article)
   article.save()
 
+  if (article.get('published')) {
+    redirectToList(true)
+  }
   return {
     type: actions.SAVE_ARTICLE,
     payload: {
       isSaving: true
     }
+  }
+}
+
+export const toggleSpinner = (isVisible) => {
+  if (isVisible) {
+    $('#edit-sections-spinner').show()
+  } else {
+    $('#edit-sections-spinner').hide()
+  }
+
+  return {
+    type: actions.TOGGLE_SPINNER
   }
 }
 
@@ -149,5 +187,13 @@ export function setupSection (type) {
         type: 'text',
         body: ''
       }
+  }
+}
+
+export function setSeoKeyword (article) {
+  if (article.get('published')) {
+    const seo_keyword = $('input#edit-seo__focus-keyword').val()
+
+    article.set({ seo_keyword })
   }
 }

--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -79,7 +79,7 @@ export const onChangeSection = (key, value) => {
 }
 
 export const onFirstSave = (id) => {
-  location.assign(`/articles/${id}/edit`)
+  window.location.assign(`/articles/${id}/edit`)
 
   return {
     type: actions.ON_FIRST_SAVE
@@ -103,7 +103,7 @@ export const publishArticle = (article, published) => {
 }
 
 export const redirectToList = (published) => {
-  location.assign(`/articles?published=${published}`)
+  window.location.assign(`/articles?published=${published}`)
 
   return {
     type: actions.REDIRECT_TO_LIST
@@ -190,9 +190,9 @@ export function setupSection (type) {
   }
 }
 
-export function setSeoKeyword (article) {
+export const setSeoKeyword = (article) => {
   if (article.get('published')) {
-    const seo_keyword = $('input#edit-seo__focus-keyword').val()
+    const seo_keyword = $('input#edit-seo__focus-keyword').val() || ''
 
     article.set({ seo_keyword })
   }

--- a/client/apps/edit/client.js
+++ b/client/apps/edit/client.js
@@ -15,17 +15,30 @@ export function init () {
   const article = new Article(sd.ARTICLE)
   const channel = sd.CURRENT_CHANNEL
   const author = _.pick(article.get('author'), 'id', 'name')
+  const author_id = sd.USER.id
 
   article.set({
-    author
+    author,
+    author_id
   })
+  article.sections.removeBlank()
 
   new EditLayout({ el: $('#layout-content'), article, channel })
 
   const store = createReduxStore(reducers, initialState)
 
+  if (article.isNew()) {
+    article.once('sync', () => {
+      editActions.onFirstSave(article.get('id'))
+    })
+  }
+
   article.on('sync', () => {
     store.dispatch(editActions.changeSavedStatus(article.attributes, true))
+  })
+
+  article.on('finished', () => {
+    $(document).ajaxStop(() => editActions.redirectToList(article.get('published')))
   })
 
   ReactDOM.render(

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { changeSavedStatus, saveArticle, toggleSpinner } from 'client/actions/editActions'
-
+import {
+  changeSavedStatus,
+  saveArticle,
+  toggleSpinner
+} from 'client/actions/editActions'
 import { ErrorBoundary } from 'client/components/error/error_boundary'
 import { EditAdmin } from './admin/index.jsx'
 import { EditContent } from './content/index.jsx'
@@ -10,7 +13,7 @@ import { EditDisplay } from './display/index.jsx'
 import EditHeader from './header/index.jsx'
 import EditError from './error/index.jsx'
 
-class EditContainer extends Component {
+export class EditContainer extends Component {
   static propTypes = {
     activeView: PropTypes.string,
     article: PropTypes.object,
@@ -19,16 +22,11 @@ class EditContainer extends Component {
     error: PropTypes.object,
     isSaved: PropTypes.bool,
     saveArticleAction: PropTypes.func,
-    toggleSpinnerAction: PropTypes.func,
-    user: PropTypes.object
+    toggleSpinnerAction: PropTypes.func
   }
 
   constructor (props) {
     super(props)
-
-    this.state = {
-      lastUpdated: null
-    }
 
     this.beforeUnload = this.beforeUnload.bind(this)
     this.setupBeforeUnload()

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -34,6 +34,10 @@ class EditContainer extends Component {
     )
   }
 
+  componentDidMount = () => {
+    $('#edit-sections-spinner').hide()
+  }
+
   onChange = (key, value) => {
     const { article } = this.props
 
@@ -96,7 +100,6 @@ class EditContainer extends Component {
           {error && <EditError />}
           {this.getActiveView()}
         </ErrorBoundary>
-
       </div>
     )
   }

--- a/client/apps/edit/components/header/index.jsx
+++ b/client/apps/edit/components/header/index.jsx
@@ -33,9 +33,9 @@ export class EditHeader extends Component {
   }
 
   onSave = () => {
-    const { actions, article, beforeUnload } = this.props
+    const { actions, article } = this.props
 
-    window.removeEventListener('beforeunload', beforeUnload)
+    this.removeUnsavedAlert()
     actions.saveArticle(article)
   }
 
@@ -43,8 +43,15 @@ export class EditHeader extends Component {
     const { actions, article } = this.props
 
     if (confirm('Are you sure?')) {
+      this.removeUnsavedAlert()
       actions.deleteArticle(article)
     }
+  }
+
+  removeUnsavedAlert = () => {
+    const { beforeUnload } = this.props
+    // dont show popup for unsaved changes when saving/deleting
+    window.removeEventListener('beforeunload', beforeUnload)
   }
 
   getSaveColor = () => {

--- a/client/apps/edit/components/header/index.jsx
+++ b/client/apps/edit/components/header/index.jsx
@@ -10,6 +10,7 @@ export class EditHeader extends Component {
   static propTypes = {
     actions: PropTypes.any,
     article: PropTypes.object,
+    beforeUnload: PropTypes.func,
     channel: PropTypes.object,
     edit: PropTypes.object,
     isAdmin: PropTypes.bool
@@ -29,6 +30,13 @@ export class EditHeader extends Component {
         !article.get('published')
       )
     }
+  }
+
+  onSave = () => {
+    const { actions, article, beforeUnload } = this.props
+
+    window.removeEventListener('beforeunload', beforeUnload)
+    actions.saveArticle(article)
   }
 
   onDelete = () => {
@@ -158,10 +166,8 @@ export class EditHeader extends Component {
           <button
             className='avant-garde-button'
             style={{color: this.getSaveColor()}}
-            onClick={() => article.get('published')
-              ? article.trigger('savePublished')
-              : actions.saveArticle(article)
-            }>
+            onClick={this.onSave}
+          >
             {this.getSaveText()}
           </button>
 

--- a/client/apps/edit/components/header/test/index.test.js
+++ b/client/apps/edit/components/header/test/index.test.js
@@ -24,6 +24,7 @@ describe('Edit Header Controls', () => {
         publishArticle: jest.fn(),
         saveArticle: jest.fn()
       },
+      beforeUnload: jest.fn(),
       article: new Article(Fixtures.StandardArticle),
       channel: { type: 'partner' },
       edit: {
@@ -139,14 +140,23 @@ describe('Edit Header Controls', () => {
     })
 
     it('Saves a published article on button click', () => {
-      props.article.trigger = jest.fn()
       props.article.set('published', true)
       const component = getWrapper(props)
       const button = component.find('button').at(4)
       button.simulate('click')
 
-      expect(props.actions.saveArticle.mock.calls.length).toBe(0)
-      expect(props.article.trigger.mock.calls[2][0]).toBe('savePublished')
+      expect(props.actions.saveArticle.mock.calls.length).toBe(1)
+    })
+
+    it('Removes beforeUnload listener on click', () => {
+      window.removeEventListener = jest.fn()
+      props.article.set('published', true)
+      const component = getWrapper(props)
+      const button = component.find('button').at(4)
+      button.simulate('click')
+
+      expect(window.removeEventListener.mock.calls[3][0]).toBe('beforeunload')
+      expect(window.removeEventListener.mock.calls[3][1]).toBe(props.beforeUnload)
     })
   })
 

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -26,7 +26,6 @@ module.exports = class EditLayout extends Backbone.View
       @setupYoast()
       @article.on 'change', @onYoastKeyup
     @setupOnBeforeUnload()
-    @$('#edit-sections-spinner').hide()
 
   onFirstSave: =>
     Backbone.history.navigate "/articles/#{@article.get 'id'}/edit"

--- a/client/apps/edit/components/layout/index.coffee
+++ b/client/apps/edit/components/layout/index.coffee
@@ -1,5 +1,4 @@
 _ = require 'underscore'
-_s = require 'underscore.string'
 Backbone = require 'backbone'
 sd = require('sharify').data
 Channel = require '../../../../models/channel.coffee'
@@ -12,56 +11,11 @@ module.exports = class EditLayout extends Backbone.View
 
   initialize: (options) ->
     { @article } = options
-    @user = new User sd.USER
     @channel = new Channel sd.CURRENT_CHANNEL
-    @$window = $(window)
-    @article.sections.removeBlank()
-    @article.sync = _.debounce _.bind(@article.sync, @article), 500
-    @article.sections.on 'add remove reset', @addRemoveReset
-    @article.on 'finished', @onFinished
-    @article.on 'loading', @showSpinner
-    @article.once 'sync', @onFirstSave if @article.isNew()
-    @article.on 'savePublished', @savePublished
+
     if @channel?.isArtsyChannel()
       @setupYoast()
       @article.on 'change', @onYoastKeyup
-    @setupOnBeforeUnload()
-
-  onFirstSave: =>
-    Backbone.history.navigate "/articles/#{@article.get 'id'}/edit"
-
-  setupOnBeforeUnload: ->
-    window.onbeforeunload = =>
-      if $.active > 0
-        "Your article is not finished saving."
-      else if @changedSection is true and not @finished
-        "You have unsaved changes, do you wish to continue?"
-      else
-        null
-
-  serialize: ->
-    {
-      author_id: @user.get('id')
-      seo_keyword: @$('input#edit-seo__focus-keyword').val()
-    }
-
-  redirectToList: =>
-    location.assign '/articles?published=' + @article.get('published')
-
-  showSpinner: =>
-    @$('#edit-sections-spinner').show()
-
-  onFinished: =>
-    @finished = true
-    @showSpinner()
-    $(document).ajaxStop @redirectToList
-
-  savePublished: =>
-    @article.save @serialize()
-    @onFinished()
-
-  addRemoveReset: =>
-    @changedSection = true
 
   events:
     'keyup #edit-seo__focus-keyword': 'onYoastKeyup'

--- a/client/apps/edit/components/layout/test/index.coffee
+++ b/client/apps/edit/components/layout/test/index.coffee
@@ -26,7 +26,6 @@ describe 'EditLayout', ->
         benv.expose $: benv.require('jquery')
         Backbone.$ = $
         sinon.stub Backbone, 'sync'
-        sinon.stub Backbone.history, 'navigate'
         @EditLayout = rewire '../index.coffee'
         @EditLayout.__set__ 'YoastView', @YoastView = sinon.stub().returns onKeyup: @yoastKeyup = sinon.stub()
         @EditLayout.__set__ 'sd', sd
@@ -42,45 +41,7 @@ describe 'EditLayout', ->
   afterEach ->
     benv.teardown()
     Backbone.sync.restore()
-    Backbone.history.navigate.restore()
     _.debounce.restore()
-
-  describe '#serialize', ->
-
-    it 'adds the current user as the author_id', ->
-      @view.user.set id: 'foo'
-      @view.serialize().author_id.should.equal 'foo'
-
-  describe '#onFinished', ->
-
-    it 'redirects to the list if the articles is saved', ->
-      sinon.stub $.fn, 'ajaxStop'
-      @view.redirectToList = sinon.stub()
-      @view.onFinished()
-      $.fn.ajaxStop.args[0][0]()
-      @view.redirectToList.called.should.be.ok
-      $.fn.ajaxStop.restore()
-
-  describe '#onFirstSave', ->
-
-    it 'updates the url', ->
-      @view.article.set id: 'foo'
-      @view.onFirstSave()
-      Backbone.history.navigate.args[0][0].should.equal '/articles/foo/edit'
-
-  describe '#setupOnBeforeUnload', ->
-
-    it 'stops you if theres ajax requests going on', ->
-      $.active = 3
-      @view.setupOnBeforeUnload()
-      window.onbeforeunload().should.containEql 'not finished'
-
-    it 'stops you if theres a published article that is not yet saved', ->
-      $.active = 0
-      @view.changedSection = true
-      @view.finished = false
-      @view.setupOnBeforeUnload()
-      window.onbeforeunload().should.containEql 'do you wish to continue'
 
   describe '#getBodyText', ->
 

--- a/client/apps/edit/components/tests/edit_container.test.js
+++ b/client/apps/edit/components/tests/edit_container.test.js
@@ -1,0 +1,141 @@
+import React from 'react'
+import configureStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
+import { mount, shallow } from 'enzyme'
+import { Fixtures } from '@artsy/reaction-force/dist/Components/Publishing'
+import Article from '../../../../models/article.coffee'
+import { EditContainer } from '../edit_container'
+import { EditAdmin } from '../admin/index.jsx'
+import { EditContent } from '../content/index.jsx'
+import { EditDisplay } from '../display/index.jsx'
+import { EditHeader } from '../header/index.jsx'
+import { EditError } from '../error/index.jsx'
+require('typeahead.js')
+
+describe('EditContainer', () => {
+  let props
+
+  const getWrapper = (props) => {
+    const mockStore = configureStore([])
+
+    const store = mockStore({
+      app: {
+        channel: props.channel
+      },
+      edit: {
+        activeView: props.activeView,
+        article: props.article,
+        error: props.error
+      }
+    })
+
+    return mount(
+      <Provider store={store}>
+        <EditContainer {...props} />
+      </Provider>
+    )
+  }
+
+  const getShallowWrapper = (props) => {
+    return shallow(
+      <EditContainer {...props} />
+    )
+  }
+
+  beforeEach(() => {
+    props = {
+      activeView: 'content',
+      article: new Article(Fixtures.StandardArticle),
+      changeSavedStatusAction: jest.fn(),
+      channel: {},
+      error: {},
+      isSaved: false,
+      saveArticleAction: jest.fn(),
+      toggleSpinnerAction: jest.fn()
+    }
+    window.addEventListener = jest.fn()
+  })
+
+  it('#componentDidMount hides the loading spinner', () => {
+    getShallowWrapper(props)
+    expect(props.toggleSpinnerAction.mock.calls[0][0]).toBe(false)
+  })
+
+  it('sets up an event listener for #beforeUnload when a published article changes', () => {
+    props.article.set('published', true)
+    const component = getShallowWrapper(props)
+    component.instance().props.article.set('title', 'New Title')
+
+    expect(window.addEventListener.mock.calls[0][0]).toBe('beforeunload')
+  })
+
+  it('#onChange sets the article with key/value and calls #maybeSaveArticle', () => {
+    const title = 'New Title'
+    const component = getShallowWrapper(props)
+    component.instance().onChange('title', title)
+
+    expect(props.saveArticleAction.mock.calls[0][0].get('title')).toBe(title)
+  })
+
+  it('#onChangeHero sets the article hero_section with key/value and calls #maybeSaveArticle', () => {
+    const url = 'New Url'
+    const component = getShallowWrapper(props)
+    component.instance().onChangeHero('url', url)
+
+    expect(props.saveArticleAction.mock.calls[0][0].get('hero_section').url).toBe(url)
+  })
+
+  describe('#maybeSaveArticle', () => {
+    it('Calls #saveArticleAction if unpublished', () => {
+      const component = getShallowWrapper(props)
+      component.instance().maybeSaveArticle()
+
+      expect(props.saveArticleAction.mock.calls[0][0]).toBe(props.article)
+    })
+
+    it('Calls #changeSavedStatusAction if published', () => {
+      props.article.set('published', true)
+      const component = getShallowWrapper(props)
+      component.instance().maybeSaveArticle()
+
+      expect(props.changeSavedStatusAction.mock.calls[0][0]).toBe(props.article.attributes)
+      expect(props.changeSavedStatusAction.mock.calls[0][1]).toBe(false)
+    })
+  })
+
+  describe('Rendering', () => {
+    it('Renders the EditHeader', () => {
+      const component = getWrapper(props).find(EditContainer)
+      expect(component.find(EditHeader).exists()).toBe(true)
+    })
+
+    describe('activeView', () => {
+      it('Can render the content activeView', () => {
+        const component = getWrapper(props).find(EditContainer)
+        expect(component.find(EditContent).exists()).toBe(true)
+      })
+
+      it('Can render the admin activeView', () => {
+        props.activeView = 'admin'
+        const component = getShallowWrapper(props)
+
+        expect(component.find(EditAdmin).exists()).toBe(true)
+      })
+
+      it('Can render the admin activeView', () => {
+        props.activeView = 'display'
+        const component = getWrapper(props).find(EditContainer)
+
+        expect(component.find(EditDisplay).exists()).toBe(true)
+      })
+    })
+
+    it('Displays an error message if present', () => {
+      props.error = {message: 'an error'}
+      const component = getWrapper(props).find(EditContainer)
+
+      expect(component.text()).toMatch(props.error.message)
+      expect(component.find(EditError).exists()).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Moves all actions related to article saving/setup out of EditLayout backbone view.  

Was not able to deprecate the view yet, as auto-linking and Yoast are still using backbone.