### PR TITLE
@kanaabe => First section of news does not allow embeds

### DIFF
--- a/client/apps/edit/components/content/section_list/index.jsx
+++ b/client/apps/edit/components/content/section_list/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { compact } from 'lodash'
 import { connect } from 'react-redux'
-import { resetSections, setSection } from 'client/actions/editActions'
+import { logError, resetSections, setSection } from 'client/actions/editActions'
 import SectionContainer from '../section_container'
 import SectionTool from '../section_tool'
 import DragContainer from 'client/components/drag_drop/index.coffee'
@@ -11,6 +11,7 @@ export class SectionList extends Component {
   static propTypes = {
     article: PropTypes.object,
     editSection: PropTypes.object,
+    logErrorAction: PropTypes.func,
     resetSectionsAction: PropTypes.func,
     sectionIndex: PropTypes.any,
     setSectionAction: PropTypes.func
@@ -24,8 +25,17 @@ export class SectionList extends Component {
   }
 
   onDragEnd = (newSections) => {
-    const { resetSectionsAction } = this.props
+    const {
+      article: { layout },
+      logErrorAction,
+      resetSectionsAction
+    } = this.props
 
+    if (newSections[0].type === 'social_embed' && layout === 'news') {
+      return logErrorAction({
+        message: 'Embeds are not allowed in the first section.'
+      })
+    }
     resetSectionsAction(compact(newSections))
   }
 
@@ -104,6 +114,7 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = {
+  logErrorAction: logError,
   resetSectionsAction: resetSections,
   setSectionAction: setSection
 }

--- a/client/apps/edit/components/content/section_list/test/index.test.jsx
+++ b/client/apps/edit/components/content/section_list/test/index.test.jsx
@@ -37,6 +37,8 @@ describe('SectionList', () => {
 
     props = {
       article,
+      logErrorAction: jest.fn(),
+      resetSectionsAction: jest.fn(),
       sectionIndex: null,
       setSectionAction: jest.fn()
     }
@@ -80,5 +82,19 @@ describe('SectionList', () => {
     component.instance().onNewSection(newSection)
 
     expect(component.props().setSectionAction.mock.calls[0][0]).toBe(sections.length - 1)
+  })
+
+  it('Shows an error if attempting to drag a news social_embed to first section', () => {
+    props.article.layout = 'news'
+    const component = getWrapper(props).find(SectionList)
+    component.instance().onDragEnd([
+      {type: 'social_embed'},
+      {type: 'text'}
+    ])
+
+    expect(props.logErrorAction.mock.calls[0][0].message).toBe(
+      'Embeds are not allowed in the first section.'
+    )
+    expect(props.resetSectionsAction).not.toBeCalled()
   })
 })

--- a/client/apps/edit/components/content/section_tool/index.jsx
+++ b/client/apps/edit/components/content/section_tool/index.jsx
@@ -16,10 +16,10 @@ export class SectionTool extends Component {
   static propTypes = {
     article: PropTypes.object,
     firstSection: PropTypes.bool,
-    hasFeatures: PropTypes.bool,
     index: PropTypes.number,
     isEditing: PropTypes.bool,
     isHero: PropTypes.bool,
+    isPartnerChannel: PropTypes.bool,
     newHeroSectionAction: PropTypes.func,
     newSectionAction: PropTypes.func,
     onSetEditing: PropTypes.func,
@@ -74,7 +74,7 @@ export class SectionTool extends Component {
     const {
       article: { layout },
       firstSection,
-      hasFeatures
+      isPartnerChannel
     } = this.props
     const { open } = this.state
     const isNews = layout === 'news'
@@ -102,7 +102,7 @@ export class SectionTool extends Component {
               Video
             </li>
           }
-          {hasFeatures && !isNews &&
+          {!isPartnerChannel && !isNews &&
             <li
               className='edit-tool__edit-embed'
               onClick={() => this.newSection('embed')}>
@@ -160,7 +160,7 @@ export class SectionTool extends Component {
 
 const mapStateToProps = (state) => ({
   article: state.edit.article,
-  hasFeatures: state.app.hasFeatures
+  isPartnerChannel: state.app.isPartnerChannel
 })
 
 const mapDispatchToProps = {

--- a/client/apps/edit/components/content/section_tool/index.jsx
+++ b/client/apps/edit/components/content/section_tool/index.jsx
@@ -14,16 +14,16 @@ import { newHeroSection, newSection } from 'client/actions/editActions'
 
 export class SectionTool extends Component {
   static propTypes = {
+    article: PropTypes.object,
     firstSection: PropTypes.bool,
+    hasFeatures: PropTypes.bool,
     index: PropTypes.number,
     isEditing: PropTypes.bool,
     isHero: PropTypes.bool,
     newHeroSectionAction: PropTypes.func,
     newSectionAction: PropTypes.func,
     onSetEditing: PropTypes.func,
-    sections: PropTypes.array,
-    channel: PropTypes.object,
-    article: PropTypes.object
+    sections: PropTypes.array
   }
 
   state = {
@@ -72,8 +72,9 @@ export class SectionTool extends Component {
 
   renderSectionMenu () {
     const {
-      channel: { type },
-      article: { layout }
+      article: { layout },
+      firstSection,
+      hasFeatures
     } = this.props
     const { open } = this.state
     const isNews = layout === 'news'
@@ -101,7 +102,7 @@ export class SectionTool extends Component {
               Video
             </li>
           }
-          {['editorial', 'team'].includes(type) && !isNews &&
+          {hasFeatures && !isNews &&
             <li
               className='edit-tool__edit-embed'
               onClick={() => this.newSection('embed')}>
@@ -109,8 +110,7 @@ export class SectionTool extends Component {
               Embed
             </li>
           }
-          {
-            this.props.article.layout === 'news' &&
+          {isNews && !firstSection &&
             <li
               className='edit-tool__edit-socialembed'
               onClick={() => this.newSection('social_embed')}>
@@ -160,7 +160,7 @@ export class SectionTool extends Component {
 
 const mapStateToProps = (state) => ({
   article: state.edit.article,
-  channel: state.app.channel
+  hasFeatures: state.app.channel.type !== 'partner'
 })
 
 const mapDispatchToProps = {

--- a/client/apps/edit/components/content/section_tool/index.jsx
+++ b/client/apps/edit/components/content/section_tool/index.jsx
@@ -160,7 +160,7 @@ export class SectionTool extends Component {
 
 const mapStateToProps = (state) => ({
   article: state.edit.article,
-  hasFeatures: state.app.channel.type !== 'partner'
+  hasFeatures: state.app.hasFeatures
 })
 
 const mapDispatchToProps = {

--- a/client/apps/edit/components/content/section_tool/test/index.test.js
+++ b/client/apps/edit/components/content/section_tool/test/index.test.js
@@ -28,18 +28,19 @@ describe('SectionTool', () => {
       sections = clone(FeatureArticle.sections)
 
       props = {
-        isEditing: false,
-        isHero: false,
-        section: null,
-        index: sections.length - 1,
-        sections,
-        newSectionAction: jest.fn(),
         article: {
           layout: 'standard'
         },
         channel: {
           type: 'editorial'
-        }
+        },
+        hasFeatures: true,
+        isEditing: false,
+        index: sections.length - 1,
+        isHero: false,
+        newSectionAction: jest.fn(),
+        section: null,
+        sections
       }
     })
 
@@ -60,16 +61,6 @@ describe('SectionTool', () => {
       expect(component.find(IconEditEmbed).exists()).toBe(true)
     })
 
-    it('adds a new section of the correct type on click', () => {
-      const expectedIndex = props.sections.length
-      const component = getWrapper(props)
-
-      component.find('.edit-tool__icon').simulate('click')
-      component.find(IconEditText).simulate('click')
-      expect(props.newSectionAction.mock.calls[0][0]).toBe('text')
-      expect(props.newSectionAction.mock.calls[0][1]).toBe(expectedIndex)
-    })
-
     it('Adds a data-visible prop to the last section tool', () => {
       const component = getWrapper(props)
       expect(component.html()).toMatch('data-visible="true"')
@@ -83,41 +74,140 @@ describe('SectionTool', () => {
       expect(component.html()).toMatch('data-visible="true"')
     })
 
-    it('does not render embed option on lower tier channels', () => {
-      props.channel = {
-        type: 'team'
-      }
-      props.article = { layout: 'news' }
+    describe('Section options', () => {
+      it('Renders correct icons for Classic layout with features', () => {
+        props.article.layout = 'classic'
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
 
-      const component = getWrapper(props)
-      component.find('.edit-tool__icon').simulate('click')
+        expect(component.find(IconEditText).exists()).toBe(true)
+        expect(component.find(IconEditImages).exists()).toBe(true)
+        expect(component.find(IconEditVideo).exists()).toBe(true)
+        expect(component.find(IconEditEmbed).exists()).toBe(true)
+      })
 
-      expect(component.find(IconEditEmbed).length).toBe(1)
+      it('Renders correct icons for Classic layout without features', () => {
+        props.article.layout = 'classic'
+        props.hasFeatures = false
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+
+        expect(component.find(IconEditText).exists()).toBe(true)
+        expect(component.find(IconEditImages).exists()).toBe(true)
+        expect(component.find(IconEditVideo).exists()).toBe(true)
+        expect(component.find(IconEditEmbed).exists()).toBe(false)
+      })
+
+      it('Renders correct icons for Standard layout', () => {
+        props.article.layout = 'standard'
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+
+        expect(component.find(IconEditText).exists()).toBe(true)
+        expect(component.find(IconEditImages).exists()).toBe(true)
+        expect(component.find(IconEditVideo).exists()).toBe(true)
+        expect(component.find(IconEditEmbed).exists()).toBe(true)
+      })
+
+      it('Renders correct icons for Feature layout', () => {
+        props.article.layout = 'feature'
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+
+        expect(component.find(IconEditText).exists()).toBe(true)
+        expect(component.find(IconEditImages).exists()).toBe(true)
+        expect(component.find(IconEditVideo).exists()).toBe(true)
+        expect(component.find(IconEditEmbed).exists()).toBe(true)
+      })
+
+      it('Renders correct icons for News layout', () => {
+        props.article.layout = 'news'
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+
+        expect(component.find(IconEditText).exists()).toBe(true)
+        expect(component.find(IconEditImages).exists()).toBe(true)
+        expect(component.find(IconEditVideo).exists()).toBe(false)
+        expect(component.find(IconEditEmbed).exists()).toBe(true)
+      })
+
+      it('Renders correct icons for first tool in News layout', () => {
+        props.article.layout = 'news'
+        props.firstSection = true
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+
+        expect(component.find(IconEditText).exists()).toBe(true)
+        expect(component.find(IconEditImages).exists()).toBe(true)
+        expect(component.find(IconEditVideo).exists()).toBe(false)
+        expect(component.find(IconEditEmbed).exists()).toBe(false)
+      })
     })
 
-    it('does not render video option on news layouts', () => {
-      props.channel = {
-        type: 'team'
-      }
-      props.article = { layout: 'news' }
+    describe('Section creation', () => {
+      it('Can create a text section', () => {
+        const expectedIndex = props.sections.length
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+        component.find(IconEditText).simulate('click')
 
-      const component = getWrapper(props)
-      component.find('.edit-tool__icon').simulate('click')
+        expect(props.newSectionAction.mock.calls[0][0]).toBe('text')
+        expect(props.newSectionAction.mock.calls[0][1]).toBe(expectedIndex)
+      })
 
-      expect(component.find(IconEditVideo).exists()).toBe(false)
+      it('Can create an image section', () => {
+        const expectedIndex = props.sections.length
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+        component.find(IconEditImages).simulate('click')
+
+        expect(props.newSectionAction.mock.calls[0][0]).toBe('image_collection')
+        expect(props.newSectionAction.mock.calls[0][1]).toBe(expectedIndex)
+      })
+
+      it('Can create a video section', () => {
+        const expectedIndex = props.sections.length
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+        component.find(IconEditVideo).simulate('click')
+
+        expect(props.newSectionAction.mock.calls[0][0]).toBe('video')
+        expect(props.newSectionAction.mock.calls[0][1]).toBe(expectedIndex)
+      })
+
+      it('Can create an embed section', () => {
+        const expectedIndex = props.sections.length
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+        component.find(IconEditEmbed).simulate('click')
+
+        expect(props.newSectionAction.mock.calls[0][0]).toBe('embed')
+        expect(props.newSectionAction.mock.calls[0][1]).toBe(expectedIndex)
+      })
+
+      it('Can create a social embed section', () => {
+        props.article.layout = 'news'
+        const expectedIndex = props.sections.length
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+        component.find(IconEditEmbed).simulate('click')
+
+        expect(props.newSectionAction.mock.calls[0][0]).toBe('social_embed')
+        expect(props.newSectionAction.mock.calls[0][1]).toBe(expectedIndex)
+      })
     })
   })
 
-  describe('SectionTool: Hero', () => {
+  describe('In Hero Section', () => {
     beforeEach(() => {
       props = {
         isEditing: false,
         isHero: true,
-        section: {},
         index: -1,
-        sections: clone(FeatureArticle.sections),
+        newHeroSectionAction: jest.fn(),
         onSetEditing: jest.fn(),
-        newHeroSectionAction: jest.fn()
+        section: {},
+        sections: clone(FeatureArticle.sections)
       }
     })
 
@@ -136,13 +226,25 @@ describe('SectionTool', () => {
       expect(component.find(IconHeroVideo).exists()).toBe(true)
     })
 
-    it('adds a new section of the correct type on click', () => {
-      const component = getWrapper(props)
-      component.find('.edit-tool__icon').simulate('click')
-      component.find(IconHeroImage).simulate('click')
+    describe('Section creation', () => {
 
-      expect(props.newHeroSectionAction.mock.calls[0][0]).toBe('image_collection')
-      expect(props.onSetEditing.mock.calls[0][0]).toBe(true)
+      it('Can create an image section', () => {
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+        component.find(IconHeroImage).simulate('click')
+
+        expect(props.newHeroSectionAction.mock.calls[0][0]).toBe('image_collection')
+        expect(props.onSetEditing.mock.calls[0][0]).toBe(true)
+      })
+
+      it('Can create a video section', () => {
+        const component = getWrapper(props)
+        component.find('.edit-tool__icon').simulate('click')
+        component.find(IconHeroVideo).simulate('click')
+
+        expect(props.newHeroSectionAction.mock.calls[0][0]).toBe('video')
+        expect(props.onSetEditing.mock.calls[0][0]).toBe(true)
+      })
     })
   })
 })

--- a/client/apps/edit/components/content/section_tool/test/index.test.js
+++ b/client/apps/edit/components/content/section_tool/test/index.test.js
@@ -34,7 +34,7 @@ describe('SectionTool', () => {
         channel: {
           type: 'editorial'
         },
-        hasFeatures: true,
+        isPartnerChannel: false,
         isEditing: false,
         index: sections.length - 1,
         isHero: false,
@@ -75,7 +75,7 @@ describe('SectionTool', () => {
     })
 
     describe('Section options', () => {
-      it('Renders correct icons for Classic layout with features', () => {
+      it('Renders correct icons for Classic layout with internal channel features', () => {
         props.article.layout = 'classic'
         const component = getWrapper(props)
         component.find('.edit-tool__icon').simulate('click')
@@ -86,9 +86,9 @@ describe('SectionTool', () => {
         expect(component.find(IconEditEmbed).exists()).toBe(true)
       })
 
-      it('Renders correct icons for Classic layout without features', () => {
+      it('Renders correct icons for Classic layout in partner channel', () => {
         props.article.layout = 'classic'
-        props.hasFeatures = false
+        props.isPartnerChannel = true
         const component = getWrapper(props)
         component.find('.edit-tool__icon').simulate('click')
 

--- a/client/reducers/appReducer.js
+++ b/client/reducers/appReducer.js
@@ -6,6 +6,7 @@ export const initialState = {
   artsyURL: sd.ARTSY_URL,
   channel: sd.CURRENT_CHANNEL,
   forceURL: sd.FORCE_URL,
+  hasFeatures: sd.CURRENT_CHANNEL.type !== 'partner',
   isAdmin: sd.USER.type === 'Admin',
   isEditorial: sd.CURRENT_CHANNEL.type === 'editorial',
   metaphysicsURL: sd.GRAPHQL_ENDPOINT,

--- a/client/reducers/appReducer.js
+++ b/client/reducers/appReducer.js
@@ -6,9 +6,9 @@ export const initialState = {
   artsyURL: sd.ARTSY_URL,
   channel: sd.CURRENT_CHANNEL,
   forceURL: sd.FORCE_URL,
-  hasFeatures: sd.CURRENT_CHANNEL.type !== 'partner',
   isAdmin: sd.USER.type === 'Admin',
   isEditorial: sd.CURRENT_CHANNEL.type === 'editorial',
+  isPartnerChannel: sd.CURRENT_CHANNEL.type === 'partner',
   metaphysicsURL: sd.GRAPHQL_ENDPOINT,
   user: sd.USER
 }


### PR DESCRIPTION
- SectionTool does not show social_embed for first section of news
- SectionList does not allow dragging social_embed to first section of news
- SectionList shows an error message if attempting to drag social_embed to first section
- Adds hasFeatures prop to store.app
- Adds more granular tests for SectionTool