### PR TITLE
@l2succes => Return default for recognized key commands

### DIFF
--- a/src/client/components/rich_text/test/utils/keybindings.test.js
+++ b/src/client/components/rich_text/test/utils/keybindings.test.js
@@ -4,14 +4,24 @@ const Draft = require('draft-js')
 describe('Draft Utils: Keybindings', () => {
   describe('#keyBindingFnParagraph', () => {
     let e
-    Draft.getDefaultKeyBinding = jest.fn()
-    Draft.KeyBindingUtil.hasCommandModifier = jest.fn()
+
+    beforeEach(() => {
+      Draft.getDefaultKeyBinding = jest.fn()
+      Draft.KeyBindingUtil.hasCommandModifier = jest.fn()
+    })
 
     it('Returns the name of a recognized key binding if command modifier', () => {
       Draft.KeyBindingUtil.hasCommandModifier.mockReturnValueOnce(true)
       e = { keyCode: 75 }
       expect(keyBindingFnParagraph(e)).toBe('link-prompt')
       expect(Draft.getDefaultKeyBinding.mock.calls.length).toBe(0)
+    })
+
+    it('Returns the default key binding if command modifier and not link', () => {
+      Draft.KeyBindingUtil.hasCommandModifier.mockReturnValueOnce(false)
+      e = { keyCode: 73 }
+      keyBindingFnParagraph(e)
+      expect(Draft.getDefaultKeyBinding.mock.calls.length).toBe(1)
     })
 
     it('Returns the default key binding if no command modifier', () => {

--- a/src/client/components/rich_text/utils/keybindings.js
+++ b/src/client/components/rich_text/utils/keybindings.js
@@ -43,10 +43,8 @@ export const keyBindingFnFull = (e) => {
 
 export const keyBindingFnParagraph = (e) => {
   // Custom key commands for paragraph editor
-  if (KeyBindingUtil.hasCommandModifier(e)) {
-    if (e.keyCode === 75) {
-      return 'link-prompt'
-    }
+  if (KeyBindingUtil.hasCommandModifier(e) && e.keyCode === 75) {
+    return 'link-prompt'
   } else {
     return getDefaultKeyBinding(e)
   }


### PR DESCRIPTION
Fixes [GROW-243](https://artsyproduct.atlassian.net/browse/GROW-243)

if/else statement was stopping early for commands with modifier key, updates statement to return default key binding unless key command is 'link'.