### PR TITLE
@eveessex => [Socket] filter sessions by channel

### DIFF
--- a/client/actions/articlesActions.js
+++ b/client/actions/articlesActions.js
@@ -7,10 +7,11 @@ export const actions = keyMirror(
   'EDITED_ARTICLES_RECEIVED'
 )
 
-export const viewArticles = emitAction(() => ({
+export const viewArticles = emitAction((channel) => ({
   type: actions.VIEW_ARTICLES,
   key: messageTypes.articlesRequested,
   payload: {
+    channel,
     timestamp: new Date().toISOString()
   }
 }))

--- a/client/apps/articles_list/client.js
+++ b/client/apps/articles_list/client.js
@@ -9,7 +9,7 @@ import { init as initWebsocket } from 'client/apps/websocket/client'
 import ArticlesList from './components/articles_list'
 
 const store = createReduxStore(reducers, initialState)
-initWebsocket(store)
+initWebsocket(store, sd.APP_URL)
 
 export const init = () => (
   render(

--- a/client/apps/articles_list/components/articles_list.jsx
+++ b/client/apps/articles_list/components/articles_list.jsx
@@ -28,8 +28,8 @@ export class ArticlesList extends Component {
   }
 
   componentDidMount () {
-    const { viewArticlesAction } = this.props
-    viewArticlesAction()
+    const { channel, viewArticlesAction } = this.props
+    viewArticlesAction(channel)
 
     const canLoadMore = debounce(this.canLoadMore, 300)
     $.onInfiniteScroll(canLoadMore)

--- a/client/apps/articles_list/icons.jade
+++ b/client/apps/articles_list/icons.jade
@@ -1,2 +1,0 @@
-.new-article
-  include ../../components/layout/public/icons/layout_new_article.svg

--- a/client/apps/articles_list/routes.coffee
+++ b/client/apps/articles_list/routes.coffee
@@ -3,7 +3,7 @@ query = require './query.coffee'
 Lokka = require('lokka').Lokka
 Transport = require('lokka-transport-http').Transport
 { API_URL } = process.env
-{ articlesInSession } = require '../websocket'
+{ getSessionsForChannel } = require '../websocket'
 
 @articles_list = (req, res, next) ->
   channel_id = req.user?.get('current_channel').id
@@ -31,9 +31,9 @@ Transport = require('lokka-transport-http').Transport
 
 renderArticles = (res, req, result, published) ->
   res.locals.sd.ARTICLES = result.articles
-  res.locals.sd.ARTICLES_IN_SESSION = articlesInSession
-  res.locals.sd.CURRENT_CHANNEL = req.user?.get('current_channel')
+  channel = res.locals.sd.CURRENT_CHANNEL = req.user?.get('current_channel')
+  res.locals.sd.ARTICLES_IN_SESSION = getSessionsForChannel channel
   res.locals.sd.HAS_PUBLISHED = published
   res.render 'index',
     articles: result.articles || []
-    current_channel: req.user?.get('current_channel')
+    current_channel: channel

--- a/client/apps/edit/client.js
+++ b/client/apps/edit/client.js
@@ -27,7 +27,7 @@ export function init () {
   new EditLayout({ el: $('#layout-content'), article, channel })
 
   const store = createReduxStore(reducers, initialState)
-  initWebsocket(store)
+  initWebsocket(store, sd.APP_URL)
 
   if (article.isNew()) {
     article.once('sync', () => {

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -61,8 +61,9 @@ export class EditContainer extends Component {
   }
 
   componentDidMount () {
-    const { startEditingArticleAction, user } = this.props
+    const { channel, startEditingArticleAction, user } = this.props
     startEditingArticleAction({
+      channel,
       user,
       article: this.props.article.id
     })
@@ -102,11 +103,12 @@ export class EditContainer extends Component {
   }
 
   onChange = (key, value) => {
-    const { article, updateArticleAction } = this.props
+    const { article, channel, updateArticleAction } = this.props
 
     this.resetInactivityCounter()
     article.set(key, value)
     updateArticleAction({
+      channel,
       article: article.id
     })
     this.maybeSaveArticle()
@@ -136,8 +138,9 @@ export class EditContainer extends Component {
   sendStopEditing = () => {
     if (this.state.sentStopEditingEvent) return
 
-    const { article, stopEditingArticleAction, user } = this.props
+    const { article, channel, stopEditingArticleAction, user } = this.props
     stopEditingArticleAction({
+      channel,
       article: article.id,
       user
     })

--- a/client/apps/edit/routes.coffee
+++ b/client/apps/edit/routes.coffee
@@ -2,12 +2,12 @@ Article = require '../../models/article'
 User = require '../../models/user'
 Channel = require '../../models/channel'
 sd = require('sharify').data
-{ articlesInSession } = require '../websocket'
+{ sessions } = require '../websocket'
 
 @create = (req, res, next) ->
   channel = new Channel req.user.get('current_channel')
   res.locals.sd.CURRENT_CHANNEL = channel
-  res.locals.sd.CURRENT_SESSION = articlesInSession[req.params.id]
+  res.locals.sd.CURRENT_SESSION = sessions[req.params.id]
   article = new Article {
     channel_id: channel.get('id') if channel.get('type') isnt 'partner'
     partner_channel_id: channel.get('id') if channel.get('type') is 'partner'
@@ -24,7 +24,7 @@ sd = require('sharify').data
     error: res.backboneError
     success: (article) ->
       return next() unless req.user.hasArticleAccess article
-      res.locals.sd.CURRENT_SESSION = articlesInSession[req.params.id]
+      res.locals.sd.CURRENT_SESSION = sessions[req.params.id]
       res.locals.sd.ACCESS_TOKEN = req.user.get('access_token')
       res.locals.sd.CURRENT_CHANNEL = new Channel req.user.get('current_channel')
       if (article.get('channel_id') or article.get('partner_channel_id')) isnt req.user.get('current_channel').id
@@ -34,7 +34,7 @@ sd = require('sharify').data
 
 render = (req, res, article) ->
   res.locals.sd.ARTICLE = article.toJSON()
-  res.locals.sd.CURRENT_SESSION = articlesInSession[req.params.id]
+  res.locals.sd.CURRENT_SESSION = sessions[req.params.id]
 
   view = if res.locals.sd.IS_MOBILE then 'mobile/index' else 'layout/index'
   res.render view, article: article

--- a/client/apps/websocket/client.js
+++ b/client/apps/websocket/client.js
@@ -1,10 +1,10 @@
 import io from 'socket.io-client'
 import { messageTypes } from './messageTypes'
 
-const sd = require('sharify').data
-const socket = io(sd.APP_URL)
+let socket
 
-const init = (store) => {
+const init = (store, rootURL) => {
+  socket = io(rootURL)
   // add listeners to socket messages so we can re-dispatch them as actions
   Object.keys(messageTypes)
     .forEach(key =>

--- a/client/components/article_list/index.jsx
+++ b/client/components/article_list/index.jsx
@@ -122,9 +122,11 @@ export class ArticleList extends Component {
   }
 
   render () {
+    const articles = this.props.articles || {}
+
     return (
       <div className='article-list__results'>
-        {!this.props.articles.length
+        {!articles.length
           ? <div className='article-list__no-results'>No Results Found</div>
           : this.renderArticles()}
       </div>


### PR DESCRIPTION
To improve security and reduce payload sizes, this modifies websocket handlers to only send to clients sessions for the currently active channel

This also fixes the following bug: https://sentry.io/artsynet/positron-staging/issues/451759495/
