### PR TITLE
@sarahscott => Do not show layout buttons for news

### DIFF
--- a/src/client/apps/edit/components/admin/components/article/index.jsx
+++ b/src/client/apps/edit/components/admin/components/article/index.jsx
@@ -109,6 +109,7 @@ export class AdminArticle extends Component {
             </Row>
 
             {channel.type === 'editorial' &&
+             article.layout !== 'news' &&
               <div className='field-group'>
                 <label>Article Layout</label>
                 <ButtonGroup>

--- a/src/client/apps/edit/components/admin/test/components/article/index.test.js
+++ b/src/client/apps/edit/components/admin/test/components/article/index.test.js
@@ -97,6 +97,15 @@ describe('AdminArticle', () => {
       expect(component.find('button').at(5).text()).toBe('Feature')
     })
 
+    it('if news layout, does not render layout buttons', () => {
+      props.article.layout = 'news'
+      const component = getWrapper(props)
+
+      expect(component.html()).not.toMatch('Article Layout')
+      expect(component.html()).not.toMatch('Standard')
+      expect(component.html()).not.toMatch('Feature')
+    })
+
     it('If not editorial, does not render layout buttons', () => {
       props.channel.type = 'partner'
       const component = getWrapper(props)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,7 +1013,6 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/e6a20591a6be418facca1b4670db24f11208cfdd"
   dependencies:
-    coffeescript "1.11.1"
     express "*"
 
 anymatch@^1.3.0:


### PR DESCRIPTION
Removes toggle from 'standard' to 'feature' layout from Admin panel for articles with 'news' layout.