### PR TITLE
@xtina-starr => Support pixel_tracking_code in graphql

### DIFF
--- a/src/api/apps/graphql/schemas/display.js
+++ b/src/api/apps/graphql/schemas/display.js
@@ -20,7 +20,8 @@ const unitSchema = Joi.object().meta({
     url: Joi.string()
   }),
   logo: Joi.string(),
-  name: Joi.string()
+  name: Joi.string(),
+  pixel_tracking_code: Joi.string()
 })
 
 const schema = Joi.object().keys({


### PR DESCRIPTION
Forgot one step for `pixel_tracking_code`-- this adds it to the graphql schema so we can query from Force.