### PR TITLE
Fix title ambiguity

### DIFF
--- a/src/client/apps/articles_list/components/articles_list.jsx
+++ b/src/client/apps/articles_list/components/articles_list.jsx
@@ -157,7 +157,7 @@ export class ArticlesList extends Component {
   showArticlesList () {
     const { channel, apiURL, checkable, selected } = this.props
     const isArtsyChannel = (type) => {
-      return type in ['editorial', 'support', 'team']
+      return ['editorial', 'support', 'team'].indexOf(type) >= 0;
     }
 
     if (this.props.articles && this.props.articles.length) {

--- a/src/client/apps/edit/components/content/sections/header/index.jsx
+++ b/src/client/apps/edit/components/content/sections/header/index.jsx
@@ -33,7 +33,7 @@ export class SectionHeader extends Component {
       <PlainText
         content={article.title}
         onChange={(content) => onChange('title', content)}
-        placeholder='Title'
+        placeholder='Page Title'
       />
     )
   }

--- a/src/client/components/article_list/index.jsx
+++ b/src/client/components/article_list/index.jsx
@@ -96,13 +96,13 @@ export class ArticleList extends Component {
           >
             <div className='article-list__image paginated-list-img'
               style={attrs.image ? {backgroundImage: `url(${attrs.image})`} : {}}>
-              {!attrs.image ? <div className='missing-img'>Missing thumbnail</div> : null}
+              {!attrs.image ? <div className='missing-img'>Missing Magazine Thumbnail</div> : null}
             </div>
             <div className='article-list__title paginated-list-text-container'>
               <h2>{article.layout}</h2>
               {attrs.headline
                 ? <h1>{attrs.headline}</h1>
-                : <h1 className='missing-title'>Missing Title</h1>
+                : <h1 className='missing-title'>Missing Magazine Title</h1>
               }
 
               {shouldLockEditing

--- a/src/client/components/article_list/index.jsx
+++ b/src/client/components/article_list/index.jsx
@@ -96,15 +96,18 @@ export class ArticleList extends Component {
           >
             <div className='article-list__image paginated-list-img'
               style={attrs.image ? {backgroundImage: `url(${attrs.image})`} : {}}>
-              {!attrs.image ? <div className='missing-img'>Missing Magazine Thumbnail</div> : null}
+              {!attrs.image
+		 ? <div className='missing-img'>
+		     Missing {this.props.isArtsyChannel ? "Magazine Thumbnail" : <span>Thumbnail<br />Image</span>}
+		   </div>
+		 : null}
             </div>
             <div className='article-list__title paginated-list-text-container'>
               <h2>{article.layout}</h2>
               {attrs.headline
                 ? <h1>{attrs.headline}</h1>
-                : <h1 className='missing-title'>Missing Magazine Title</h1>
+                : <h1 className='missing-title'>Missing {this.props.isArtsyChannel ? "Magazine" : "Thumbnail"} Title</h1>
               }
-
               {shouldLockEditing
                 ? this.currentSessionText(article)
                 : <h2>{this.publishText(article)}</h2>

--- a/src/client/components/article_list/index.styl
+++ b/src/client/components/article_list/index.styl
@@ -58,6 +58,7 @@ thumbnail-width = 145px
       text-align center
       max-width 80%
       margin 0 auto
+      margin-top 23px
   &__preview
     padding 11px 18px
     &.locked

--- a/src/client/components/filter_search/index.coffee
+++ b/src/client/components/filter_search/index.coffee
@@ -55,6 +55,7 @@ module.exports = React.createClass
           checkable: @props.checkable
           selected: @selected
           display: @props.display
+          isArtsyChannel: @props.isArtsyChannel
         }
       else if @props.contentType is 'tag'
         TagList {


### PR DESCRIPTION
Explicitly use Page Title and Magazine Title in placeholders. This should make things more intuitive, e.g. when an article list says Missing Title and the page title was actually set.

Also correctly vertical align the missing thumbnail text

Issue #1576 