### PR TITLE
@kanaabe => Remove autofocus from artworks autocomplete

### DIFF
--- a/client/apps/edit/components/content/sections/images/components/controls.jsx
+++ b/client/apps/edit/components/content/sections/images/components/controls.jsx
@@ -174,7 +174,6 @@ export class ImagesControls extends Component {
             >
               <Col xs={6}>
                 <Autocomplete
-                  autoFocus
                   disabled={inputsAreDisabled}
                   filter={this.filterAutocomplete}
                   formatSelected={(item) => this.fetchDenormalizedArtwork(item._id)}


### PR DESCRIPTION
Fixes bug where file input does not work because autocomplete is focussed.
https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROWTH&modal=detail&selectedIssue=GROWTH-366