### PR TITLE
@damassi => Use in_editorial_feed in relatedArticlesCanvas resolver

### DIFF
--- a/src/api/apps/graphql/resolvers.js
+++ b/src/api/apps/graphql/resolvers.js
@@ -238,6 +238,7 @@ export const relatedArticlesCanvas = (root) => {
     omit: [ObjectId(root.id)],
     published: true,
     featured: true,
+    in_editorial_feed: true,
     channel_id: ObjectId(root.channel_id),
     vertical,
     limit: 4,

--- a/src/test/helpers/fixtures.coffee
+++ b/src/test/helpers/fixtures.coffee
@@ -12,6 +12,7 @@ module.exports = ->
   fixtures.articles =
     id: '54276766fd4f50996aeca2b8'
     author_id: ObjectId('4d8cd73191a5c50ce210002a')
+    layout: 'standard'
     thumbnail_title: 'Top Ten Booths at miart 2014',
     thumbnail_teaser: 'Look here! Before the lines start forming...',
     thumbnail_image: 'http://kitten.com',


### PR DESCRIPTION
Related to https://github.com/artsy/positron/pull/1669

Adds `in_editorial_feed` to relatedArticlesCanvas query args