### PR TITLE
@l2succes => Debounces UPDATE_ARTICLE (getSessions)

### DIFF
--- a/client/actions/editActions.js
+++ b/client/actions/editActions.js
@@ -137,6 +137,10 @@ const debouncedSaveDispatch = debounce((dispatch) => {
   dispatch(saveArticle())
 }, 500)
 
+const debouncedUpdateDispatch = debounce((dispatch, options) => {
+  dispatch(updateArticle(options))
+}, 500)
+
 export const onChangeArticle = (key, value) => {
   return (dispatch, getState) => {
     const {
@@ -145,10 +149,8 @@ export const onChangeArticle = (key, value) => {
     } = getState()
 
     dispatch(changeArticle(key, value))
-    dispatch(updateArticle({
-      channel,
-      article: article.id
-    }))
+
+    debouncedUpdateDispatch(dispatch, { channel, article: article.id })
 
     if (!article.published) {
       debouncedSaveDispatch(dispatch)

--- a/client/actions/test/editActions.test.js
+++ b/client/actions/test/editActions.test.js
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash'
 import Backbone from 'backbone'
 import { Fixtures } from '@artsy/reaction/dist/Components/Publishing'
 import Article from 'client/models/article.coffee'
+import $ from 'jquery'
 const { FeatureArticle } = Fixtures
 
 describe('editActions', () => {
@@ -43,17 +44,19 @@ describe('editActions', () => {
       expect(dispatch.mock.calls[0][0].payload.value).toBe('New Title')
     })
 
-    it('calls #updateArticle with new attrs', () => {
+    it('calls debounced #updateArticle with new attrs', (done) => {
       editActions.onChangeArticle('title', 'New Title')(dispatch, getState)
-
-      expect(dispatch.mock.calls[1][0].type).toBe('UPDATE_ARTICLE')
-      expect(dispatch.mock.calls[1][0].key).toBe('userCurrentlyEditing')
-      expect(dispatch.mock.calls[1][0].payload.article).toBe(article.id)
+      setTimeout(() => {
+        expect(dispatch.mock.calls[1][0].type).toBe('UPDATE_ARTICLE')
+        expect(dispatch.mock.calls[1][0].key).toBe('userCurrentlyEditing')
+        expect(dispatch.mock.calls[1][0].payload.article).toBe(article.id)
+        done()
+      }, 550)
     })
 
     it('does not call #saveArticle if published', () => {
       editActions.onChangeArticle('title', 'New Title')(dispatch, getState)
-      expect(dispatch.mock.calls.length).toBe(2)
+      expect(dispatch.mock.calls.length).toBe(1)
     })
 
     it('calls debounced #saveArticle if draft', (done) => {
@@ -63,9 +66,9 @@ describe('editActions', () => {
       editActions.onChangeArticle('title', 'New')(dispatch, getState)
 
       setTimeout(() => {
-        expect(dispatch.mock.calls.length).toBe(7)
+        expect(dispatch.mock.calls.length).toBe(5)
         done()
-      }, 600)
+      }, 550)
     })
   })
 
@@ -105,7 +108,7 @@ describe('editActions', () => {
       setTimeout(() => {
         expect(dispatch.mock.calls.length).toBe(4)
         done()
-      }, 600)
+      }, 550)
     })
   })
 
@@ -145,7 +148,7 @@ describe('editActions', () => {
       setTimeout(() => {
         expect(dispatch.mock.calls.length).toBe(4)
         done()
-      }, 600)
+      }, 550)
     })
   })
 


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROWTH-360

Debounce the dispatch that takes care of keeping session info updated so it doesn't fire on every keystroke! 