### PR TITLE
@l2succes => Canvas-based Thumbnail Image

### DIFF
--- a/src/client/apps/edit/components/display/components/magazine.jsx
+++ b/src/client/apps/edit/components/display/components/magazine.jsx
@@ -6,6 +6,7 @@ import { onChangeArticle } from 'client/actions/editActions'
 import { MagazinePreview } from './preview/magazine_preview'
 import { CharacterLimit } from 'client/components/character_limit'
 import ImageUpload from 'client/apps/edit/components/admin/components/image_upload.coffee'
+import ImageGenerator from 'client/components/image_generator/index.tsx'
 
 export class DisplayMagazine extends Component {
   static propTypes = {
@@ -54,6 +55,10 @@ export class DisplayMagazine extends Component {
               defaultValue={article.description}
             />
           </div>
+
+          {article.layout === 'news' &&
+            <ImageGenerator />
+          }
         </Col>
 
         <Col xs={8}>

--- a/src/client/components/image_generator/index.tsx
+++ b/src/client/components/image_generator/index.tsx
@@ -16,12 +16,8 @@ interface Props {
 }
 
 export class ImageGenerator extends Component<Props, State> {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      text: props.article.thumbnail_title || ""
-    }
+  state = {
+    text: this.props.article.thumbnail_title || ""
   }
 
   onChange = (text) => {

--- a/src/client/components/image_generator/index.tsx
+++ b/src/client/components/image_generator/index.tsx
@@ -1,0 +1,95 @@
+import React, { Component } from 'react'
+import gemup from 'gemup'
+import styled from 'styled-components'
+import { connect } from 'react-redux'
+import { Col, Row } from 'react-styled-flexboxgrid'
+import { onChangeArticle } from 'client/actions/editActions'
+import { data as sd } from 'sharify'
+
+interface State {
+  text: string
+}
+
+interface Props {
+  onChangeArticleAction: any
+}
+
+export class ImageGenerator extends Component<Props, State> {
+  onChange = (text) => {
+    this.setState({ text })
+  }
+
+  onClick = async () => {
+    const { text } = this.state
+
+    const canvas = document.getElementById('canvas')
+    if (canvas) {
+      const ctx = canvas.getContext('2d')
+      ctx.font = '30px Helvetica'
+      ctx.fillStyle = 'black'
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+      ctx.fillStyle = 'white'
+      ctx.fillText(text, 10, 50)
+      const newImage = canvas.toDataURL('image/png')
+
+      // Create blob and upload to s3
+      const blob = await (await fetch(newImage)).blob()
+      this.upload(blob)
+    }
+  }
+
+  upload = (image) => {
+    const { onChangeArticleAction } = this.props
+
+    gemup(image, {
+      app: sd.GEMINI_APP,
+      key: sd.GEMINI_KEY,
+      done: (src) => {
+        onChangeArticleAction('thumbnail_image', src)
+      }
+    })
+  }
+
+  render () {
+    return (
+      <Row>
+
+        <Col xs={6} className='field-group'>
+          <label>Image Text</label>
+          <textarea
+            className='bordered-input'
+            onChange={(e) => this.onChange(e.target.value)}
+            placeholder='Custom Headline'
+          />
+          <Canvas
+            id='canvas'
+            width='600px'
+            height='400px'
+          />
+          <button
+            onClick={this.onClick}
+          >Save New Image</button>
+        </Col>
+
+      </Row>
+    )
+  }
+}
+
+const Canvas = styled.canvas`
+  border: 1px solid black;
+  display: none;
+`
+
+const mapStateToProps = (state) => ({
+  article: state.edit.article
+})
+
+const mapDispatchToProps = {
+  onChangeArticleAction: onChangeArticle
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ImageGenerator)

--- a/src/client/components/image_generator/index.tsx
+++ b/src/client/components/image_generator/index.tsx
@@ -5,12 +5,14 @@ import { connect } from 'react-redux'
 import { Col, Row } from 'react-styled-flexboxgrid'
 import { onChangeArticle } from 'client/actions/editActions'
 import { data as sd } from 'sharify'
+import moment from 'moment'
 
 interface State {
   text: string
 }
 
 interface Props {
+  article: any
   onChangeArticleAction: any
 }
 
@@ -20,16 +22,23 @@ export class ImageGenerator extends Component<Props, State> {
   }
 
   onClick = async () => {
+    const { article } = this.props
     const { text } = this.state
 
     const canvas = document.getElementById('canvas')
     if (canvas) {
       const ctx = canvas.getContext('2d')
-      ctx.font = '30px Helvetica'
+      console.log(article.published_at || "")
+      const date = moment(article.published_at || "").format('MMM DD')
+
       ctx.fillStyle = 'black'
       ctx.fillRect(0, 0, canvas.width, canvas.height)
       ctx.fillStyle = 'white'
-      ctx.fillText(text, 10, 50)
+      ctx.font = '32px "Unica77LLWebMedium"'
+      ctx.fillText("News", 200, 50)
+      ctx.fillText(date, 400, 50)
+      ctx.font = '50px "Adobe Garamond W08"'
+      ctx.fillText(text, 200, 200, 840)
       const newImage = canvas.toDataURL('image/png')
 
       // Create blob and upload to s3

--- a/src/client/components/image_generator/index.tsx
+++ b/src/client/components/image_generator/index.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import gemup from 'gemup'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
-import { onChangeArticle } from 'client/actions/editActions'
+import { onChangeArticle } from '../../actions/editActions'
 import { data as sd } from 'sharify'
 import moment from 'moment'
 
@@ -33,6 +33,7 @@ export class ImageGenerator extends Component<Props, State> {
     const { text } = this.state
 
     const canvas: any = document.getElementById('canvas')
+
     if (canvas) {
       const ctx = canvas.getContext('2d')
       const dateString = article.published_at || article.scheduled_publish_at
@@ -55,7 +56,7 @@ export class ImageGenerator extends Component<Props, State> {
     }
   }
 
-  // Originallly from https://codepen.io/bramus/pen/eZYqoO
+  // Originally from https://codepen.io/bramus/pen/eZYqoO
   wrapText(ctx, text, x, y, maxWidth, lineHeight) {
     const words = text.split(' ')
     let line = ''

--- a/src/client/components/image_generator/index.tsx
+++ b/src/client/components/image_generator/index.tsx
@@ -114,7 +114,6 @@ export class ImageGenerator extends Component<Props, State> {
 }
 
 const Canvas = styled.canvas`
-  border: 1px solid black;
   display: none;
 `
 

--- a/src/client/components/image_generator/test/index.test.tsx
+++ b/src/client/components/image_generator/test/index.test.tsx
@@ -1,0 +1,83 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import { ImageGenerator } from '..'
+import gemup from 'gemup'
+
+jest.mock('gemup')
+
+describe('ImageGenerator', () => {
+  let props
+  let onChangeArticleAction = jest.fn()
+  let component
+  let fillText = jest.fn()
+  let fillRect = jest.fn()
+  let canvas: any
+
+  const getWrapper = props => {
+    return mount(<ImageGenerator {...props} />, {
+      attachTo: document.body
+    })
+  }
+
+  beforeEach(() => {
+    const article = {
+      thumbnail_title: 'Some Title that can be Wrapped',
+      published_at: '2018-01-01'
+    }
+
+    onChangeArticleAction.mockClear()
+    props = {
+      article,
+      onChangeArticleAction
+    }
+
+    window.fetch = jest.fn(() => {
+      return {
+        blob: jest.fn().mockReturnValue('foo.img')
+      }
+    })
+
+    component = getWrapper(props)
+    canvas = document.getElementById('canvas')
+    fillRect.mockClear()
+    fillText.mockClear()
+    let textWidth = 100
+    const measureText = jest.fn(() => {
+      return { width: (textWidth += 140) }
+    })
+    canvas.getContext = jest.fn(() => {
+      return { fillStyle: '', font: '', fillRect, fillText, measureText }
+    })
+    canvas.toDataURL = jest.fn(() => 'foo')
+  })
+
+  it('renders image generator field and canvas', () => {
+    expect(component.find(ImageGenerator).exists()).toBe(true)
+    expect(component.find('canvas').length).toBe(1)
+    expect(component.find('textarea').length).toBe(1)
+    expect(component.find('button').length).toBe(1)
+  })
+
+  it('generates new image based on text', () => {
+    component.find('button').simulate('click')
+    expect(canvas.getContext.mock.calls.length).toBe(1)
+    expect(fillRect.mock.calls[0]).toEqual([0, 0, 1080, 470])
+    expect(fillText.mock.calls[0]).toEqual(['News', 120, 62])
+    expect(fillText.mock.calls[1]).toEqual(['Jan 01', 490, 62])
+  })
+
+  it('handles wrapped text', () => {
+    component.find('button').simulate('click')
+    console.log(fillText.mock.calls)
+    expect(fillText.mock.calls.length).toBe(4)
+    expect(fillText.mock.calls[2][0]).toBe('Some Title that can be ')
+    expect(fillText.mock.calls[3][0]).toBe('Wrapped ')  })
+
+  it('uploads the image to s3 and returns a url', () => {
+    component.find('button').simulate('click')
+    expect(gemup.mock.calls[0][0]).toEqual('foo.img')
+    gemup.mock.calls[0][1].done('artsy.net/foo.jpg')
+    component.update()
+    expect(props.onChangeArticleAction.mock.calls[0][0]).toBe('thumbnail_image')
+  })
+})

--- a/src/client/components/image_generator/test/index.test.tsx
+++ b/src/client/components/image_generator/test/index.test.tsx
@@ -68,7 +68,6 @@ describe('ImageGenerator', () => {
 
   it('handles wrapped text', () => {
     component.find('button').simulate('click')
-    console.log(fillText.mock.calls)
     expect(fillText.mock.calls.length).toBe(4)
     expect(fillText.mock.calls[2][0]).toBe('Some Title that can be ')
     expect(fillText.mock.calls[3][0]).toBe('Wrapped ')  })


### PR DESCRIPTION
This uses the Canvas API to "draw" some custom text to a canvas, generate an image out of it, converts it to a Blob type, and uploads it to S3 using `gemup`.

The screenshots below show a mismatch in cropping, but that's actually intentional. This format is optimized for social which is seen in the social tab as I scroll down. 

Generates Image:
![canvas-image-generator](https://user-images.githubusercontent.com/2236794/38899108-ec4ba686-4264-11e8-914c-3bce6a412dd6.gif)

Can use scheduled publish date:
![canvas-image-generator-2](https://user-images.githubusercontent.com/2236794/38899106-e7d45f58-4264-11e8-8edb-251cb8308d4c.gif)
