### PR TITLE
@l2success => Can save session if no username

### DIFF
--- a/api/apps/sessions/model.js
+++ b/api/apps/sessions/model.js
@@ -10,7 +10,7 @@ const schema = Joi.object().keys({
   timestamp: Joi.date(),
   user: Joi.object().keys({
     id: Joi.string().objectid(),
-    name: Joi.string()
+    name: Joi.string().default('')
   }),
   article: Joi.string().objectid(),
   channel: Joi.object().keys({

--- a/api/apps/sessions/test/model.test.js
+++ b/api/apps/sessions/test/model.test.js
@@ -34,6 +34,24 @@ describe('Sessions Model', () => {
     })
   })
 
+  it('Can #save without username (partners)', (done) => {
+    save({
+      _id: '59fa424574132b001d917253',
+      id: '59fa424574132b001d917253',
+      timestamp: '2018-02-20T21:13:09.358Z',
+      user: { id: '586ff4069c18db5923002ca6' },
+      article: '59fa424574132b001d917253',
+      channel:
+      { id: '5759e3efb5989e6f98f77993',
+        name: 'Artsy Editorial',
+        type: 'editorial'
+      }
+    }, (_, session) => {
+      session._id.should.equal('59fa424574132b001d917253')
+      done()
+    })
+  })
+
   it('#destroy', (done) => {
     where({}, (_, data) => {
       data.length.should.equal(3)


### PR DESCRIPTION
Fixes a bug that popped up in sentry, 
`child "user" fails because [child "name" fails because ["name" is not allowed to be empty]]`
https://sentry.io/artsynet/positron-production/issues/471161874/