### PR TITLE
@kanaabe => Move fetch mentioned to article model

### DIFF
--- a/client/test/models/article.test.js
+++ b/client/test/models/article.test.js
@@ -43,4 +43,69 @@ describe('Article', () => {
       expect(byline).toBe('Casey Lesser, Molly Gottschalk and Tess Thackara')
     })
   })
+
+  describe('#getSlugsFromHTML', () => {
+    it('Extracts a slug from an Artsy link', () => {
+      const html = '<p><a href="http://artsy.net/artist/cy-twombly"></p>'
+      const result = Article.getSlugsFromHTML(html, 'artist')
+
+      expect(result[0]).toBe('cy-twombly')
+    })
+
+    it('Extracts a slug from an Artsy link with query junk', () => {
+      const html = '<p><a href="http://artsy.net/artist/cy-twombly?foo=bar"></p>'
+      const result = Article.getSlugsFromHTML(html, 'artist')
+
+      expect(result[0]).toBe('cy-twombly')
+    })
+
+    it('Extracts a slug from an Artsy link with query junk', () => {
+      const html = '<p><a href="https://www.google.com/url?q=https%3A%2F%2Fwww.artsy.net%2Fartist%2Ftrenton-doyle-hancock&sa=D&sntz=1"></p>'
+      const result = Article.getSlugsFromHTML(html, 'artist')
+
+      expect(result[0]).toBe('trenton-doyle-hancock')
+    })
+
+    it('Extracts multiple slugs from an Artsy link', () => {
+      const html = '<p><a href="http://artsy.net/artist/cy-twombly"><a href="https://www.google.com/url?q=https%3A%2F%2Fwww.artsy.net%2Fartist%2Ftrenton-doyle-hancock&sa=D&sntz=1"></p>'
+      const result = Article.getSlugsFromHTML(html, 'artist')
+
+      expect(result[0]).toBe('cy-twombly')
+      expect(result[1]).toBe('trenton-doyle-hancock')
+    })
+  })
+
+  describe('#getMentionedArtistSlugs', () => {
+    it('Finds artists mentioned in text and image sections', () => {
+      let article = {
+        sections: [
+          {type: 'image_collection', images: [{type: 'artwork', artists: [{id: 'trenton-doyle-hancock'}]}]},
+          {type: 'text', body: "<p><a href='artsy.net/artist/jutta-koether'>Jutta Koether</a></p>"},
+          {type: 'image_set', images: [{type: 'image', caption: "<p><a href='artsy.net/artist/cy-twombly'>Cy Twombly</a></p>"}]}
+        ]
+      }
+      let result = Article.getMentionedArtistSlugs(article)
+
+      expect(result[0]).toBe('trenton-doyle-hancock')
+      expect(result[1]).toBe('jutta-koether')
+      expect(result[2]).toBe('cy-twombly')
+    })
+  })
+
+  describe('#getMentionedArtworkSlugs', () => {
+    it('Finds artworks mentioned in text and image sections', () => {
+      let article = {
+        sections: [
+          {type: 'image_collection', images: [{type: 'artwork', slug: 'sam-moyer-untitled-29'}]},
+          {type: 'text', body: "<p><a href='artsy.net/artwork/gretta-johnson-untitled'></p>"},
+          {type: 'image_set', images: [{type: 'image', caption: "<p><a href='artsy.net/artwork/chip-hughes-stripes'></p>"}]}
+        ]
+      }
+      let result = Article.getMentionedArtworkSlugs(article)
+
+      expect(result[0]).toBe('sam-moyer-untitled-29')
+      expect(result[1]).toBe('gretta-johnson-untitled')
+      expect(result[2]).toBe('chip-hughes-stripes')
+    })
+  })
 })


### PR DESCRIPTION
In anticipation of redux admin panel, duplicated functions for fetching mentioned artists and artworks out of section model and sections collection into article model. 

The Backbone functionality can be removed after the new admin panel is finished (working through some metaphysics/gravity issues before this is finished)