### PR TITLE
[Dev] fix bootstrap issue reading API_URL from sharify

### DIFF
--- a/client/collections/sessions.js
+++ b/client/collections/sessions.js
@@ -1,8 +1,7 @@
 import Backbone from 'backbone'
 import Session from '../models/session'
-import { data as sd } from 'sharify'
 
 export default class Sessions extends Backbone.Collection {
-  url = `${sd.API_URL}/sessions`
+  url = `${process.env.API_URL}/sessions`
   model = Session
 }

--- a/client/models/session.js
+++ b/client/models/session.js
@@ -1,6 +1,5 @@
 import Backbone from 'backbone'
-import { data as sd } from 'sharify'
 
 export default class Session extends Backbone.Model {
-  urlRoot = `${sd.API_URL}/sessions`
+  urlRoot = `${process.env.API_URL}/sessions`
 }


### PR DESCRIPTION
We switch reading `API_URL` from `sharify.data` to `process.env` since sharify is not yet instantiated by the time it's used