### PR TITLE
@xtinastarr => Add series object to article api

### DIFF
--- a/src/api/apps/articles/model/schema.coffee
+++ b/src/api/apps/articles/model/schema.coffee
@@ -117,6 +117,10 @@ ImageCollectionSection = (->
   gravity_id: @string().objectid().allow('', null)
   hero_section: @alternatives().try(videoSection, ImageCollectionSection, imageSection, featureSection, seriesSection).allow(null).default(null)
   series_description: @string().allow(null)
+  series: @object().keys(
+    description: @string().allow('')
+    sub_title: @string().allow('')
+  ).allow(null)
   sections: @array().items([
     ImageCollectionSection
     videoSection

--- a/src/api/apps/articles/test/model/index/persistence.test.coffee
+++ b/src/api/apps/articles/test/model/index/persistence.test.coffee
@@ -651,6 +651,28 @@ describe 'Article Persistence', ->
         article.series_description.should.equal '<p>Here is some text describing a series.</p>'
         done()
 
+    it 'saves a series description', (done) ->
+      Article.save {
+        author_id: '5086df098523e60002000018'
+        series: {
+          description: '<p>Here is some text describing a series.</p>'
+        }
+      }, 'foo', {}, (err, article) ->
+        return done err if err
+        article.series.description.should.equal '<p>Here is some text describing a series.</p>'
+        done()
+
+    it 'saves a series sub_title', (done) ->
+      Article.save {
+        author_id: '5086df098523e60002000018'
+        series: {
+          sub_title: 'About this feature'
+        }
+      }, 'foo', {}, (err, article) ->
+        return done err if err
+        article.series.sub_title.should.equal 'About this feature'
+        done()
+
     it 'saves verticals', (done) ->
       Article.save {
         author_id: '5086df098523e60002000018'


### PR DESCRIPTION
Related to [GROW-501](https://artsyproduct.atlassian.net/browse/GROW-501), adds a `series` object with keys `description` and `sub_title`. 

This PR will be followed by a backfill to existing series_description fields to new object, and a second PR deprecating the existing field. 