### PR TITLE
@damassi => Exclude unused fields from news admin

### DIFF
--- a/src/client/apps/edit/components/admin/components/article/article_authors.jsx
+++ b/src/client/apps/edit/components/admin/components/article/article_authors.jsx
@@ -101,14 +101,15 @@ export class ArticleAuthors extends Component {
               />
             </div>
           }
-
-          <div className='field-group'>
-            <AutocompleteListMetaphysics
-              field='contributing_authors'
-              label='Contributing Authors'
-              model='users'
-            />
-          </div>
+          {article.layout !== 'news' &&
+            <div className='field-group'>
+              <AutocompleteListMetaphysics
+                field='contributing_authors'
+                label='Contributing Authors'
+                model='users'
+              />
+            </div>
+          }
         </Col>
       </Row>
     )

--- a/src/client/apps/edit/components/admin/components/article/index.jsx
+++ b/src/client/apps/edit/components/admin/components/article/index.jsx
@@ -66,47 +66,48 @@ export class AdminArticle extends Component {
 
         <Row>
           <Col xs={6}>
-            <Row>
-              <Col xs={6}>
-                <div className='field-group'>
-                  <label>Article Tier</label>
-                  <ButtonGroup>
-                    <Button
-                      active={article.tier === 1}
-                      onClick={() => onChangeArticleAction('tier', 1)}
-                    >
-                      Tier 1
-                    </Button>
-                    <Button
-                      active={article.tier === 2}
-                      onClick={() => onChangeArticleAction('tier', 2)}
-                    >
-                      Tier 2
-                    </Button>
-                  </ButtonGroup>
-                </div>
-              </Col>
-
-              <Col xs={6}>
-                <div className='field-group'>
-                  <label>Magazine Feed</label>
-                  <ButtonGroup>
-                    <Button
-                      active={article.featured}
-                      onClick={() => onChangeArticleAction('featured', true)}
-                    >
-                      Yes
-                    </Button>
-                    <Button
-                      active={!article.featured}
-                      onClick={() => onChangeArticleAction('featured', false)}
-                    >
-                      No
-                    </Button>
-                  </ButtonGroup>
-                </div>
-              </Col>
-            </Row>
+            {article.layout !== 'news' &&
+              <Row>
+                <Col xs={6}>
+                  <div className='field-group'>
+                    <label>Article Tier</label>
+                    <ButtonGroup>
+                      <Button
+                        active={article.tier === 1}
+                        onClick={() => onChangeArticleAction('tier', 1)}
+                      >
+                        Tier 1
+                      </Button>
+                      <Button
+                        active={article.tier === 2}
+                        onClick={() => onChangeArticleAction('tier', 2)}
+                      >
+                        Tier 2
+                      </Button>
+                    </ButtonGroup>
+                  </div>
+                </Col>
+                <Col xs={6}>
+                  <div className='field-group'>
+                    <label>Magazine Feed</label>
+                    <ButtonGroup>
+                      <Button
+                        active={article.featured}
+                        onClick={() => onChangeArticleAction('featured', true)}
+                      >
+                        Yes
+                      </Button>
+                      <Button
+                        active={!article.featured}
+                        onClick={() => onChangeArticleAction('featured', false)}
+                      >
+                        No
+                      </Button>
+                    </ButtonGroup>
+                  </div>
+                </Col>
+              </Row>
+            }
 
             {channel.type === 'editorial' &&
              article.layout !== 'news' &&

--- a/src/client/apps/edit/components/admin/index.jsx
+++ b/src/client/apps/edit/components/admin/index.jsx
@@ -12,30 +12,41 @@ import AdminVerticalsTags from './components/verticals_tags'
 
 export class EditAdmin extends Component {
   static propTypes = {
-    channel: PropTypes.object
+    isNews: PropTypes.bool,
+    isEditorial: PropTypes.bool
   }
 
   getSections = () => {
-    const { channel } = this.props
-    const sections = [
-      {title: 'Tags'},
-      {title: 'Article'},
-      {title: 'Featuring'},
-      {title: 'Additional Appearances'}
-    ]
+    const { isNews, isEditorial } = this.props
 
-    if (channel.type === 'editorial') {
-      sections.push({title: 'Super Article'})
-      sections.push({title: 'Sponsor'})
-      sections[0].title = 'Verticals & Tagging'
+    if (isNews) {
+      return [
+        {title: 'Verticals & Tagging'},
+        {title: 'Article'},
+        {title: 'Featuring'}
+      ]
+    } else if (isEditorial) {
+      return [
+        {title: 'Verticals & Tagging'},
+        {title: 'Article'},
+        {title: 'Featuring'},
+        {title: 'Additional Appearances'},
+        {title: 'Super Article'},
+        {title: 'Sponsor'}
+      ]
+    } else {
+      return [
+        {title: 'Tags'},
+        {title: 'Article'},
+        {title: 'Featuring'},
+        {title: 'Additional Appearances'}
+      ]
     }
-    return sections
   }
 
   render () {
-    const { channel } = this.props
+    const { isNews, isEditorial } = this.props
     const sections = this.getSections()
-    const isEditorial = channel.type === 'editorial'
 
     return (
       <div className='EditAdmin'>
@@ -55,12 +66,13 @@ export class EditAdmin extends Component {
 
           <AdminFeaturing />
 
-          <AdminAppearances />
-
-          {isEditorial &&
+          {!isNews &&
+            <AdminAppearances />
+          }
+          {isEditorial && !isNews &&
             <AdminSuperArticle />
           }
-          {isEditorial &&
+          {isEditorial && !isNews &&
             <AdminSponsor />
           }
         </DropDownList>
@@ -70,7 +82,8 @@ export class EditAdmin extends Component {
 }
 
 const mapStateToProps = (state) => ({
-  channel: state.app.channel
+  isNews: state.edit.article.layout === 'news',
+  isEditorial: state.app.channel.type === 'editorial'
 })
 
 export default connect(

--- a/src/client/apps/edit/components/admin/test/components/article/article_authors.test.js
+++ b/src/client/apps/edit/components/admin/test/components/article/article_authors.test.js
@@ -83,6 +83,12 @@ describe('ArticleAuthors', () => {
     expect(component.find(AutocompleteListMetaphysics).length).toBe(1)
   })
 
+  it('Does not render contributing authors if layout is news', () => {
+    props.article.layout = 'news'
+    const component = getWrapper(props)
+    expect(component.find(AutocompleteListMetaphysics).length).toBeFalsy()
+  })
+
   it('#fetchAuthors fetches authors', () => {
     props.article.author_ids = ['123']
     const callback = jest.fn()

--- a/src/client/apps/edit/components/admin/test/components/article/index.test.js
+++ b/src/client/apps/edit/components/admin/test/components/article/index.test.js
@@ -81,12 +81,28 @@ describe('AdminArticle', () => {
       expect(component.find('button').at(1).text()).toBe('Tier 2')
     })
 
+    it('if news layout, does not render tier buttons', () => {
+      props.article.layout = 'news'
+      const component = getWrapper(props)
+
+      expect(component.html()).not.toMatch('Article Tier')
+      expect(component.find('button').length).toBe(1)
+    })
+
     it('Renders featured/magazine buttons', () => {
       const component = getWrapper(props)
 
       expect(component.html()).toMatch('Magazine Feed')
       expect(component.find('button').at(2).text()).toBe('Yes')
       expect(component.find('button').at(3).text()).toBe('No')
+    })
+
+    it('if news layout, does not render featured/magazine buttons', () => {
+      props.article.layout = 'news'
+      const component = getWrapper(props)
+
+      expect(component.html()).not.toMatch('Magazine Feed')
+      expect(component.find('button').length).toBe(1)
     })
 
     it('Renders layout buttons if editorial', () => {

--- a/src/client/apps/edit/components/admin/test/index.test.js
+++ b/src/client/apps/edit/components/admin/test/index.test.js
@@ -5,6 +5,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { Fixtures } from '@artsy/reaction/dist/Components/Publishing'
 import { DropDownList } from 'client/components/drop_down/drop_down_list'
+import { AdminArticle } from '../components/article'
 import { AdminTags } from '../components/tags'
 import { AdminVerticalsTags } from '../components/verticals_tags'
 import { EditAdmin } from '../index.jsx'
@@ -53,19 +54,44 @@ describe('EditAdmin', () => {
     expect(component.find(DropDownList).exists()).toBe(true)
   })
 
-  it('Renders editorial sections', () => {
+  it('Renders correct section for editorial', () => {
+    props.isEditorial = true
     const component = getWrapper(props)
 
+    expect(component.find(AdminArticle).exists()).toBe(true)
     expect(component.find(AdminVerticalsTags).exists()).toBe(true)
+    expect(component.html()).toMatch('Featuring')
+    expect(component.html()).toMatch('Additional Appearances')
     expect(component.html()).toMatch('Super Article')
     expect(component.html()).toMatch('Sponsor')
+
+    expect(component.find(AdminTags).exists()).toBe(false)
+  })
+
+  it('Renders correct section for editorial news', () => {
+    props.isEditorial = true
+    props.isNews = true
+    const component = getWrapper(props)
+
+    expect(component.find(AdminArticle).exists()).toBe(true)
+    expect(component.find(AdminVerticalsTags).exists()).toBe(true)
+    expect(component.html()).toMatch('Featuring')
+
+    expect(component.find(AdminTags).exists()).toBe(false)
+    expect(component.html()).not.toMatch('Additional Appearances')
+    expect(component.html()).not.toMatch('Super Article')
+    expect(component.html()).not.toMatch('Sponsor')
   })
 
   it('Renders correct sections for non-editorial channels', () => {
     props.channel.type = 'partner'
     const component = getWrapper(props)
 
+    expect(component.find(AdminArticle).exists()).toBe(true)
     expect(component.find(AdminTags).exists()).toBe(true)
+    expect(component.html()).toMatch('Featuring')
+    expect(component.html()).toMatch('Additional Appearances')
+
     expect(component.find(AdminVerticalsTags).exists()).toBe(false)
     expect(component.html()).not.toMatch('Super Article')
     expect(component.html()).not.toMatch('Sponsor')


### PR DESCRIPTION
Removes fields from Admin panel that are not used in News articles. 
Related to [GROW-433](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-433)