### PR TITLE
@eessex => Debounced autosave on articles

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -133,7 +133,7 @@ export const newHeroSection = (type) => {
   }
 }
 
-const dispatchDebouncedSave = debounce((dispatch) => {
+const debouncedSaveDispatch = debounce((dispatch) => {
   dispatch(saveArticle())
 }, 500)
 
@@ -151,7 +151,7 @@ export const onChangeArticle = (key, value) => {
     }))
 
     if (!article.published) {
-      dispatchDebouncedSave(dispatch)
+      debouncedSaveDispatch(dispatch)
     }
   }
 }
@@ -175,7 +175,7 @@ export const onChangeHero = (key, value) => {
     dispatch(changeArticle('hero_section', hero_section))
 
     if (!article.published) {
-      dispatchDebouncedSave(dispatch)
+      debouncedSaveDispatch(dispatch)
     }
   }
 }
@@ -187,7 +187,7 @@ export const onChangeSection = (key, value) => {
     dispatch(changeSection(key, value))
 
     if (!article.published) {
-      dispatchDebouncedSave(dispatch)
+      debouncedSaveDispatch(dispatch)
     }
   }
 }

--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -293,8 +293,6 @@ export const saveArticle = () => {
   }
 }
 
-const debouncedSaveArticle = debounce(saveArticle, 500)
-
 export const saveArticlePending = () => {
   return {
     type: actions.SAVE_ARTICLE,

--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -1,5 +1,5 @@
 
-import { clone, cloneDeep, extend } from 'lodash'
+import { clone, cloneDeep, debounce, extend } from 'lodash'
 import keyMirror from 'client/lib/keyMirror'
 import Article from 'client/models/article.coffee'
 import { emitAction } from 'client/apps/websocket/client'
@@ -133,6 +133,10 @@ export const newHeroSection = (type) => {
   }
 }
 
+const dispatchDebouncedSave = debounce((dispatch) => {
+  dispatch(saveArticle())
+}, 500)
+
 export const onChangeArticle = (key, value) => {
   return (dispatch, getState) => {
     const {
@@ -147,7 +151,7 @@ export const onChangeArticle = (key, value) => {
     }))
 
     if (!article.published) {
-      dispatch(saveArticle())
+      dispatchDebouncedSave(dispatch)
     }
   }
 }
@@ -171,7 +175,7 @@ export const onChangeHero = (key, value) => {
     dispatch(changeArticle('hero_section', hero_section))
 
     if (!article.published) {
-      dispatch(saveArticle())
+      dispatchDebouncedSave(dispatch)
     }
   }
 }
@@ -183,7 +187,7 @@ export const onChangeSection = (key, value) => {
     dispatch(changeSection(key, value))
 
     if (!article.published) {
-      dispatch(saveArticle())
+      dispatchDebouncedSave(dispatch)
     }
   }
 }
@@ -288,6 +292,8 @@ export const saveArticle = () => {
     }
   }
 }
+
+const debouncedSaveArticle = debounce(saveArticle, 500)
 
 export const saveArticlePending = () => {
   return {

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -56,11 +56,96 @@ describe('editActions', () => {
       expect(dispatch.mock.calls.length).toBe(2)
     })
 
-    it('calls #saveArticle if draft', () => {
+    it('calls debounced #saveArticle if draft', (done) => {
       article.published = false
-      editActions.onChangeArticle('title', 'New Title')(dispatch, getState)
+      editActions.onChangeArticle('title', 'N')(dispatch, getState)
+      editActions.onChangeArticle('title', 'Ne')(dispatch, getState)
+      editActions.onChangeArticle('title', 'New')(dispatch, getState)
 
-      expect(dispatch.mock.calls.length).toBe(3)
+      setTimeout(() => {
+        expect(dispatch.mock.calls.length).toBe(7)
+        done()
+      }, 600)
+    })
+  })
+
+  describe('#onChangeHero', () => {
+    let getState
+    let dispatch
+    let setArticleSpy = jest.spyOn(Article.prototype, 'set')
+
+    beforeEach(() => {
+      setArticleSpy.mockClear()
+      Backbone.sync = jest.fn()
+      getState = jest.fn(() => ({
+        edit: { article }
+      }))
+      dispatch = jest.fn()
+    })
+
+    it('calls #changeArticle with new attrs', () => {
+      editActions.onChangeHero('type', 'basic')(dispatch, getState)
+
+      expect(dispatch.mock.calls[0][0].type).toBe('CHANGE_ARTICLE')
+      expect(dispatch.mock.calls[0][0].payload.key).toBe('hero_section')
+      expect(dispatch.mock.calls[0][0].payload.value.type).toBe('basic')
+    })
+
+    it('does not call #saveArticle if published', () => {
+      editActions.onChangeHero('type', 'basic')(dispatch, getState)
+      expect(dispatch.mock.calls.length).toBe(1)
+    })
+
+    it('calls debounced #saveArticle if draft', done => {
+      article.published = false
+      editActions.onChangeHero('deck', 'De')(dispatch, getState)
+      editActions.onChangeHero('deck', 'Dec')(dispatch, getState)
+      editActions.onChangeHero('deck', 'Deck')(dispatch, getState)
+
+      setTimeout(() => {
+        expect(dispatch.mock.calls.length).toBe(4)
+        done()
+      }, 600)
+    })
+  })
+
+  describe('#onChangeSection', () => {
+    let getState
+    let dispatch
+    let setArticleSpy = jest.spyOn(Article.prototype, 'set')
+
+    beforeEach(() => {
+      setArticleSpy.mockClear()
+      Backbone.sync = jest.fn()
+      getState = jest.fn(() => ({
+        edit: { article }
+      }))
+      dispatch = jest.fn()
+    })
+
+    it('calls #changeArticle with new attrs', () => {
+      editActions.onChangeSection('body', 'New Text')(dispatch, getState)
+
+      expect(dispatch.mock.calls[0][0].type).toBe('CHANGE_SECTION')
+      expect(dispatch.mock.calls[0][0].payload.key).toBe('body')
+      expect(dispatch.mock.calls[0][0].payload.value).toBe('New Text')
+    })
+
+    it('does not call #saveArticle if published', () => {
+      editActions.onChangeSection('body', 'New Text')(dispatch, getState)
+      expect(dispatch.mock.calls.length).toBe(1)
+    })
+
+    it('calls debounced #saveArticle if draft', done => {
+      article.published = false
+      editActions.onChangeSection('body', 'New')(dispatch, getState)
+      editActions.onChangeSection('body', 'New Te')(dispatch, getState)
+      editActions.onChangeSection('body', 'New Text')(dispatch, getState)
+
+      setTimeout(() => {
+        expect(dispatch.mock.calls.length).toBe(4)
+        done()
+      }, 600)
     })
   })
 

--- a/client/lib/createReduxStore.js
+++ b/client/lib/createReduxStore.js
@@ -1,6 +1,7 @@
 import get from 'lodash.get'
 import thunkMiddleware from 'redux-thunk'
 import { createLogger } from 'redux-logger'
+import createDebounce from 'redux-debounce'
 import { compose, createStore, applyMiddleware } from 'redux'
 import { contains } from 'underscore'
 import { data as sd } from 'sharify'
@@ -9,8 +10,14 @@ export function createReduxStore (rootReducer, initialState = {}) {
   const isDevelopment = contains(['development', 'staging'], sd.NODE_ENV)
   let composeEnhancers = compose
 
+  const debounceConfig = {
+    simple: 300
+  }
+  const debounceMiddleware = createDebounce(debounceConfig)
+
   const middleware = [
-    thunkMiddleware
+    thunkMiddleware,
+    debounceMiddleware
   ]
 
   if (isDevelopment) {

--- a/client/lib/createReduxStore.js
+++ b/client/lib/createReduxStore.js
@@ -1,7 +1,6 @@
 import get from 'lodash.get'
 import thunkMiddleware from 'redux-thunk'
 import { createLogger } from 'redux-logger'
-import createDebounce from 'redux-debounce'
 import { compose, createStore, applyMiddleware } from 'redux'
 import { contains } from 'underscore'
 import { data as sd } from 'sharify'
@@ -10,14 +9,8 @@ export function createReduxStore (rootReducer, initialState = {}) {
   const isDevelopment = contains(['development', 'staging'], sd.NODE_ENV)
   let composeEnhancers = compose
 
-  const debounceConfig = {
-    simple: 300
-  }
-  const debounceMiddleware = createDebounce(debounceConfig)
-
   const middleware = [
-    thunkMiddleware,
-    debounceMiddleware
+    thunkMiddleware
   ]
 
   if (isDevelopment) {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "react-tracking": "^5.1.0",
     "react-waypoint": "^7.3.1",
     "redux": "^3.7.2",
-    "redux-debounce": "^1.0.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "sailthru-client": "^2.0.3",
@@ -179,6 +178,12 @@
     "webpack-hot-middleware": "^2.20.0",
     "webpack-notifier": "^1.5.0",
     "zombie": "^5.0.5"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "bracketSpacing": true
   },
   "jest": {
     "transform": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-tracking": "^5.1.0",
     "react-waypoint": "^7.3.1",
     "redux": "^3.7.2",
+    "redux-debounce": "^1.0.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "sailthru-client": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,7 +291,6 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/e6a20591a6be418facca1b4670db24f11208cfdd"
   dependencies:
-    coffeescript "1.11.1"
     express "*"
 
 anymatch@^1.3.0:
@@ -3718,6 +3717,12 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+flux-standard-action@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/flux-standard-action/-/flux-standard-action-0.6.1.tgz#6f34211b94834ea1c3cc30f4e7afad3d0fbf71a2"
+  dependencies:
+    lodash.isplainobject "^3.2.0"
+
 for-each@^0.3.2, for-each@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
@@ -5692,6 +5697,10 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.debounce@^4.0.6:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -5712,6 +5721,14 @@ lodash.isinteger@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
 
+lodash.isplainobject@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz#9a8238ae16b200432960cd7346512d0123fbf4c5"
+  dependencies:
+    lodash._basefor "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.keysin "^3.0.0"
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -5723,6 +5740,17 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash.keysin@^3.0.0:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.keysin/-/lodash.keysin-3.0.8.tgz#22c4493ebbedb1427962a54b445b2c8a767fb47f"
+  dependencies:
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
+
+lodash.mapvalues@^4.3.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -7705,6 +7733,14 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-debounce@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/redux-debounce/-/redux-debounce-1.0.1.tgz#76a70953fbb3f89e9fd40c390674aceef400d105"
+  dependencies:
+    flux-standard-action "^0.6.1"
+    lodash.debounce "^4.0.6"
+    lodash.mapvalues "^4.3.0"
 
 redux-logger@^3.0.6:
   version "3.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3717,12 +3717,6 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flux-standard-action@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/flux-standard-action/-/flux-standard-action-0.6.1.tgz#6f34211b94834ea1c3cc30f4e7afad3d0fbf71a2"
-  dependencies:
-    lodash.isplainobject "^3.2.0"
-
 for-each@^0.3.2, for-each@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
@@ -5697,10 +5691,6 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
-lodash.debounce@^4.0.6:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -5721,14 +5711,6 @@ lodash.isinteger@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
 
-lodash.isplainobject@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz#9a8238ae16b200432960cd7346512d0123fbf4c5"
-  dependencies:
-    lodash._basefor "^3.0.0"
-    lodash.isarguments "^3.0.0"
-    lodash.keysin "^3.0.0"
-
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -5740,17 +5722,6 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
-
-lodash.keysin@^3.0.0:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.keysin/-/lodash.keysin-3.0.8.tgz#22c4493ebbedb1427962a54b445b2c8a767fb47f"
-  dependencies:
-    lodash.isarguments "^3.0.0"
-    lodash.isarray "^3.0.0"
-
-lodash.mapvalues@^4.3.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -7733,14 +7704,6 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
-
-redux-debounce@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/redux-debounce/-/redux-debounce-1.0.1.tgz#76a70953fbb3f89e9fd40c390674aceef400d105"
-  dependencies:
-    flux-standard-action "^0.6.1"
-    lodash.debounce "^4.0.6"
-    lodash.mapvalues "^4.3.0"
 
 redux-logger@^3.0.6:
   version "3.0.6"


### PR DESCRIPTION
This debounces the dispatch to `saveArticle` on autosaves. The problem was that we were piling up PUTs on the server which caused a race condition and sometimes old data was the last thing to have actually saved. 

You can see the example here -- it debounces the actions related to `SAVE_ARTICLE` but still allows `CHANGE_SECTION` to dispatch therefore making the UI update smoothly.

![debounced-save](https://user-images.githubusercontent.com/2236794/37546435-3786fe6a-2943-11e8-892d-2fe5025331c6.gif)
