### PR TITLE
@sarahscott => Controls position bug

### DIFF
--- a/client/apps/edit/components/content/section_controls/index.jsx
+++ b/client/apps/edit/components/content/section_controls/index.jsx
@@ -65,10 +65,9 @@ export class SectionControls extends Component {
 
       if (insideComponent && !isHero) {
         return stickyBottom + 'px'
-      } else {
-        return '100%'
       }
     }
+    return '100%'
   }
 
   isScrollingOver = ($section) => {


### PR DESCRIPTION
Fixes bug referenced here:
https://artsy.slack.com/files/U02CR0JD9/F9QGWF2LS/screen_shot_2018-03-15_at_11.41.37_am.png

Default position was not getting returned because return value was inside conditional looking for refs existing.  Moves default out of clause so something is always returned. 