### PR TITLE
@kanaabe => Remove/reset section bugfixes

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -1,5 +1,5 @@
 
-import { clone, cloneDeep, debounce, extend } from 'lodash'
+import { clone, cloneDeep, debounce } from 'lodash'
 import keyMirror from 'client/lib/keyMirror'
 import Article from 'client/models/article.coffee'
 import { emitAction } from 'client/apps/websocket/client'
@@ -244,28 +244,15 @@ export const redirectToList = (published) => {
   }
 }
 
-export const removeSection = (sectionIndex) => ({
-  type: actions.REMOVE_SECTION,
-  payload: {
-    sectionIndex
-  }
-})
-
-export const resetSections = (sections) => {
+export const removeSection = (sectionIndex) => {
   return (dispatch, getState) => {
     const { edit: { article } } = getState()
-    const newArticle = extend(cloneDeep(article), { sections })
+    const newArticle = cloneDeep(article)
 
-    dispatch(onResetSections(newArticle))
+    newArticle.sections.splice(sectionIndex, 1)
+    dispatch(onChangeArticle('sections', newArticle.sections))
   }
 }
-
-export const onResetSections = (article) => ({
-  type: actions.RESET_SECTIONS,
-  payload: {
-    article
-  }
-})
 
 export const saveArticle = () => {
   return (dispatch, getState) => {

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -402,6 +402,32 @@ describe('editActions', () => {
     })
   })
 
+  describe('#newHeroSection', () => {
+    let getState
+    let dispatch
+
+    beforeEach(() => {
+      getState = jest.fn(() => ({edit: { article }}))
+      dispatch = jest.fn()
+    })
+
+    it('Can create an image_collection section', () => {
+      editActions.newHeroSection('image_collection')(dispatch, getState)
+
+      expect(dispatch.mock.calls[0][0].type).toBe('CHANGE_ARTICLE')
+      expect(dispatch.mock.calls[0][0].payload.key).toBe('hero_section')
+      expect(dispatch.mock.calls[0][0].payload.value.type).toBe('image_collection')
+    })
+
+    it('Can create a video section', () => {
+      editActions.newHeroSection('video')(dispatch, getState)
+
+      expect(dispatch.mock.calls[0][0].type).toBe('CHANGE_ARTICLE')
+      expect(dispatch.mock.calls[0][0].payload.key).toBe('hero_section')
+      expect(dispatch.mock.calls[0][0].payload.value.type).toBe('video')
+    })
+  })
+
   it('#removeSection calls #onChangeArticle with new sections', () => {
     let dispatch = jest.fn()
     let getState = jest.fn(() => ({edit: { article }, app: {channel: { type: 'editorial' }}}))
@@ -433,7 +459,49 @@ describe('editActions', () => {
     })
   })
 
-  describe('#onAddFeaturedItem', () => {})
-  describe('#setMentionedItems', () => {})
-  describe('#newHeroSection', () => {})
+  describe('#onAddFeaturedItem', () => {
+    let getState
+    let dispatch
+
+    beforeEach(() => {
+      getState = jest.fn(() => ({edit: { article }}))
+      dispatch = jest.fn()
+    })
+
+    it('Can add a featured artist', () => {
+      editActions.onAddFeaturedItem('artist', {_id: '123'})(dispatch, getState)
+
+      expect(dispatch.mock.calls[0][0].type).toBe('CHANGE_ARTICLE')
+      expect(dispatch.mock.calls[0][0].payload.key).toBe('primary_featured_artist_ids')
+      expect(dispatch.mock.calls[0][0].payload.value[0]).toBe('123')
+    })
+
+    it('Can add a featured artwork', () => {
+      editActions.onAddFeaturedItem('artwork', {_id: '123'})(dispatch, getState)
+
+      expect(dispatch.mock.calls[0][0].type).toBe('CHANGE_ARTICLE')
+      expect(dispatch.mock.calls[0][0].payload.key).toBe('featured_artwork_ids')
+      expect(dispatch.mock.calls[0][0].payload.value[0]).toBe('123')
+    })
+  })
+
+  describe('#setMentionedItems', () => {
+    it('Can set mentioned artists', () => {
+      const items = [{name: 'Joseph Beuys', _id: '123'}]
+      const action = editActions.setMentionedItems('artist', items)
+
+      expect(action.type).toBe('SET_MENTIONED_ITEMS')
+      expect(action.payload.model).toBe('artist')
+      expect(action.payload.items[0]).toBe(items[0])
+    })
+
+    it('Can set mentioned artworks', () => {
+      const items = [{title: 'Stripes', _id: '123'}]
+      const action = editActions.setMentionedItems('artwork', items)
+
+      expect(action.type).toBe('SET_MENTIONED_ITEMS')
+      expect(action.payload.model).toBe('artwork')
+      expect(action.payload.items[0]).toBe(items[0])
+    })
+  })
 })

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -402,30 +402,17 @@ describe('editActions', () => {
     })
   })
 
-  it('#removeSection sets sectionIndex to index', () => {
-    const action = editActions.removeSection(6)
+  it('#removeSection calls #onChangeArticle with new sections', () => {
+    let dispatch = jest.fn()
+    let getState = jest.fn(() => ({edit: { article }, app: {channel: { type: 'editorial' }}}))
+    editActions.removeSection(6)(dispatch, getState)
+    dispatch.mock.calls[0][0](dispatch, getState)
 
-    expect(action.type).toBe('REMOVE_SECTION')
-    expect(action.payload.sectionIndex).toBe(6)
-  })
-
-  describe('#publishArticle', () => {
-    let getState
-    let dispatch
-
-    beforeEach(() => {
-      getState = jest.fn(() => ({edit: { article }}))
-      dispatch = jest.fn()
-    })
-
-    it('#resetSections sets sections to arg', () => {
-      const sections = [{title: 'Cool exhibition'}]
-      getState = jest.fn((article) => ({edit: {article: {published: false}}}))
-      editActions.resetSections(sections)(dispatch, getState)
-
-      expect(dispatch.mock.calls[0][0].type).toBe('RESET_SECTIONS')
-      expect(dispatch.mock.calls[0][0].payload.article.sections).toBe(sections)
-    })
+    expect(dispatch.mock.calls[1][0].type).toBe('CHANGE_ARTICLE')
+    expect(dispatch.mock.calls[1][0].payload.key).toBe('sections')
+    expect(dispatch.mock.calls[1][0].payload.value[6].body).toBe(article.sections[7].body)
+    expect(dispatch.mock.calls[1][0].payload.value[5].body).toBe(article.sections[5].body)
+    expect(dispatch.mock.calls[1][0].payload.value.length).toBe(article.sections.length - 1)
   })
 
   describe('Editing errors', () => {
@@ -445,4 +432,8 @@ describe('editActions', () => {
       expect(action.payload.error).toBe(null)
     })
   })
+
+  describe('#onAddFeaturedItem', () => {})
+  describe('#setMentionedItems', () => {})
+  describe('#newHeroSection', () => {})
 })

--- a/client/apps/edit/components/content/section_list/index.jsx
+++ b/client/apps/edit/components/content/section_list/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { compact } from 'lodash'
 import { connect } from 'react-redux'
-import { logError, resetSections, setSection } from 'client/actions/editActions'
+import { logError, onChangeArticle, setSection } from 'client/actions/editActions'
 import SectionContainer from '../section_container'
 import SectionTool from '../section_tool'
 import DragContainer from 'client/components/drag_drop/index.coffee'
@@ -12,7 +12,7 @@ export class SectionList extends Component {
     article: PropTypes.object,
     editSection: PropTypes.object,
     logErrorAction: PropTypes.func,
-    resetSectionsAction: PropTypes.func,
+    onChangeArticleAction: PropTypes.func,
     sectionIndex: PropTypes.any,
     setSectionAction: PropTypes.func
   }
@@ -28,7 +28,7 @@ export class SectionList extends Component {
     const {
       article: { layout },
       logErrorAction,
-      resetSectionsAction
+      onChangeArticleAction
     } = this.props
 
     if (newSections[0].type === 'social_embed' && layout === 'news') {
@@ -36,7 +36,7 @@ export class SectionList extends Component {
         message: 'Embeds are not allowed in the first section.'
       })
     }
-    resetSectionsAction(compact(newSections))
+    onChangeArticleAction('sections', compact(newSections))
   }
 
   renderSectionList = () => {
@@ -115,7 +115,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = {
   logErrorAction: logError,
-  resetSectionsAction: resetSections,
+  onChangeArticleAction: onChangeArticle,
   setSectionAction: setSection
 }
 

--- a/client/apps/edit/components/content/section_list/test/index.test.jsx
+++ b/client/apps/edit/components/content/section_list/test/index.test.jsx
@@ -38,7 +38,7 @@ describe('SectionList', () => {
     props = {
       article,
       logErrorAction: jest.fn(),
-      resetSectionsAction: jest.fn(),
+      onChangeArticleAction: jest.fn(),
       sectionIndex: null,
       setSectionAction: jest.fn()
     }
@@ -95,6 +95,6 @@ describe('SectionList', () => {
     expect(props.logErrorAction.mock.calls[0][0].message).toBe(
       'Embeds are not allowed in the first section.'
     )
-    expect(props.resetSectionsAction).not.toBeCalled()
+    expect(props.onChangeArticleAction).not.toBeCalled()
   })
 })

--- a/client/reducers/editReducer.js
+++ b/client/reducers/editReducer.js
@@ -124,28 +124,6 @@ export function editReducer (state = initialState, action) {
       }, state)
     }
 
-    case actions.REMOVE_SECTION: {
-      const { sectionIndex } = action.payload
-      const article = cloneDeep(state.article)
-
-      article.sections.splice(sectionIndex, 1)
-      return u({
-        article,
-        sectionIndex: null,
-        section: null,
-        isSaved: false
-      }, state)
-    }
-
-    case actions.RESET_SECTIONS: {
-      const { article } = action.payload
-
-      return u({
-        article,
-        isSaved: false
-      }, state)
-    }
-
     case actions.SAVE_ARTICLE: {
       return u({
         isSaving: true

--- a/client/reducers/tests/editReducer.test.js
+++ b/client/reducers/tests/editReducer.test.js
@@ -110,35 +110,5 @@ describe('editReducer', () => {
       expect(updatedState.section.body).toMatch(value)
       expect(updatedState.article.sections[0].body).toMatch(value)
     })
-
-    it('REMOVE_SECTION should remove a section by index', () => {
-      const sectionIndex = 2
-      const updatedState = editReducer(initialState, {
-        type: actions.REMOVE_SECTION,
-        payload: {
-          sectionIndex
-        }
-      })
-      expect(updatedState.section).toBe(null)
-      expect(updatedState.sectionIndex).toBe(null)
-      expect(updatedState.article.sections.length).toBe(
-        initialSections.length - 1
-      )
-      expect(updatedState.article.sections[2]).not.toEqual(
-        initialSections[2]
-      )
-    })
-
-    it('RESET_SECTIONS should reset the sections to provided array', () => {
-      const sections = initialSections.slice(1, 3)
-      const updatedState = editReducer(initialState, {
-        type: actions.RESET_SECTIONS,
-        payload: {
-          article: { sections }
-        }
-      })
-
-      expect(updatedState.article.sections.length).not.toEqual(initialSections.length)
-    })
   })
 })


### PR DESCRIPTION
RemoveSection and ResetSection actions were updating the store, but didn't loop in the ChangeArticle action, meaning they skipped the auto-save set (part of the disappearing/duplicating sections problem).

- Removes `ResetSection` action, instead calling `onChangeArticle` with new sections
- `RemoveSection` action calls `onChangeArticle` with new sections, rather than updating store directly
- Also adds some unit tests to `editActions` for 3 functions that did not have coverage (maybe somehow got overwritten in the edit/edit2 merge) 