### PR TITLE
@damassi => Add query for articles in editorial/read-more stream

### DIFF
--- a/src/api/apps/articles/model/retrieve.coffee
+++ b/src/api/apps/articles/model/retrieve.coffee
@@ -32,6 +32,7 @@ moment = require 'moment'
     'scheduled'
     'access_token'
     'omit'
+    'in_editorial_feed'
   query.fair_ids = input.fair_id if input.fair_id
   if input.fair_programming_id
     query.fair_programming_ids = input.fair_programming_id
@@ -82,6 +83,10 @@ moment = require 'moment'
   # Find articles that contain fair_ids
   if input.fair_ids
     query.fair_ids = { $elemMatch: { $in: input.fair_ids } }
+
+  # Convert query for articles in editorial feed
+  if input.in_editorial_feed
+    query.layout = { $in: ["feature", "standard", "series", "video"] }
 
   # Convert query for articles by vertical
   query["vertical.id"] = input.vertical if input.vertical

--- a/src/api/apps/articles/model/schema.coffee
+++ b/src/api/apps/articles/model/schema.coffee
@@ -273,6 +273,7 @@ ImageCollectionSection = (->
   featured: @boolean()
   has_video: @boolean()
   indexable: @boolean()
+  in_editorial_feed: @boolean()
   is_super_article: @boolean()
   layout: @string()
   limit: @number().max(Number API_MAX).default(Number API_PAGE_SIZE)

--- a/src/api/apps/articles/test/model/retrieve.test.coffee
+++ b/src/api/apps/articles/test/model/retrieve.test.coffee
@@ -95,6 +95,16 @@ describe 'Retrieve', ->
       query._id['$in'][0].should.containEql ObjectId '54276766fd4f50996aeca2b8'
       query._id['$in'][1].should.containEql ObjectId '54276766fd4f50996aeca2b7'
 
+    it 'finds articles in editorial feed', ->
+      { query } = Retrieve.toQuery {
+        in_editorial_feed: true
+      }
+      query.layout['$in'].should.be.ok()
+      query.layout['$in'][0].should.containEql 'feature'
+      query.layout['$in'][1].should.containEql 'standard'
+      query.layout['$in'][2].should.containEql 'series'
+      query.layout['$in'][3].should.containEql 'video'
+
     it 'finds scheduled articles', ->
       { query } = Retrieve.toQuery {
         scheduled: true


### PR DESCRIPTION
Related to [GROW-426](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-426)

Adds boolean query field, `in_magazine_feed` to articles API, which returns articles in 'standard' or 'feature' layouts.  This will be used to exclude news/video/series from the "More from Artsy Editorial" canvas on `/news` pages, and potentially used to simplify some other fetches down the road such as infinite scroll on article pages. 