### PR TITLE
@kanaabe => Autocomplete remove

### DIFF
--- a/src/client/components/autocomplete2/list.jsx
+++ b/src/client/components/autocomplete2/list.jsx
@@ -51,7 +51,7 @@ export class AutocompleteList extends Component {
     let newItemsIds
 
     newItems.splice(item, 1)
-    if (newItems[0]._id) {
+    if (newItems.length && newItems[0]._id) {
       newItemsIds = map(newItems, '_id')
     } else {
       newItemsIds = map(newItems, 'id')

--- a/src/client/components/autocomplete2/test/list.test.js
+++ b/src/client/components/autocomplete2/test/list.test.js
@@ -62,6 +62,17 @@ describe('AutocompleteList', () => {
     expect(props.onSelect.mock.calls[0][0][0]).not.toMatch('123')
   })
 
+  it('Can remove if only one item', () => {
+    items = [
+      { id: '123', title: 'First Article' }
+    ]
+    const component = getWrapper(props)
+    const button = component.find('button').at(0)
+    button.simulate('click')
+
+    expect(props.onSelect.mock.calls[0][0].length).toBe(0)
+  })
+
   it('Can remove list items with id', () => {
     items = [
       { id: '123', title: 'First Article' },


### PR DESCRIPTION
Fixes bug recently introduced for removing items from autocompletes, checks if array has length before looking at contents.