### PR TITLE
@kanaabe => Redirect new articles before change is allowed

### DIFF
--- a/client/apps/edit/client.js
+++ b/client/apps/edit/client.js
@@ -8,6 +8,7 @@ import { Provider } from 'react-redux'
 import { reducers, initialState } from 'client/reducers'
 import { createReduxStore } from 'client/lib/createReduxStore'
 import { init as initWebsocket } from 'client/apps/websocket/client'
+import * as editActions from 'client/actions/editActions'
 import { data as sd } from 'sharify'
 
 export function init () {
@@ -18,6 +19,10 @@ export function init () {
 
   const store = createReduxStore(reducers, initialState)
   initWebsocket(store, sd.APP_URL)
+
+  if (article.isNew()) {
+    store.dispatch(editActions.saveArticle())
+  }
 
   ReactDOM.render(
     <Provider store={store}>

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -48,18 +48,11 @@ export class EditContainer extends Component {
   }
 
   componentDidMount () {
-    const { article, channel, startEditingArticleAction, user } = this.props
+    const { article } = this.props
 
     if (article.id) {
     // wait for new articles to be saved before setup
-      startEditingArticleAction({
-        channel,
-        user,
-        article: article.id
-      })
-
-      this.resetInactivityCounter()
-      window.addEventListener('beforeunload', this.sendStopEditing)
+      this.setupLockout()
       this.props.toggleSpinnerAction(false)
     }
   }
@@ -85,6 +78,24 @@ export class EditContainer extends Component {
     if (article.published) {
       window.addEventListener('beforeunload', this.beforeUnload)
     }
+  }
+
+  setupLockout = () => {
+    const {
+      article,
+      channel,
+      startEditingArticleAction,
+      user
+    } = this.props
+
+    startEditingArticleAction({
+      channel,
+      user,
+      article: article.id
+    })
+
+    this.resetInactivityCounter()
+    window.addEventListener('beforeunload', this.sendStopEditing)
   }
 
   beforeUnload = (e) => {

--- a/client/apps/edit/components/edit_container.jsx
+++ b/client/apps/edit/components/edit_container.jsx
@@ -50,15 +50,18 @@ export class EditContainer extends Component {
   componentDidMount () {
     const { article, channel, startEditingArticleAction, user } = this.props
 
-    startEditingArticleAction({
-      channel,
-      user,
-      article: article.id
-    })
+    if (article.id) {
+    // wait for new articles to be saved before setup
+      startEditingArticleAction({
+        channel,
+        user,
+        article: article.id
+      })
 
-    this.resetInactivityCounter()
-    this.props.toggleSpinnerAction(false)
-    window.addEventListener('beforeunload', this.sendStopEditing)
+      this.resetInactivityCounter()
+      window.addEventListener('beforeunload', this.sendStopEditing)
+      this.props.toggleSpinnerAction(false)
+    }
   }
 
   componentWillReceiveProps = (nextProps) => {

--- a/client/apps/edit/components/tests/edit_container.test.js
+++ b/client/apps/edit/components/tests/edit_container.test.js
@@ -85,6 +85,12 @@ describe('EditContainer', () => {
     expect(props.toggleSpinnerAction.mock.calls[0][0]).toBe(false)
   })
 
+  it('#componentDidMount does not hide the loading spinner if article is new', () => {
+    delete props.article.id
+    getShallowWrapper(props)
+    expect(props.toggleSpinnerAction).not.toBeCalled()
+  })
+
   it('sets up an event listener for #beforeUnload if article is published and changed', () => {
     const component = getShallowWrapper(props)
     component.instance().componentWillReceiveProps({article: {published: true}})

--- a/client/apps/edit/components/tests/edit_container.test.js
+++ b/client/apps/edit/components/tests/edit_container.test.js
@@ -91,6 +91,23 @@ describe('EditContainer', () => {
     expect(props.toggleSpinnerAction).not.toBeCalled()
   })
 
+  it('#componentDidMount calls #setupLockout', () => {
+    const component = getShallowWrapper(props)
+    component.instance().setupLockout = jest.fn()
+    component.instance().componentDidMount()
+
+    expect(component.instance().setupLockout).toBeCalled()
+  })
+
+  it('#componentDidMount does not call #setupLockout if article is new', () => {
+    delete props.article.id
+    const component = getShallowWrapper(props)
+    component.instance().setupLockout = jest.fn()
+    component.instance().componentDidMount()
+
+    expect(component.instance().setupLockout).not.toBeCalled()
+  })
+
   it('sets up an event listener for #beforeUnload if article is published and changed', () => {
     const component = getShallowWrapper(props)
     component.instance().componentWillReceiveProps({article: {published: true}})


### PR DESCRIPTION
When creating a new article, waiting for the save callback while typing would cause multiple articles to be created, because the window had not yet finished forwarding to the article's static url.

This adds a save on the client `init()` if there is no id, and then waits for the article to have an id before removing the loading spinner. 

