### PR TITLE
@xtina-starr => Display Admin has fields for pixel_tracking_code

### DIFF
--- a/src/client/apps/edit/components/admin/components/image_upload.coffee
+++ b/src/client/apps/edit/components/admin/components/image_upload.coffee
@@ -3,6 +3,7 @@ ReactDOM = require 'react-dom'
 gemup = require 'gemup'
 sd = require('sharify').data
 { crop } = require '../../../../../components/resizer/index.coffee'
+{ RemoveButton } = require '../../../../../components/remove_button/index.jsx'
 { section, h1, h2, span, input, div, video } = React.DOM
 
 module.exports = React.createClass
@@ -81,9 +82,7 @@ module.exports = React.createClass
             style: backgroundImage: 'url(' + crop(@props.src, width: 215, height: 150) + ')', display: 'block'
           }
         unless  @props.disabled
-          div {
-            className: 'image-upload-form-remove'
-            style: display: 'block'
+          RemoveButton {
             onClick: @remove
           }
 

--- a/src/client/apps/edit/components/admin/test/components/image_upload.test.coffee
+++ b/src/client/apps/edit/components/admin/test/components/image_upload.test.coffee
@@ -14,6 +14,9 @@ describe 'ImageUpload', ->
     benv.setup =>
       benv.expose $: benv.require 'jquery'
       window.jQuery = $
+      window.matchMedia = sinon.stub().returns({
+        matches: sinon.stub()
+      })
       @ImageUpload = benv.require resolve __dirname, '../../components/image_upload.coffee'
       @ImageUpload.__set__ 'gemup', @gemup = sinon.stub()
       @props = {
@@ -102,5 +105,6 @@ describe 'ImageUpload', ->
     it 'removes the state and callsback', ->
       @props.src = 'http://artsy.net/image.jpg'
       component = ReactDOM.render React.createElement(@ImageUpload, @props), (@$el = $ "<div></div>")[0]
-      r.simulate.click r.find(component, 'image-upload-form-remove')[0]
+      button = $(ReactDOM.findDOMNode(component)).find('.RemoveButton')[0]
+      r.simulate.click button
       component.props.onChange.args[0].should.eql [ 'my_image', '' ]

--- a/src/client/apps/settings/client/curations/display/components/canvas/canvas_text.jsx
+++ b/src/client/apps/settings/client/curations/display/components/canvas/canvas_text.jsx
@@ -50,6 +50,14 @@ export const CanvasText = (props) => {
           onChange={(value) => onChange('canvas.disclaimer', value, index)}
           limit={150} />
       </div>
+      <div className='field-group'>
+        <label>Pixel Tracking Code (optional)</label>
+        <input
+          className='bordered-input'
+          placeholder='Paste 3rd party script here'
+          defaultValue={canvas.pixel_tracking_code || ''}
+          onChange={(e) => onChange('canvas.pixel_tracking_code', e.target.value, index)} />
+      </div>
     </div>
   )
 }

--- a/src/client/apps/settings/client/curations/display/components/canvas/index.jsx
+++ b/src/client/apps/settings/client/curations/display/components/canvas/index.jsx
@@ -27,7 +27,8 @@ export class Canvas extends React.Component {
         </div>
         <CanvasControls
           activeLayout={this.state.activeLayout}
-          setActiveLayout={this.setActiveLayout} />
+          setActiveLayout={this.setActiveLayout}
+        />
         <Row className='display-admin__section--canvas'>
           <Col lg>
             <CanvasText

--- a/src/client/apps/settings/client/curations/display/components/panel/index.jsx
+++ b/src/client/apps/settings/client/curations/display/components/panel/index.jsx
@@ -41,6 +41,14 @@ export const Panel = (props) => {
                 limit={45}
               />
             </div>
+            <div className='field-group'>
+              <label>Pixel Tracking Code (optional)</label>
+              <input
+                className='bordered-input'
+                placeholder='Paste 3rd party script here'
+                defaultValue={panel.pixel_tracking_code || ''}
+                onChange={(e) => onChange('panel.pixel_tracking_code', e.target.value, index)} />
+            </div>
           </Col>
           <Col lg>
             <PanelImages

--- a/src/client/apps/settings/client/curations/display/index.jsx
+++ b/src/client/apps/settings/client/curations/display/index.jsx
@@ -28,7 +28,10 @@ export default class DisplayAdmin extends React.Component {
   save = () => {
     this.state.curation.save({}, {
       success: () => this.setState({ saveStatus: 'Saved' }),
-      error: error => this.setState({ saveStatus: 'Error' })
+      error: error => {
+        console.error(error)
+        this.setState({ saveStatus: 'Error' })
+      }
     })
   }
 

--- a/src/client/apps/settings/client/curations/display/test/components/canvas/canvas_images.test.js
+++ b/src/client/apps/settings/client/curations/display/test/components/canvas/canvas_images.test.js
@@ -136,7 +136,7 @@ describe('Canvas Images', () => {
         const component = mount(
           <CanvasImages {...props} />
         )
-        component.find('.image-upload-form-remove').at(0).simulate('click')
+        component.find('.RemoveButton').at(0).simulate('click')
         expect(props.onChange.mock.calls[1][0]).toMatch('canvas.logo')
         expect(props.onChange.mock.calls[1][2]).toBe(props.index)
       })
@@ -176,7 +176,7 @@ describe('Canvas Images', () => {
         const component = mount(
           <CanvasImages {...props} />
         )
-        component.find('.image-upload-form-remove').at(1).simulate('click')
+        component.find('.RemoveButton').at(1).simulate('click')
         const onChangeArgs = props.onChange.mock.calls[4]
 
         expect(onChangeArgs[0]).toMatch('canvas.assets')

--- a/src/client/apps/settings/client/curations/display/test/components/canvas/canvas_text.test.js
+++ b/src/client/apps/settings/client/curations/display/test/components/canvas/canvas_text.test.js
@@ -46,11 +46,10 @@ describe('Canvas Text', () => {
     const component = mount(
       <CanvasText {...props} />
     )
-    const input = component.find('input').at(0)
+    const input = component.find('input').at(1)
     input.simulate('change', { target: { value: 'Read More' } })
 
-    // FIXME TEST: Not sure...
-    // expect(props.onChange.mock.calls[0][0]).toMatch('canvas.link.text')
+    expect(props.onChange.mock.calls[0][0]).toMatch('canvas.link.text')
     expect(props.onChange.mock.calls[0][1]).toMatch('Read More')
     expect(props.onChange.mock.calls[0][2]).toBe(0)
   })
@@ -59,12 +58,23 @@ describe('Canvas Text', () => {
     const component = mount(
       <CanvasText {...props} />
     )
-    const input = component.find('input').at(1)
+    const input = component.find('input').at(2)
     input.simulate('change', { target: { value: 'http://artsy.net' } })
 
-    // FIXME TEST: Not sure...
-    // expect(props.onChange.mock.calls[0][0]).toMatch('canvas.link.url')
+    expect(props.onChange.mock.calls[0][0]).toMatch('canvas.link.url')
     expect(props.onChange.mock.calls[0][1]).toMatch('http://artsy.net')
+    expect(props.onChange.mock.calls[0][2]).toBe(0)
+  })
+
+  it('Can save an edited Pixel Tracking Code', () => {
+    const component = mount(
+      <CanvasText {...props} />
+    )
+    const input = component.find('input').at(3)
+    input.simulate('change', { target: { value: 'a pixel tracking script' } })
+
+    expect(props.onChange.mock.calls[0][0]).toMatch('canvas.pixel_tracking_code')
+    expect(props.onChange.mock.calls[0][1]).toMatch('a pixel tracking script')
     expect(props.onChange.mock.calls[0][2]).toBe(0)
   })
 

--- a/src/client/apps/settings/client/curations/display/test/components/canvas/index.test.js
+++ b/src/client/apps/settings/client/curations/display/test/components/canvas/index.test.js
@@ -60,6 +60,7 @@ describe('Canvas', () => {
       expect(component.text()).toMatch('CTA Text')
       expect(component.text()).toMatch('CTA Link')
       expect(component.text()).toMatch('Disclaimer (optional)')
+      expect(component.text()).toMatch('Pixel Tracking Code (optional)')
       expect(component.text()).toMatch('Background Image')
       expect(component.text()).toMatch('Logo')
     })
@@ -90,11 +91,13 @@ describe('Canvas', () => {
       expect(component.text()).toMatch('CTA Text')
       expect(component.text()).toMatch('CTA Link')
       expect(component.text()).toMatch('Disclaimer (optional)')
+      expect(component.text()).toMatch('Pixel Tracking Code (optional)')
       expect(component.text()).toMatch('Image / Video')
       expect(component.text()).toMatch('Logo')
     })
 
     it('Renders saved data', () => {
+      props.campaign.canvas.pixel_tracking_code = 'pixel tracking script'
       const component = mount(
         <Canvas {...props} />
       )
@@ -102,6 +105,7 @@ describe('Canvas', () => {
       expect(component.html()).toMatch(props.campaign.canvas.link.text)
       expect(component.html()).toMatch(props.campaign.canvas.link.url)
       expect(component.text()).toMatch(props.campaign.canvas.disclaimer)
+      expect(component.html()).toMatch(props.campaign.canvas.pixel_tracking_code)
       expect(component.html()).toMatch('artsy-logo-wide-black.png')
       expect(component.html()).toMatch('Rachel_Rossin_portrait_2.jpg')
     })
@@ -127,12 +131,14 @@ describe('Canvas', () => {
       expect(component.text()).toMatch('CTA Text')
       expect(component.text()).toMatch('CTA Link')
       expect(component.text()).toMatch('Disclaimer (optional)')
+      expect(component.text()).toMatch('Pixel Tracking Code (optional)')
       expect(component.text()).toMatch('Image 1')
       expect(component.text()).toMatch('Image 2')
       expect(component.text()).toMatch('Logo')
     })
 
     it('Renders saved data', () => {
+      props.campaign.canvas.pixel_tracking_code = 'pixel tracking script'
       const component = mount(
         <Canvas {...props} />
       )
@@ -140,6 +146,7 @@ describe('Canvas', () => {
       expect(component.html()).toMatch(props.campaign.canvas.link.text)
       expect(component.html()).toMatch(props.campaign.canvas.link.url)
       expect(component.text()).toMatch(props.campaign.canvas.disclaimer)
+      expect(component.html()).toMatch(props.campaign.canvas.pixel_tracking_code)
       expect(component.html()).toMatch('artsy-logo-wide-black.png')
       expect(component.html()).toMatch('Rachel_Rossin_portrait_2.jpg')
       expect(component.html()).toMatch('larger.jpg')

--- a/src/client/apps/settings/client/curations/display/test/components/panel/index.test.js
+++ b/src/client/apps/settings/client/curations/display/test/components/panel/index.test.js
@@ -13,26 +13,31 @@ global.window.getSelection = jest.fn(() => {
 })
 
 describe('Panel', () => {
-  const props = {
-    campaign: {
-      canvas: {},
-      panel: {}
-    },
-    index: 0,
-    onChange: jest.fn()
-  }
+  let props = {}
+
+  beforeEach(() => {
+    props = {
+      campaign: {
+        canvas: {},
+        panel: {}
+      },
+      index: 0,
+      onChange: jest.fn()
+    }
+  })
 
   it('renders all fields', () => {
     const component = mount(
       <Panel {...props} />
     )
-    expect(component.find('input').length).toBe(4)
+    expect(component.find('input').length).toBe(5)
     expect(component.find(CharacterLimit).length).toBe(2)
     expect(component.find(ImageUpload).length).toBe(2)
     expect(component.find('label').at(0).text()).toMatch('Headline')
     expect(component.find('label').at(0).text()).toMatch('25 Characters')
     expect(component.find('label').at(2).text()).toMatch('Body')
     expect(component.find('label').at(2).text()).toMatch('45 Characters')
+    expect(component.find('label').at(3).text()).toMatch('Pixel Tracking Code (optional)')
   })
 
   it('renders saved text data', () => {
@@ -41,7 +46,8 @@ describe('Panel', () => {
       body: '<p>Sample body text. <a href="http://artsy.net">Example link</a>.',
       headline: 'Sample Headline',
       link: {url: 'http://artsy.net'},
-      logo: 'http://artsy.net/logo.jpg'
+      logo: 'http://artsy.net/logo.jpg',
+      pixel_tracking_code: 'pixel tracking code'
     }
     const component = mount(
       <Panel {...props} />
@@ -52,6 +58,7 @@ describe('Panel', () => {
     expect(component.find('.rich-text--paragraph').at(0).text()).toMatch('Sample body text.')
     expect(component.find('.rich-text--paragraph').at(0).text()).toMatch('Example link')
     expect(component.find('.rich-text--paragraph').at(0).html()).toMatch('<a href="http://artsy.net/">')
+    expect(component.find('input').at(2).instance().value).toMatch(props.campaign.panel.pixel_tracking_code)
   })
 
   it('Calls props.onChange on headline change', () => {
@@ -69,9 +76,19 @@ describe('Panel', () => {
       <Panel {...props} />
     )
     component.find('input').at(1).simulate('change', {target: {value: 'http://new-link.com'}})
-    expect(props.onChange.mock.calls[1][0]).toMatch('panel.link.url')
-    expect(props.onChange.mock.calls[1][1]).toMatch('http://new-link.com')
-    expect(props.onChange.mock.calls[1][2]).toBe(props.index)
+    expect(props.onChange.mock.calls[0][0]).toMatch('panel.link.url')
+    expect(props.onChange.mock.calls[0][1]).toMatch('http://new-link.com')
+    expect(props.onChange.mock.calls[0][2]).toBe(props.index)
+  })
+
+  it('Calls props.onChange on pixel_tracking_code change', () => {
+    const component = mount(
+      <Panel {...props} />
+    )
+    component.find('input').at(2).simulate('change', {target: {value: 'new tracking code'}})
+    expect(props.onChange.mock.calls[0][0]).toMatch('panel.pixel_tracking_code')
+    expect(props.onChange.mock.calls[0][1]).toMatch('new tracking code')
+    expect(props.onChange.mock.calls[0][2]).toBe(props.index)
   })
 
   it('Calls props.onChange on body change', () => {
@@ -79,8 +96,8 @@ describe('Panel', () => {
       <Panel {...props} />
     )
     component.find(CharacterLimit).at(1).instance().onChange('new value')
-    expect(props.onChange.mock.calls[2][0]).toMatch('panel.body')
-    expect(props.onChange.mock.calls[2][1]).toMatch('new value')
-    expect(props.onChange.mock.calls[2][2]).toBe(props.index)
+    expect(props.onChange.mock.calls[0][0]).toMatch('panel.body')
+    expect(props.onChange.mock.calls[0][1]).toMatch('new value')
+    expect(props.onChange.mock.calls[0][2]).toBe(props.index)
   })
 })

--- a/src/client/components/image_upload_form/index.styl
+++ b/src/client/components/image_upload_form/index.styl
@@ -56,6 +56,16 @@ fill-form()
   &[data-error=size]
     .size-error
       display block
+  .RemoveButton
+    position absolute
+    right -10px
+    top -10px
+    z-index 10
+    width 30px
+    height 30px
+    cursor pointer
+    &:hover circle
+      fill red-color
 
 .image-upload-form-input
   fill-form()


### PR DESCRIPTION
- Adds support for attaching a `pixel_tracking_code` string to display panel and canvas units
- Also replaces remove-button on `ImageUpload` component, which had lost its styles somewhere.