### PR TITLE
[Edit] fixes draft editor to never show lock modal

### DIFF
--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -48,7 +48,7 @@ export class EditContainer extends Component {
       lastUpdated: null,
       isOtherUserInSession: !!props.currentSession && !isCurrentUserEditing,
       inactivityPeriodEntered: false,
-      shouldShowModal: true,
+      shouldShowModal: !props.article.isNew(),
       sentStopEditingEvent: false
     }
 


### PR DESCRIPTION
Fix for a bug that affects editing a new draft. It should not show the lock modal in that case