### PR TITLE
@kanaabe => Use layout-based slug in deleteArticleFromSailthru

### DIFF
--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -10,7 +10,7 @@ url = require 'url'
 Q = require 'bluebird-q'
 request = require 'superagent'
 Article = require './index'
-{ distributeArticle, deleteArticleFromSailthru, indexForSearch } = require './distribute'
+{ distributeArticle, deleteArticleFromSailthru, getArticleUrl, indexForSearch } = require './distribute'
 { ARTSY_URL, GEMINI_CLOUDFRONT_URL } = process.env
 artsyXapp = require('artsy-xapp').token or ''
 
@@ -21,7 +21,7 @@ artsyXapp = require('artsy-xapp').token or ''
 
 @onUnpublish = (article, cb) =>
   @generateSlugs article, (err, article) =>
-    deleteArticleFromSailthru _.last(article.slugs), =>
+    deleteArticleFromSailthru getArticleUrl(article), =>
       cb null, article
 
 setOnPublishFields = (article) =>

--- a/src/api/apps/articles/test/model/distribute.test.coffee
+++ b/src/api/apps/articles/test/model/distribute.test.coffee
@@ -219,3 +219,43 @@ describe 'Save', ->
       Distribute.deleteArticleFromSailthru 'artsy-editorial-delete-me', (err, article) =>
         @sailthru.apiDelete.args[0][1].url.should.containEql 'artsy-editorial-delete-me'
         done()
+
+  describe '#cleanArticlesInSailthru', ->
+    it 'Calls #deleteArticleFromSailthru on slugs that are not last', (done) ->
+      Distribute.deleteArticleFromSailthru = sinon.stub()
+      Distribute.cleanArticlesInSailthru({
+          author_id: '5086df098523e60002000018'
+          layout: 'video'
+          published: true
+          slugs: [
+            'artsy-editorial-slug-one'
+            'artsy-editorial-slug-two'
+            'artsy-editorial-slug-three'
+          ]
+        })
+      Distribute.deleteArticleFromSailthru.args[0][0].should.containEql '/video/artsy-editorial-slug-one'
+      Distribute.deleteArticleFromSailthru.args[1][0].should.containEql '/video/artsy-editorial-slug-two'
+      done()
+
+  describe '#getArticleUrl', ->
+    it 'constructs the url for an article using the last slug by default', ->
+      article = {
+        layout: 'classic'
+        slugs: [
+          'artsy-editorial-slug-one'
+          'artsy-editorial-slug-two'
+        ]
+      }
+      url = Distribute.getArticleUrl article
+      url.should.containEql('article/artsy-editorial-slug-two')
+
+    it 'Can use a specified slug if provided', ->
+      article = {
+        layout: 'classic'
+        slugs: [
+          'artsy-editorial-slug-one'
+          'artsy-editorial-slug-two'
+        ]
+      }
+      url = Distribute.getArticleUrl article, article.slugs[0]
+      url.should.containEql('article/artsy-editorial-slug-one')

--- a/src/api/apps/articles/test/model/index/persistence.test.coffee
+++ b/src/api/apps/articles/test/model/index/persistence.test.coffee
@@ -120,6 +120,7 @@ describe 'Article Persistence', ->
             thumbnail_title: 'Foo Bar Baz'
             author_id: @user._id.toString()
             published: true
+            layout: 'standard'
             author: name: @user.name
           }, 'foo', {}, (err, article) ->
             return done err if err

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -118,9 +118,10 @@ describe 'Save', ->
         author: {
           name: 'artsy editorial'
         }
+        layout: 'video'
       }, (err, article) =>
         article.slugs.length.should.equal 1
-        @deleteArticleFromSailthru.args[0][0].should.containEql 'artsy-editorial-delete-title'
+        @deleteArticleFromSailthru.args[0][0].should.containEql 'video/artsy-editorial-delete-title'
         done()
 
     it 'Regenerates the slug with stop words removed', (done) ->
@@ -130,9 +131,10 @@ describe 'Save', ->
         author: {
           name: 'artsy editorial'
         }
+        layout: 'feature'
       }, (err, article) =>
         article.slugs.length.should.equal 1
-        @deleteArticleFromSailthru.args[0][0].should.containEql 'artsy-editorial-one-new-york-building-changed-way-art-made-seen-sold'
+        @deleteArticleFromSailthru.args[0][0].should.containEql 'article/artsy-editorial-one-new-york-building-changed-way-art-made-seen-sold'
         done()
 
 


### PR DESCRIPTION
Additional updates based on recent changes to Sailthru distribution -- uses `getArticleSlug` method for `deleteArticleFronSailthru` method as well. 
