### PR TITLE
@kanaabe => [DO NOT MERGE] Backfill logic for new Sailthru tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "assets": "sh scripts/assets.sh",
     "deploy": "sh scripts/deploy.sh",
     "mocha": "sh scripts/mocha.sh",
-    "task": "node -r coffee-script/register -r babel-core/register -r dotenv/config"
+    "task": "node -r coffee-script/register -r @babel/register -r dotenv/config"
   },
   "resolutions": {
     "babel-core": "^7.0.0-0",

--- a/src/api/apps/articles/model/index.js
+++ b/src/api/apps/articles/model/index.js
@@ -13,7 +13,12 @@ import moment from 'moment'
 const db = require('../../../lib/db.coffee')
 const { onPublish, generateSlugs, generateKeywords,
   sanitizeAndSave, onUnpublish } = require('./save.coffee')
-const { removeFromSearch, deleteArticleFromSailthru } = require('./distribute.coffee')
+const {
+  removeFromSearch,
+  deleteArticleFromSailthru,
+  distributeArticle,
+  getArticleUrl
+} = require('./distribute.coffee')
 
 //
 // Retrieval
@@ -289,6 +294,18 @@ export const backfill = (callback) => {
         Write backfill logic here. Make sure to callback with cb()
         eg: distributeArticle(article,cb)
       */
+
+      const url = getArticleUrl(article)
+
+      const deleteCb = () => {
+        console.log('article deleted')
+      }
+
+      // remove existing article from sailthru
+      deleteArticleFromSailthru(url, deleteCb)
+
+      // re-send to sailthru with updated tags
+      distributeArticle(article, cb)
     }, (err, results) => {
       console.log(err)
       callback()


### PR DESCRIPTION
Planning to run deleteArticleFromSailthru and distributeArticle as separate backfills, but wanted to make sure I'm not missing any steps here.