### PR TITLE
@kanaabe => Unschedule article bug

### DIFF
--- a/src/api/apps/articles/model/schema.coffee
+++ b/src/api/apps/articles/model/schema.coffee
@@ -216,7 +216,7 @@ ImageCollectionSection = (->
     partner_logo_link: @string().allow('')
   )
   email_metadata: @object().default({}).keys
-    image_url: @string().allow('')
+    image_url: @string().allow('', null)
     headline: @string().allow('')
     author: @string().allow('')
     custom_text: @string().allow('')

--- a/src/client/apps/edit/components/admin/components/article/article_publish_date.jsx
+++ b/src/client/apps/edit/components/admin/components/article/article_publish_date.jsx
@@ -25,19 +25,36 @@ export class ArticlePublishDate extends Component {
 
   onScheduleChange = () => {
     const { article, onChange } = this.props
+    const { scheduled_publish_at } = article
+    const { hasChanged } = this.state
 
     if (this.date && this.time) {
       const date = this.date.value
       const time = this.time.value
-      const new_published = moment(`${date} ${time}`).local()
+      const new_published = moment(`${date} ${time}`).local().toISOString()
 
-      if (!article.published) {
-        onChange('scheduled_publish_at', new_published.toISOString())
+      if (scheduled_publish_at && !hasChanged) {
+        this.onUnschedule()
+      } else if (!article.published) {
+        onChange('scheduled_publish_at', new_published)
       } else {
-        onChange('published_at', new_published.toISOString())
+        onChange('published_at', new_published)
       }
-      this.setState({hasChanged: false})
+      this.setState({ hasChanged: false })
     }
+  }
+
+  onUnschedule = () => {
+    const { onChange } = this.props
+    let publish_date = null
+    let publish_time = null
+
+    if (this.date && this.time) {
+      this.date.value = publish_date
+      this.time.value = publish_time
+    }
+    onChange('scheduled_publish_at', null)
+    this.setState({hasChanged: false, publish_date, publish_time})
   }
 
   setupPublishDate = () => {
@@ -60,9 +77,12 @@ export class ArticlePublishDate extends Component {
   }
 
   getPublishText = () => {
+    const { hasChanged } = this.state
     const { published, scheduled_publish_at } = this.props.article
 
-    if (published) {
+    if (published ||
+      (scheduled_publish_at && hasChanged)
+    ) {
       return 'Update'
     } else if (scheduled_publish_at) {
       return 'Unschedule'

--- a/src/client/apps/edit/components/admin/components/article/article_publish_date.jsx
+++ b/src/client/apps/edit/components/admin/components/article/article_publish_date.jsx
@@ -36,6 +36,7 @@ export class ArticlePublishDate extends Component {
       } else {
         onChange('published_at', new_published.toISOString())
       }
+      this.setState({hasChanged: false})
     }
   }
 

--- a/src/client/apps/edit/components/admin/test/components/article/article_publish_date.test.js
+++ b/src/client/apps/edit/components/admin/test/components/article/article_publish_date.test.js
@@ -149,6 +149,16 @@ describe('ArticlePublishDate', () => {
 
       expect(text).toBe('Update')
     })
+
+    it('Returns "Update" if scheduled_publish_at has changed', () => {
+      props.article.scheduled_publish_at = moment().toISOString()
+      const component = getWrapper(props)
+      component.setState({hasChanged: true})
+      const text = component.instance().getPublishText()
+
+      expect(text).toBe('Update')
+    })
+
     it('Returns "Schedule" if unpublished', () => {
       const component = getWrapper(props)
       const text = component.instance().getPublishText()
@@ -188,13 +198,72 @@ describe('ArticlePublishDate', () => {
   })
 
   it('Button calls #onScheduleChange on click', () => {
-    const date = moment().add('1', 'days').toISOString()
-    props.article.scheduled_publish_at = date
-    delete props.article.published_at
     const component = getWrapper(props)
     component.find('button').at(0).simulate('click')
 
     expect(props.onChange.mock.calls[0][0]).toBe('scheduled_publish_at')
-    expect(props.onChange.mock.calls[0][1]).toMatch(moment(date).format('YYYY-MM-'))
+  })
+
+  describe('#onScheduleChange', () => {
+    it('Sets published_at if article is published', () => {
+      props.article.published = true
+      const component = getWrapper(props)
+      component.instance().date.value = '2018-02-02'
+      component.find('button').at(0).simulate('click')
+
+      expect(props.onChange.mock.calls[0][0]).toBe('published_at')
+      expect(props.onChange.mock.calls[0][1]).toMatch('2018-02-02')
+    })
+
+    it('Sets scheduled_publish_at if article is not published', () => {
+      const component = getWrapper(props)
+      component.instance().date.value = '2018-02-02'
+      component.find('button').at(0).simulate('click')
+
+      expect(props.onChange.mock.calls[0][0]).toBe('scheduled_publish_at')
+      expect(props.onChange.mock.calls[0][1]).toMatch('2018-02-02')
+    })
+
+    it('Calls #onUnschedule if scheduled_publish_at exists', () => {
+      delete props.article.published_at
+      props.article.scheduled_publish_at = new Date().toISOString()
+      const component = getWrapper(props)
+      component.find('button').at(0).simulate('click')
+
+      expect(props.onChange.mock.calls[0][0]).toBe('scheduled_publish_at')
+      expect(props.onChange.mock.calls[0][1]).toBe(null)
+    })
+
+    it('Sets state.hasChanged to false', () => {
+      const component = getWrapper(props)
+      component.instance().setState({hasChanged: true})
+      component.find('button').at(0).simulate('click')
+
+      expect(component.state().hasChanged).toBe(false)
+    })
+  })
+
+  describe('#onUnschedule', () => {
+    beforeEach(() => {
+      delete props.article.published_at
+      props.article.scheduled_publish_at = new Date().toISOString()
+    })
+
+    it('Un-sets scheduled_publish_at', () => {
+      const component = getWrapper(props)
+      component.instance().onUnschedule()
+
+      expect(props.onChange.mock.calls[0][0]).toBe('scheduled_publish_at')
+      expect(props.onChange.mock.calls[0][1]).toBe(null)
+    })
+
+    it('Updates the state', () => {
+      const component = getWrapper(props)
+      component.instance().onUnschedule()
+
+      expect(component.state().publish_date).toBe(null)
+      expect(component.state().publish_time).toBe(null)
+      expect(component.state().hasChanged).toBe(false)
+    })
   })
 })

--- a/src/client/apps/edit/components/admin/test/components/article/article_publish_date.test.js
+++ b/src/client/apps/edit/components/admin/test/components/article/article_publish_date.test.js
@@ -66,6 +66,7 @@ describe('ArticlePublishDate', () => {
 
       expect(props.onChange.mock.calls[0][0]).toBe('published_at')
       expect(props.onChange.mock.calls[0][1]).toMatch('2018-05-04')
+      expect(component.state().hasChanged).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
When unscheduling an article, save was returning a Joi error because 'email_metadata.image_url' was not set, causing the save not to finish.

- Allows null for 'email_image.image_url'
- Adds `onUnschedule`, which explicitly sets `scheduled_publish_at` to null
- Resets fields to null when clicking 'unschedule' button
- Resets button color on click

![publish-date](https://user-images.githubusercontent.com/1497424/39142612-2a77210e-46f9-11e8-8589-e985b9fcc985.gif)

