### PR TITLE
@kanaabe => Updates to Sailthru distribution

### DIFF
--- a/src/api/apps/articles/model/distribute.coffee
+++ b/src/api/apps/articles/model/distribute.coffee
@@ -56,7 +56,6 @@ getArticleUrl = (article) ->
 postSailthruAPI = (article, cb) ->
   return cb() if article.scheduled_publish_at
   tags = ['article']
-  tags = tags.concat ['magazine'] if article.featured is true
   tags = tags.concat article.keywords if article.keywords
   tags = tags.concat article.tracking_tags if article.tracking_tags
   tags = tags.concat article.vertical.name if article.vertical

--- a/src/api/apps/articles/model/distribute.coffee
+++ b/src/api/apps/articles/model/distribute.coffee
@@ -45,6 +45,14 @@ cleanArticlesInSailthru = (slugs = []) =>
       unless i is slugs.length - 1
         @deleteArticleFromSailthru slug, ->
 
+getArticleUrl = (article) ->
+  switch article.layout
+    when 'classic', 'feature', 'standard'
+      layout = 'article'
+    else
+      layout = article.layout
+  return "#{FORCE_URL}/#{layout}/#{_.last(article.slugs)}"
+
 postSailthruAPI = (article, cb) ->
   return cb() if article.scheduled_publish_at
   tags = ['article']
@@ -58,7 +66,7 @@ postSailthruAPI = (article, cb) ->
     thumb: url: crop(imageSrc, { width: 900, height: 530 } )
   html = if article.send_body then getTextSections(article) else ''
   sailthru.apiPost 'content',
-  url: "#{FORCE_URL}/article/#{_.last(article.slugs)}"
+  url: getArticleUrl article
   date: article.published_at
   title: article.email_metadata?.headline
   author: article.email_metadata?.author
@@ -66,11 +74,12 @@ postSailthruAPI = (article, cb) ->
   images: images
   spider: 0
   vars:
-    html: html
     custom_text: article.email_metadata?.custom_text
     daily_email: article.daily_email
-    weekly_email: article.weekly_email
+    html: html
+    layout: article.layout
     vertical: article.vertical?.name
+    weekly_email: article.weekly_email
   , (err, response) ->
     if err
       debug err

--- a/src/api/apps/articles/model/distribute.coffee
+++ b/src/api/apps/articles/model/distribute.coffee
@@ -56,6 +56,7 @@ getArticleUrl = (article) ->
 postSailthruAPI = (article, cb) ->
   return cb() if article.scheduled_publish_at
   tags = ['article']
+  tags = tags.concat 'artsy-editorial' if article.channel_id?.toString() is EDITORIAL_CHANNEL
   tags = tags.concat article.keywords if article.keywords
   tags = tags.concat article.tracking_tags if article.tracking_tags
   tags = tags.concat article.vertical.name if article.vertical

--- a/src/api/apps/articles/test/model/distribute.test.coffee
+++ b/src/api/apps/articles/test/model/distribute.test.coffee
@@ -32,6 +32,54 @@ describe 'Save', ->
   describe '#distributeArticle', ->
 
     describe 'sends article to sailthru', ->
+      describe 'article url', ->
+        article = {}
+
+        beforeEach ->
+          article = {
+            author_id: '5086df098523e60002000018'
+            published: true
+            slugs: [
+              'artsy-editorial-slug-one'
+              'artsy-editorial-slug-two'
+            ]
+          }
+
+        it 'constructs the url for classic articles', (done) ->
+          article.layout = 'classic'
+          Distribute.distributeArticle article, (err, article) =>
+          @sailthru.apiPost.args[0][1].url.should.containEql('article/artsy-editorial-slug-two')
+          done()
+
+        it 'constructs the url for standard articles', (done) ->
+          article.layout = 'standard'
+          Distribute.distributeArticle article, (err, article) =>
+          @sailthru.apiPost.args[0][1].url.should.containEql('article/artsy-editorial-slug-two')
+          done()
+
+        it 'constructs the url for feature articles', (done) ->
+          article.layout = 'feature'
+          Distribute.distributeArticle article, (err, article) =>
+          @sailthru.apiPost.args[0][1].url.should.containEql('article/artsy-editorial-slug-two')
+          done()
+
+        it 'constructs the url for series articles', (done) ->
+          article.layout = 'series'
+          Distribute.distributeArticle article, (err, article) =>
+          @sailthru.apiPost.args[0][1].url.should.containEql('series/artsy-editorial-slug-two')
+          done()
+
+        it 'constructs the url for video articles', (done) ->
+          article.layout = 'video'
+          Distribute.distributeArticle article, (err, article) =>
+          @sailthru.apiPost.args[0][1].url.should.containEql('video/artsy-editorial-slug-two')
+          done()
+
+        it 'constructs the url for news articles', (done) ->
+          article.layout = 'news'
+          Distribute.distributeArticle article, (err, article) =>
+          @sailthru.apiPost.args[0][1].url.should.containEql('news/artsy-editorial-slug-two')
+          done()
 
       it 'concats the article tag for a normal article', (done) ->
         Distribute.distributeArticle {
@@ -75,6 +123,16 @@ describe 'Save', ->
         }, (err, article) =>
           @sailthru.apiPost.calledOnce.should.be.true()
           @sailthru.apiPost.args[0][1].vars.vertical.should.equal 'culture'
+          done()
+
+      it 'sends layout as a custom variable', (done) ->
+        Distribute.distributeArticle {
+          author_id: '5086df098523e60002000018'
+          published: true
+          layout: 'news'
+        }, (err, article) =>
+          @sailthru.apiPost.calledOnce.should.be.true()
+          @sailthru.apiPost.args[0][1].vars.layout.should.equal 'news'
           done()
 
       it 'concats the artsy-editorial and magazine tags for specialized articles', (done) ->

--- a/src/api/apps/articles/test/model/distribute.test.coffee
+++ b/src/api/apps/articles/test/model/distribute.test.coffee
@@ -135,7 +135,7 @@ describe 'Save', ->
           @sailthru.apiPost.args[0][1].vars.layout.should.equal 'news'
           done()
 
-      it 'concats the artsy-editorial and magazine tags for specialized articles', (done) ->
+      it 'concats artsy-editorial for specialized articles', (done) ->
         Distribute.distributeArticle {
           author_id: '5086df098523e60002000018'
           published: true
@@ -143,7 +143,6 @@ describe 'Save', ->
         }, (err, article) =>
           @sailthru.apiPost.calledOnce.should.be.true()
           @sailthru.apiPost.args[0][1].tags.should.containEql 'article'
-          @sailthru.apiPost.args[0][1].tags.should.containEql 'magazine'
           done()
 
       it 'concats the keywords at the end', (done) ->
@@ -155,10 +154,9 @@ describe 'Save', ->
         }, (err, article) =>
           @sailthru.apiPost.calledOnce.should.be.true()
           @sailthru.apiPost.args[0][1].tags[0].should.equal 'article'
-          @sailthru.apiPost.args[0][1].tags[1].should.equal 'magazine'
-          @sailthru.apiPost.args[0][1].tags[2].should.equal 'sofa'
-          @sailthru.apiPost.args[0][1].tags[3].should.equal 'midcentury'
-          @sailthru.apiPost.args[0][1].tags[4].should.equal 'knoll'
+          @sailthru.apiPost.args[0][1].tags[1].should.equal 'sofa'
+          @sailthru.apiPost.args[0][1].tags[2].should.equal 'midcentury'
+          @sailthru.apiPost.args[0][1].tags[3].should.equal 'knoll'
           done()
 
       it 'uses email_metadata vars if provided', (done) ->

--- a/src/api/apps/articles/test/model/distribute.test.coffee
+++ b/src/api/apps/articles/test/model/distribute.test.coffee
@@ -1,3 +1,4 @@
+{ EDITORIAL_CHANNEL } = process.env
 _ = require 'underscore'
 rewire = require 'rewire'
 { fabricate, empty } = require '../../../../test/helpers/db'
@@ -91,6 +92,17 @@ describe 'Save', ->
           @sailthru.apiPost.args[0][1].tags.should.not.containEql 'artsy-editorial'
           done()
 
+      it 'concats the article and artsy-editorial tag for editorial channel', (done) ->
+        Distribute.distributeArticle {
+          author_id: '5086df098523e60002000018'
+          published: true
+          channel_id: EDITORIAL_CHANNEL
+        }, (err, article) =>
+          @sailthru.apiPost.calledOnce.should.be.true()
+          @sailthru.apiPost.args[0][1].tags.should.containEql 'article'
+          @sailthru.apiPost.args[0][1].tags.should.containEql 'artsy-editorial'
+          done()
+
       it 'does not send if it is scheduled', (done) ->
         Distribute.distributeArticle {
           author_id: '5086df098523e60002000018'
@@ -135,21 +147,10 @@ describe 'Save', ->
           @sailthru.apiPost.args[0][1].vars.layout.should.equal 'news'
           done()
 
-      it 'concats artsy-editorial for specialized articles', (done) ->
-        Distribute.distributeArticle {
-          author_id: '5086df098523e60002000018'
-          published: true
-          featured: true
-        }, (err, article) =>
-          @sailthru.apiPost.calledOnce.should.be.true()
-          @sailthru.apiPost.args[0][1].tags.should.containEql 'article'
-          done()
-
       it 'concats the keywords at the end', (done) ->
         Distribute.distributeArticle {
           author_id: '5086df098523e60002000018'
           published: true
-          featured: true
           keywords: ['sofa', 'midcentury', 'knoll']
         }, (err, article) =>
           @sailthru.apiPost.calledOnce.should.be.true()


### PR DESCRIPTION
Addresses [GROW-393](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-393)

- Removes 'magazine' tag from articles
- Adds 'layout' to custom vars
- Uses layout to construct correct article slug
- Adds 'artsy-editorial' tag to articles from the editorial channel

It wasn't completely clear from the ticket what changes were needed, please let me know if there is something missing.