### PR TITLE
@kanaabe => Draft rules for news articles

### DIFF
--- a/client/apps/edit/components/content/article_layouts/news.jsx
+++ b/client/apps/edit/components/content/article_layouts/news.jsx
@@ -60,14 +60,13 @@ export default connect(
 )(EditNews)
 
 const EditNewsContainer = styled.div`
-  max-width: 780px;
+  max-width: 820px;
   margin: 40px auto;
 
   .SectionText {
     max-width: 680px;
   }
-
-  .SectionContainer {
-    padding: 20px 0;
+  div[class*='NewsByline__NewsBylineContainer'] {
+    padding: 0 20px;
   }
 `

--- a/client/apps/edit/components/content/section_controls/index.styl
+++ b/client/apps/edit/components/content/section_controls/index.styl
@@ -86,5 +86,5 @@
 [data-layout='news'] .SectionContainer
   &[data-type=image_collection]
     .edit-controls
-      max-width news-body-width
-      margin-left 0px
+      max-width news-body-width-w-margin
+      margin-left -20px

--- a/client/apps/edit/components/content/sections/text/draft_config.js
+++ b/client/apps/edit/components/content/sections/text/draft_config.js
@@ -16,29 +16,59 @@ export const inlineStyles = (layout) => {
     {label: 'B', name: 'BOLD'},
     {label: 'I', name: 'ITALIC'}
   ]
-  if (layout === 'standard') {
+  if (['standard', 'news'].includes(layout)) {
     styles.push({label: ' S ', name: 'STRIKETHROUGH'})
   }
   return styles
 }
 
 export const blockTypes = (layout, hasFeatures) => {
-  // blocks available on menu display
-  const blocks = [
-    {label: 'H2', name: 'header-two'},
-    {label: 'H3', name: 'header-three'},
-    {name: 'unordered-list-item'}
-  ]
-  if (layout === 'feature') {
-    blocks.unshift({label: 'H1', name: 'header-one'})
+  // blocks available in pop-up menu
+  switch (layout) {
+    case 'classic': {
+      if (!hasFeatures) {
+        return [
+          {label: 'H2', name: 'header-two'},
+          {label: 'H3', name: 'header-three'},
+          {name: 'ordered-list-item'},
+          {name: 'unordered-list-item'}
+        ]
+      } else {
+        return [
+          {label: 'H2', name: 'header-two'},
+          {label: 'H3', name: 'header-three'},
+          {name: 'ordered-list-item'},
+          {name: 'unordered-list-item'},
+          {name: 'blockquote'}
+        ]
+      }
+    }
+    case 'feature': {
+      return [
+        {label: 'H1', name: 'header-one'},
+        {label: 'H2', name: 'header-two'},
+        {label: 'H3', name: 'header-three'},
+        {name: 'unordered-list-item'},
+        {name: 'blockquote'}
+      ]
+    }
+    case 'news': {
+      return [
+        {label: 'H3', name: 'header-three'},
+        {name: 'ordered-list-item'},
+        {name: 'unordered-list-item'},
+        {name: 'blockquote'}
+      ]
+    }
+    default: {
+      return [
+        {label: 'H2', name: 'header-two'},
+        {label: 'H3', name: 'header-three'},
+        {name: 'unordered-list-item'},
+        {name: 'blockquote'}
+      ]
+    }
   }
-  if (layout === 'classic') {
-    blocks.push({name: 'ordered-list-item'})
-  }
-  if (hasFeatures) {
-    blocks.push({name: 'blockquote'})
-  }
-  return blocks
 }
 
 export const blockRenderMap = (layout, hasFeatures) => {
@@ -52,27 +82,40 @@ export const blockRenderMap = (layout, hasFeatures) => {
       'ordered-list-item': {element: 'li'},
       'unstyled': {element: 'div'}
     })
-  }
-  if (layout === 'feature') {
-    return Immutable.Map({
-      'header-one': { element: 'h1' },
-      'header-two': {element: 'h2'},
-      'header-three': {element: 'h3'},
-      'blockquote': {element: 'blockquote'},
-      'unordered-list-item': {element: 'li'},
-      'ordered-list-item': {element: 'li'},
-      'unstyled': {element: 'div'}
-    })
   } else {
-    // standard, classic on internal channels
-    return Immutable.Map({
-      'header-two': {element: 'h2'},
-      'header-three': {element: 'h3'},
-      'blockquote': {element: 'blockquote'},
-      'unordered-list-item': {element: 'li'},
-      'ordered-list-item': {element: 'li'},
-      'unstyled': {element: 'div'}
-    })
+    switch (layout) {
+      case 'feature': {
+        return Immutable.Map({
+          'header-one': { element: 'h1' },
+          'header-two': {element: 'h2'},
+          'header-three': {element: 'h3'},
+          'blockquote': {element: 'blockquote'},
+          'unordered-list-item': {element: 'li'},
+          'ordered-list-item': {element: 'li'},
+          'unstyled': {element: 'div'}
+        })
+      }
+      case 'news': {
+        return Immutable.Map({
+          'header-three': {element: 'h3'},
+          'unordered-list-item': {element: 'li'},
+          'ordered-list-item': {element: 'li'},
+          'blockquote': {element: 'blockquote'},
+          'unstyled': {element: 'div'}
+        })
+      }
+      default: {
+        // standard, classic on internal channels
+        return Immutable.Map({
+          'header-two': {element: 'h2'},
+          'header-three': {element: 'h3'},
+          'blockquote': {element: 'blockquote'},
+          'unordered-list-item': {element: 'li'},
+          'ordered-list-item': {element: 'li'},
+          'unstyled': {element: 'div'}
+        })
+      }
+    }
   }
 }
 
@@ -121,7 +164,7 @@ export const setEditorStateFromProps = (props) => {
 
   const decorators = composedDecorator(article.layout)
   const emptyState = EditorState.createEmpty(decorators)
-  const hasContentEnd = isContentEnd && article.layout !== 'classic'
+  const hasContentEnd = isContentEnd && ['feature', 'standard'].includes(article.layout)
   let editorState
 
   const formattedData = getFormattedState(emptyState, section.body, article.layout, hasFeatures)

--- a/client/apps/edit/components/content/sections/text/index.jsx
+++ b/client/apps/edit/components/content/sections/text/index.jsx
@@ -73,7 +73,7 @@ export class SectionText extends Component {
 
     // Reset contentEnd markers if end has changed
     if (isContentEnd !== prevProps.isContentEnd) {
-      if (article.layout !== 'classic') {
+      if (['feature', 'standard'].includes(article.layout)) {
         const html = setContentEnd(section.body, isContentEnd)
         onChange('body', html)
       }
@@ -235,9 +235,8 @@ export class SectionText extends Component {
       // Dont allow inline styles in avant-garde font
       const block = editorState.getCurrentContent().getBlockForKey(selection.anchorKey)
       Strip.stripCharacterStyles(block)
-    } //else {
+    }
     this.onChange(RichUtils.toggleInlineStyle(editorState, style))
-    // }
   }
 
   toggleBlock = (block) => {

--- a/client/apps/edit/components/content/sections/text/test/config.test.js
+++ b/client/apps/edit/components/content/sections/text/test/config.test.js
@@ -36,6 +36,18 @@ describe('SectionText: Config', () => {
       ])
     })
 
+    it('Returns the correct blocks for a news article', () => {
+      const blocks = Config.blockRenderMapArray('news', true)
+
+      expect(blocks).toEqual([
+        'header-three',
+        'unordered-list-item',
+        'ordered-list-item',
+        'blockquote',
+        'unstyled'
+      ])
+    })
+
     it('Returns the correct blocks for a classic article with features', () => {
       const blocks = Config.blockRenderMapArray('classic', true)
 
@@ -69,6 +81,7 @@ describe('SectionText: Config', () => {
       expect(styles[0]).toBe('BOLD')
       expect(styles[1]).toBe('ITALIC')
     })
+
     it('Returns rich elements for a standard article', () => {
       const styles = pluck(Config.inlineStyles('standard'), 'name')
 
@@ -76,6 +89,15 @@ describe('SectionText: Config', () => {
       expect(styles[1]).toBe('ITALIC')
       expect(styles[2]).toBe('STRIKETHROUGH')
     })
+
+    it('Returns rich elements for a news article', () => {
+      const styles = pluck(Config.inlineStyles('news'), 'name')
+
+      expect(styles[0]).toBe('BOLD')
+      expect(styles[1]).toBe('ITALIC')
+      expect(styles[2]).toBe('STRIKETHROUGH')
+    })
+
     it('Returns rich elements for a classic article', () => {
       const styles = pluck(Config.inlineStyles('classic'), 'name')
 
@@ -108,6 +130,14 @@ describe('SectionText: Config', () => {
 
       expect(blocks.length).toBe(4)
       expect(blockMap.size).toBe(6)
+      expect(styles.length).toBe(3)
+    })
+
+    it('Returns rich elements for a news article', () => {
+      const { blocks, blockMap, styles } = Config.getRichElements('news', true)
+
+      expect(blocks.length).toBe(4)
+      expect(blockMap.size).toBe(5)
       expect(styles.length).toBe(3)
     })
 
@@ -158,6 +188,16 @@ describe('SectionText: Config', () => {
 
       expect(html).toMatch('<p>Hello. </p><h3><em>Hello. </em></h3><blockquote>Hello. </blockquote><p><span><a href="artsy.net" class="is-follow-link">Hello. </a><a class="entity-follow artist-follow"></a></span><span class="content-end"> </span></p>')
       expect(editorState.getCurrentContent().getPlainText()).toMatch('Hello.')
+    })
+
+    it('Sets up editorState and formatted html for news articles', () => {
+      props.article = {layout: 'news'}
+      props.isContentEnd = true
+      const { editorState, html } = Config.setEditorStateFromProps(props)
+
+      expect(html).toMatch('<p>Hello. </p><h3><em>Hello. </em></h3><blockquote>Hello. </blockquote><p><span><a href="artsy.net" class="is-follow-link">Hello. </a><a class="entity-follow artist-follow"></a></span></p>')
+      expect(editorState.getCurrentContent().getPlainText()).toMatch('Hello.')
+      expect(html).not.toMatch('<span class="content-end">')
     })
 
     it('Sets up editorState and formatted html for classic articles with features', () => {

--- a/client/components/stylus_lib/index.styl
+++ b/client/components/stylus_lib/index.styl
@@ -28,6 +28,7 @@ feature-body-w-margin = 720px
 feature-blockquote-width = 940px
 
 news-body-width = 780px
+news-body-width-w-margin = 820px
 
 // Helpers
 fill-color(col, time=0.3s)

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -88,7 +88,12 @@ export function editReducer (state = initialState, action) {
       const { section, sectionIndex } = action.payload
       const article = cloneDeep(state.article)
 
-      article.sections.splice(sectionIndex, 0, section)
+      if (article.sections) {
+        article.sections.splice(sectionIndex, 0, section)
+      } else {
+        article.sections = [section]
+      }
+
       return u({
         article,
         sectionIndex,

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -10,6 +10,7 @@ describe('editReducer', () => {
   beforeEach(() => {
     initialState = editReducer(undefined, { payload: {} })
     initialSections = cloneDeep(FeatureArticle.sections)
+    initialState.article = cloneDeep(FeatureArticle)
   })
 
   it('should return the initial state', () => {
@@ -62,7 +63,27 @@ describe('editReducer', () => {
       )
     })
 
-    xit('CHANGE_SECTION should update section keys and reset article.sections', () => {
+    it('NEW_SECTION can add a section to an article without sections', () => {
+      initialState.article = extend(cloneDeep(initialState.article), {sections: null})
+      const section = setupSection('text')
+      const sectionIndex = 0
+
+      const updatedState = editReducer(initialState, {
+        type: actions.NEW_SECTION,
+        payload: {
+          section,
+          sectionIndex
+        }
+      })
+
+      expect(updatedState.sectionIndex).toBe(sectionIndex)
+      expect(updatedState.section.type).toBe(section.type)
+      expect(updatedState.section.body).toBe(section.body)
+      expect(updatedState.article.sections[sectionIndex]).toBe(section)
+      expect(updatedState.article.sections.length).toBe(1)
+    })
+
+    it('CHANGE_SECTION should update section keys and reset article.sections', () => {
       const stateWithSection = extend(cloneDeep(initialState), {
         section: cloneDeep(initialSections[0]),
         sectionIndex: 0


### PR DESCRIPTION
- Adds block map for news layout
- Adds text-nav items for news layout
- Tweaks container width a bit to add padding around news article sections 
- Excludes news articles from 'content-end' dot
- Updates 'NEW_SECTION' action to accommodate articles without sections array