### PR TITLE
@kanaabe => Edit Series / onChangeArticle updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.3.0",
-    "@artsy/reaction": "^0.37.2",
+    "@artsy/reaction": "^0.38.0",
     "@babel/cli": "7.0.0-beta.42",
     "@babel/core": "7.0.0-beta.42",
     "@babel/node": "7.0.0-beta.42",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.3.0",
-    "@artsy/reaction": "^0.35.1",
+    "@artsy/reaction": "^0.37.2",
     "@babel/cli": "7.0.0-beta.42",
     "@babel/core": "7.0.0-beta.42",
     "@babel/node": "7.0.0-beta.42",

--- a/src/client/actions/editActions.js
+++ b/src/client/actions/editActions.js
@@ -129,7 +129,7 @@ export const newHeroSection = (type) => {
   const section = setupSection(type)
 
   return (dispatch, getState) => {
-    dispatch(changeArticle('hero_section', section))
+    dispatch(changeArticleData('hero_section', section))
   }
 }
 
@@ -148,7 +148,7 @@ export const onChangeArticle = (key, value) => {
       edit: { article }
     } = getState()
 
-    dispatch(changeArticle(key, value))
+    dispatch(changeArticleData(key, value))
 
     debouncedUpdateDispatch(dispatch, { channel, article: article.id })
 
@@ -158,13 +158,36 @@ export const onChangeArticle = (key, value) => {
   }
 }
 
-export const changeArticle = (key, value) => {
+export const changeArticle = (data) => {
   return {
     type: actions.CHANGE_ARTICLE,
     payload: {
-      key,
-      value
+      data
     }
+  }
+}
+
+const changeArticleData = (key, value) => {
+  return (dispatch, getState) => {
+    const { edit: { article } } = getState()
+    let data = {}
+
+    if (typeof key === 'object') {
+    // extend article with an object of keys
+      data = key
+    } else if (key.split('.').length) {
+    // change a nested object value
+      const parentKey = key.split('.')[0]
+      const childKey = key.split('.')[1]
+      const newObject = clone(article[parentKey]) || {}
+
+      newObject[childKey] = value
+      data[parentKey] = newObject
+    } else {
+    // change a single key's value
+      data[key] = value
+    }
+    dispatch(changeArticle(data))
   }
 }
 
@@ -174,7 +197,7 @@ export const onChangeHero = (key, value) => {
     const hero_section = clone(article.hero_section) || {}
 
     hero_section[key] = value
-    dispatch(changeArticle('hero_section', hero_section))
+    dispatch(changeArticleData('hero_section', hero_section))
 
     if (!article.published) {
       debouncedSaveDispatch(dispatch)
@@ -298,7 +321,7 @@ export const onAddFeaturedItem = (model, item) => {
     let newFeaturedIds = cloneDeep(article)[key] || []
 
     newFeaturedIds.push(item._id)
-    dispatch(changeArticle(key, newFeaturedIds))
+    dispatch(changeArticleData(key, newFeaturedIds))
   }
 }
 

--- a/src/client/actions/editActions.js
+++ b/src/client/actions/editActions.js
@@ -167,7 +167,7 @@ export const changeArticle = (data) => {
   }
 }
 
-const changeArticleData = (key, value) => {
+export const changeArticleData = (key, value) => {
   return (dispatch, getState) => {
     const { edit: { article } } = getState()
     let data = {}
@@ -175,7 +175,7 @@ const changeArticleData = (key, value) => {
     if (typeof key === 'object') {
     // extend article with an object of keys
       data = key
-    } else if (key.split('.').length) {
+    } else if (key.split('.').length > 1) {
     // change a nested object value
       const parentKey = key.split('.')[0]
       const childKey = key.split('.')[1]

--- a/src/client/actions/editActions.js
+++ b/src/client/actions/editActions.js
@@ -1,5 +1,5 @@
 
-import { clone, cloneDeep, debounce } from 'lodash'
+import { clone, cloneDeep, debounce, set } from 'lodash'
 import keyMirror from 'client/lib/keyMirror'
 import Article from 'client/models/article.coffee'
 import { emitAction } from 'client/apps/websocket/client'
@@ -173,19 +173,19 @@ export const changeArticleData = (key, value) => {
     let data = {}
 
     if (typeof key === 'object') {
-    // extend article with an object of keys
+      // extend article with an object of key
       data = key
-    } else if (key.split('.').length > 1) {
-    // change a nested object value
-      const parentKey = key.split('.')[0]
-      const childKey = key.split('.')[1]
-      const newObject = clone(article[parentKey]) || {}
-
-      newObject[childKey] = value
-      data[parentKey] = newObject
     } else {
-    // change a single key's value
-      data[key] = value
+      let nestedObject = key.split('.')
+
+      if (nestedObject.length > 1) {
+      // change a nested object value
+        const existingValue = clone(article[nestedObject[0]]) || {}
+        data = set(existingValue, key, value)
+      } else {
+      // change a single key's value
+        data[key] = value
+      }
     }
     dispatch(changeArticle(data))
   }

--- a/src/client/apps/edit/components/content/article_layouts/series.jsx
+++ b/src/client/apps/edit/components/content/article_layouts/series.jsx
@@ -1,4 +1,3 @@
-import { clone } from 'lodash'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -47,36 +46,28 @@ export class EditSeries extends Component {
   }
 
   editSubTitle = () => {
-    const { article } = this.props
+    const { article, onChangeArticleAction } = this.props
     const sub_title = article.series ? article.series.sub_title : ''
 
     return (
       <PlainText
         content={sub_title}
-        onChange={this.onChangeSeries}
+        onChange={onChangeArticleAction}
         placeholder='About the Series'
-        name='sub_title'
+        name='series.sub_title'
       />
     )
   }
 
-  onChangeSeries = (key, value) => {
-    const { article, onChangeArticleAction } = this.props
-    const series = clone(article.series) || {}
-
-    series[key] = value
-    onChangeArticleAction('series', series)
-  }
-
   editDescription = () => {
-    const { article } = this.props
+    const { article, onChangeArticleAction } = this.props
     const description = article.series ? article.series.description : ''
 
     return (
       <Paragraph
         html={description}
         linked
-        onChange={(html) => this.onChangeSeries('description', html)}
+        onChange={(html) => onChangeArticleAction('series.description', html)}
         placeholder='Start writing here...'
       />
     )

--- a/src/client/apps/edit/components/content/article_layouts/series.jsx
+++ b/src/client/apps/edit/components/content/article_layouts/series.jsx
@@ -69,13 +69,14 @@ export class EditSeries extends Component {
   }
 
   editDescription = () => {
-    const { article, onChangeArticleAction } = this.props
+    const { article } = this.props
+    const description = article.series ? article.series.description : ''
 
     return (
       <Paragraph
-        html={article.series_description || ''}
+        html={description}
         linked
-        onChange={(html) => onChangeArticleAction('series_description', html)}
+        onChange={(html) => this.onChangeSeries('description', html)}
         placeholder='Start writing here...'
       />
     )

--- a/src/client/apps/edit/components/content/article_layouts/series.jsx
+++ b/src/client/apps/edit/components/content/article_layouts/series.jsx
@@ -29,7 +29,7 @@ export class EditSeries extends Component {
       type: 'series'
     }
 
-    onChangeArticleAction('hero_section', hero_section)
+    onChangeArticleAction({ hero_section })
   }
 
   editTitle = () => {

--- a/src/client/apps/edit/components/content/article_layouts/series.jsx
+++ b/src/client/apps/edit/components/content/article_layouts/series.jsx
@@ -47,11 +47,11 @@ export class EditSeries extends Component {
 
   editSubTitle = () => {
     const { article, onChangeArticleAction } = this.props
-    const sub_title = article.series ? article.series.sub_title : ''
+    const sub_title = article.series && article.series.sub_title
 
     return (
       <PlainText
-        content={sub_title}
+        content={sub_title || ''}
         onChange={onChangeArticleAction}
         placeholder='About the Series'
         name='series.sub_title'
@@ -61,11 +61,11 @@ export class EditSeries extends Component {
 
   editDescription = () => {
     const { article, onChangeArticleAction } = this.props
-    const description = article.series ? article.series.description : ''
+    const description = article.series && article.series.description
 
     return (
       <Paragraph
-        html={description}
+        html={description || ''}
         linked
         onChange={(html) => onChangeArticleAction('series.description', html)}
         placeholder='Start writing here...'

--- a/src/client/apps/edit/components/content/article_layouts/series.jsx
+++ b/src/client/apps/edit/components/content/article_layouts/series.jsx
@@ -1,3 +1,4 @@
+import { clone } from 'lodash'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -43,6 +44,28 @@ export class EditSeries extends Component {
         name='title'
       />
     )
+  }
+
+  editSubTitle = () => {
+    const { article } = this.props
+    const sub_title = article.series ? article.series.sub_title : ''
+
+    return (
+      <PlainText
+        content={sub_title}
+        onChange={this.onChangeSeries}
+        placeholder='About the Series'
+        name='sub_title'
+      />
+    )
+  }
+
+  onChangeSeries = (key, value) => {
+    const { article, onChangeArticleAction } = this.props
+    const series = clone(article.series) || {}
+
+    series[key] = value
+    onChangeArticleAction('series', series)
   }
 
   editDescription = () => {
@@ -98,6 +121,7 @@ export class EditSeries extends Component {
           <SeriesAbout
             article={article}
             editDescription={this.editDescription()}
+            editSubTitle={this.editSubTitle()}
             color='white'
           />
         </SeriesContent>

--- a/src/client/apps/edit/components/content/article_layouts/test/series.test.js
+++ b/src/client/apps/edit/components/content/article_layouts/test/series.test.js
@@ -27,7 +27,7 @@ describe('EditSeries', () => {
       <EditSeries {...props} />
     )
     expect(component.find(SeriesTitle).length).toBe(1)
-    expect(component.find(PlainText).length).toBe(1)
+    expect(component.find(PlainText).at(0).props().name).toBe('title')
   })
 
   it('Renders RelatedArticles list', () => {
@@ -43,6 +43,16 @@ describe('EditSeries', () => {
     )
     expect(component.find(SeriesAbout).length).toBe(1)
     expect(component.find(Paragraph).length).toBe(1)
+  })
+
+  it('Renders editable series subTitle', () => {
+    props.article.series = {sub_title: 'This Feature'}
+    const component = mount(
+      <EditSeries {...props} />
+    )
+
+    expect(component.find(PlainText).at(1).props().name).toBe('series.sub_title')
+    expect(component.find(PlainText).at(1).props().content).toBe('This Feature')
   })
 
   it('Renders a file input for background image ', () => {
@@ -61,9 +71,9 @@ describe('EditSeries', () => {
     )
     const input = component.find(FileInput).first().getElement()
     input.props.onUpload('http://new-image.jpg')
-    expect(props.onChangeArticleAction.mock.calls[0][0]).toBe('hero_section')
-    expect(props.onChangeArticleAction.mock.calls[0][1].url).toBe('http://new-image.jpg')
-    expect(props.onChangeArticleAction.mock.calls[0][1].type).toBe('series')
+
+    expect(props.onChangeArticleAction.mock.calls[0][0].hero_section.url).toBe('http://new-image.jpg')
+    expect(props.onChangeArticleAction.mock.calls[0][0].hero_section.type).toBe('series')
   })
 
   it('Renders a background image if url', () => {

--- a/src/client/reducers/editReducer.js
+++ b/src/client/reducers/editReducer.js
@@ -63,9 +63,8 @@ export function editReducer (state = initialState, action) {
     }
 
     case actions.CHANGE_ARTICLE: {
-      const { key, value } = action.payload
-      const article = cloneDeep(state.article)
-      article[key] = value
+      const { data } = action.payload
+      const article = extend(cloneDeep(state.article), data)
 
       return u({
         article,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
     chokidar "^1.7.0"
     decache "^4.4.0"
 
-"@artsy/reaction@^0.35.1":
-  version "0.35.1"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.35.1.tgz#373142ebdad231a492c5d5b86eb6f5cc17e27c6c"
+"@artsy/reaction@^0.37.2":
+  version "0.37.2"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.37.2.tgz#e51849d49db2cfa877a263cd51fd2017b298e9f3"
   dependencies:
     formik "^0.11.11"
     history "^4.6.1"
@@ -27,6 +27,7 @@
     react-lines-ellipsis "^0.8.0"
     react-markdown "^2.5.0"
     react-oembed-container "^0.3.0"
+    react-overlays "^0.8.3"
     react-relay "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/react-relay-1.5.0-artsy.3.tgz"
     react-responsive-decorator "^0.0.1"
     react-router "4.1.1"
@@ -34,6 +35,7 @@
     react-slick "^0.14.11"
     react-styled-flexboxgrid "^2.0.0"
     react-tracking "^4.2.1"
+    react-transition-group "^2.3.0"
     react-url-query "^1.1.4"
     react-waypoint "^7.3.3"
     relay-runtime "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-runtime-1.5.0-artsy.3.tgz"
@@ -3250,7 +3252,7 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-dom-helpers@^3.2.0:
+dom-helpers@^3.2.0, dom-helpers@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -7706,6 +7708,12 @@ prop-by-string@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prop-by-string/-/prop-by-string-1.0.1.tgz#a3768a9412de26bbcf982eb19fb8d5ecf573101a"
 
+prop-types-extra@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.0.1.tgz#a57bd4810e82d27a3ff4317ecc1b4ad005f79a82"
+  dependencies:
+    warning "^3.0.0"
+
 prop-types@^15.0.0, prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -7950,6 +7958,17 @@ react-oembed-container@^0.3.0:
   dependencies:
     prop-types "^15.6.0"
 
+react-overlays@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
+  dependencies:
+    classnames "^2.2.5"
+    dom-helpers "^3.2.1"
+    prop-types "^15.5.10"
+    prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.0"
+    warning "^3.0.0"
+
 react-proxy@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-1.1.8.tgz#9dbfd9d927528c3aa9f444e4558c37830ab8c26a"
@@ -8068,6 +8087,16 @@ react-transition-group@^1.2.1:
     dom-helpers "^3.2.0"
     loose-envify "^1.3.1"
     prop-types "^15.5.6"
+    warning "^3.0.0"
+
+react-transition-group@^2.2.0, react-transition-group@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.0.tgz#8dd1af58f6af284b19fd057f512e74f20438ad31"
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.8"
     warning "^3.0.0"
 
 react-url-query@^1.1.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
     chokidar "^1.7.0"
     decache "^4.4.0"
 
-"@artsy/reaction@^0.37.2":
-  version "0.37.2"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.37.2.tgz#e51849d49db2cfa877a263cd51fd2017b298e9f3"
+"@artsy/reaction@^0.38.0":
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.38.0.tgz#caf857ca457d66b6d9d25861b5faa4e0a37327ff"
   dependencies:
     formik "^0.11.11"
     history "^4.6.1"


### PR DESCRIPTION
Took this opportunity for a small refactor to the `onChangeArticle` redux action so that it can accept objects (similar to backbone's set), and update nested object fields. 
 
- Adds ability to edit a custom `series.sub_title`
- Uses `series.description` field for editing rather than `series_description`
- Updates reaction
- Adds `onChangeArticleData` action to parse different kinds of args passed to `onChangeArticle`

TODO: Backfill existing `series_description` fields to new `series` object before deploying