### PR TITLE
Jest: Re-add --runInBand

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,4 +6,4 @@ yarn assets
 yarn mocha $(find src/api -name '*.test.coffee')
 yarn mocha $(find src/api -name '*.test.js')
 yarn mocha $(find src/client -name '*.test.coffee')
-yarn jest --forceExit
+yarn jest --runInBand --forceExit


### PR DESCRIPTION
From looking at https://1670-23808195-gh.circle-artifacts.com/0/tmp/memory-usage.txt remembered why we initially added this a while back -- this prevents zombie process from spinning up. 