### PR TITLE
@kanaabe => Redux QA

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -274,6 +274,12 @@ export const saveArticle = () => {
       dispatch(changeSavedStatus(article, true))
     })
 
+    if (newArticle.isNew()) {
+      newArticle.once('sync', () => {
+        dispatch(onFirstSave(newArticle.id))
+      })
+    }
+
     dispatch(setSeoKeyword(newArticle))
     newArticle.save()
 

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -137,6 +137,7 @@ describe('editActions', () => {
 
     beforeEach(() => {
       setArticleSpy.mockClear()
+      Article.prototype.isNew = jest.fn().mockReturnValue(false)
       Backbone.sync = jest.fn()
       getState = jest.fn(() => ({edit: { article }}))
       dispatch = jest.fn()
@@ -179,6 +180,16 @@ describe('editActions', () => {
       expect(dispatch.mock.calls[1][0].type).toBe('SET_SEO_KEYWORD')
       expect(setArticleSpy.mock.calls.length).toBe(1)
       expect(setArticleSpy.mock.calls[0][0].seo_keyword).toBeFalsy()
+    })
+
+    it('Redirects to article if new', () => {
+      Article.prototype.isNew.mockReturnValueOnce(true)
+      Backbone.sync = jest.fn(() => {
+        editActions.onFirstSave('12345')
+      })
+      getState = jest.fn(() => ({edit: {article: {published: false}}}))
+      editActions.saveArticle()(dispatch, getState)
+      expect(window.location.assign.mock.calls[0][0]).toBe('/articles/12345/edit')
     })
   })
 

--- a/client/apps/edit/client.js
+++ b/client/apps/edit/client.js
@@ -1,5 +1,3 @@
-import * as editActions from 'client/actions/editActions'
-import _ from 'underscore'
 import $ from 'jquery'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -15,33 +13,11 @@ import { data as sd } from 'sharify'
 export function init () {
   const article = new Article(sd.ARTICLE)
   const channel = sd.CURRENT_CHANNEL
-  const author = _.pick(article.get('author'), 'id', 'name')
-  const author_id = sd.USER.id
-
-  article.set({
-    author,
-    author_id
-  })
-  article.sections.removeBlank()
 
   new EditLayout({ el: $('#layout-content'), article, channel })
 
   const store = createReduxStore(reducers, initialState)
   initWebsocket(store, sd.APP_URL)
-
-  if (article.isNew()) {
-    article.once('sync', () => {
-      editActions.onFirstSave(article.get('id'))
-    })
-  }
-
-  article.on('sync', () => {
-    store.dispatch(editActions.changeSavedStatus(article.attributes, true))
-  })
-
-  article.on('finished', () => {
-    $(document).ajaxStop(() => editActions.redirectToList(article.get('published')))
-  })
 
   ReactDOM.render(
     <Provider store={store}>

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -11,8 +11,9 @@ const setupArticle = () => {
 
   // strip deprecated handles from author
   const author = pick(article.author, 'id', 'name')
+  const author_id = sd.USER.id
 
-  return extend(article, { author })
+  return extend(article, { author, author_id })
 }
 
 export const initialState = {

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -3,7 +3,7 @@ import { data as sd } from 'sharify'
 import { clone, cloneDeep, extend, pick } from 'lodash'
 import { actions } from 'client/actions/editActions'
 
-const setupArticle = () => {
+export const setupArticle = () => {
   const article = sd.ARTICLE
   if (!article) {
     return null

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -1,5 +1,6 @@
 import { cloneDeep, extend } from 'lodash'
-import { editReducer } from '../editReducer'
+import { data as sd } from 'sharify'
+import { editReducer, setupArticle } from '../editReducer'
 import { actions, setupSection } from '../../actions/editActions'
 import { FeatureArticle } from '@artsy/reaction/dist/Components/Publishing/Fixtures/Articles'
 
@@ -23,6 +24,14 @@ describe('editReducer', () => {
     expect(initialState.isSaved).toBe(true)
     expect(initialState.section).toBe(null)
     expect(initialState.sectionIndex).toBe(null)
+  })
+
+  it('#setupArticle should cleanup the author and set author_id', () => {
+    sd.ARTICLE.author = extend(sd.ARTICLE.author, {twitter_handle: '@artsy'})
+    const article = setupArticle()
+
+    expect(sd.ARTICLE.author.twitter_handle).toBeFalsy()
+    expect(article.author_id).toBe(sd.USER.id)
   })
 
   describe('Sections', () => {

--- a/test/jest-setup.js
+++ b/test/jest-setup.js
@@ -31,5 +31,5 @@ window.matchMedia = window.matchMedia || function () {
 sd.data = {
   ARTICLE: FeatureArticle,
   CHANNEL: {},
-  USER: {}
+  USER: {id: '57b5fc6acd530e65f8000406'}
 }


### PR DESCRIPTION
- Move redirect from new articles to `saveArticle` action (from client, fixes bug of not forwarding)
- Set author_id in editReducer rather than client
- Delete unused redux/backbone sync actions in client (should have been removed at /edit2 merge)
