### PR TITLE
@kanaabe => Backspace key bug

### DIFF
--- a/client/apps/edit/components/content/sections/text/test/index.test.js
+++ b/client/apps/edit/components/content/sections/text/test/index.test.js
@@ -337,6 +337,17 @@ describe('SectionText', () => {
       expect(props.onSetEditing.mock.calls.length).toBe(0)
     })
 
+    it('Returns default behavior if section index is 0', () => {
+      props.index = 0
+      const component = getWrapper(props)
+      component.instance().onChange(getSelection(true))
+      component.instance().focus()
+      const handleBackspace = component.instance().handleBackspace({key: 'backspace'})
+
+      expect(handleBackspace).toBe('not-handled')
+      expect(props.onSetEditing.mock.calls.length).toBe(0)
+    })
+
     it('Merges section with previous section if at start of block', () => {
       const component = getWrapper(props)
       component.instance().onChange(getSelection())

--- a/client/components/rich_text/utils/keybindings.js
+++ b/client/components/rich_text/utils/keybindings.js
@@ -123,7 +123,7 @@ export const handleBackspace = (editorState, html, sectionBefore) => {
   const selection = getSelectionDetails(editorState)
   const { isFirstBlock, anchorOffset } = selection
 
-  const sectionBeforeIsText = sectionBefore.type === 'text'
+  const sectionBeforeIsText = sectionBefore && sectionBefore.type === 'text'
   const isAtFirstCharacter = anchorOffset === 0
 
   // only merge a section if focus is at 1st character of 1st block


### PR DESCRIPTION
Was failing because it was looking for attributes on an undefined object.  Adds a conditional before asking for `sectionBefore.type`.