### PR TITLE
@kanaabe => AutocompleteList can handle objects with id and _id

### DIFF
--- a/src/client/components/autocomplete2/list.jsx
+++ b/src/client/components/autocomplete2/list.jsx
@@ -48,10 +48,15 @@ export class AutocompleteList extends Component {
     const { onSelect } = this.props
     const { items } = this.state
     const newItems = clone(items)
+    let newItemsIds
 
     newItems.splice(item, 1)
-    const newItemsIds = uniq(map(newItems, '_id'))
-    onSelect(newItemsIds)
+    if (newItems[0]._id) {
+      newItemsIds = map(newItems, '_id')
+    } else {
+      newItemsIds = map(newItems, 'id')
+    }
+    onSelect(uniq(newItemsIds))
     this.setState({items: newItems})
   }
 

--- a/src/client/components/autocomplete2/test/list.test.js
+++ b/src/client/components/autocomplete2/test/list.test.js
@@ -53,7 +53,21 @@ describe('AutocompleteList', () => {
     expect(component.text()).toMatch(items[2].title)
   })
 
-  it('Can remove list items', () => {
+  it('Can remove list items with _id', () => {
+    const component = getWrapper(props)
+    const button = component.find('button').at(0)
+    button.simulate('click')
+
+    expect(props.onSelect.mock.calls[0][0].length).toBe(2)
+    expect(props.onSelect.mock.calls[0][0][0]).not.toMatch('123')
+  })
+
+  it('Can remove list items with id', () => {
+    items = [
+      { id: '123', title: 'First Article' },
+      { id: '234', title: 'Second Article' },
+      { id: '345', title: 'Third Article' }
+    ]
     const component = getWrapper(props)
     const button = component.find('button').at(0)
     button.simulate('click')


### PR DESCRIPTION
Fixes a bug in removing objects from AutocompleteList component, by accommodating objects with both 'id' (positron) and '_id' (sometimes used by gravity).