### PR TITLE
@eessex => Allow refreshes on changes to partner_ids 

### DIFF
--- a/src/api/apps/users/model.coffee
+++ b/src/api/apps/users/model.coffee
@@ -25,7 +25,13 @@ jwtDecode = require 'jwt-decode'
     return callback err if err
     db.users.findOne { access_token: encryptedAccessToken }, (err, user) ->
       return callback err if err
-      return callback null, user if user
+      if user
+        savedPartnerIds = user.partner_ids #TO STRING THIS TO COMPARE
+        latestPartnerIds = jwtDecode(accessToken)?.partner_ids or []
+        console.log(jwtDecode(accessToken))
+        console.log(savedPartnerIds)
+        console.log(latestPartnerIds)
+        return callback null, user if savedPartnerIds is latestPartnerIds
       # Otherwise fetch data from Gravity and flatten it into a Positron user
       async.parallel [
         (cb) ->

--- a/src/api/apps/users/test/model.test.coffee
+++ b/src/api/apps/users/test/model.test.coffee
@@ -7,7 +7,6 @@ User = rewire '../model'
 gravity = require('antigravity').server
 gravityFabricate = require('antigravity').fabricate
 express = require 'express'
-request = require 'superagent'
 
 app = express()
 app.get '/__gravity/api/v1/user/563d08e6275b247014000026', (req, res, next) ->

--- a/src/api/apps/users/test/model.test.coffee
+++ b/src/api/apps/users/test/model.test.coffee
@@ -7,6 +7,7 @@ User = rewire '../model'
 gravity = require('antigravity').server
 gravityFabricate = require('antigravity').fabricate
 express = require 'express'
+request = require 'superagent'
 
 app = express()
 app.get '/__gravity/api/v1/user/563d08e6275b247014000026', (req, res, next) ->
@@ -52,6 +53,29 @@ describe 'User', ->
       db.users.insert user, ->
         User.fromAccessToken 'foobar', (err, user) ->
           user.name.should.equal 'Craig Spaeth'
+          done()
+
+    it 'returns the user if partner_ids have not changed', (done) ->
+      user = _.extend {}, fixtures().users, {
+        name: 'Kana Abe'
+        partner_ids: ['5086df098523e60002000012']
+        access_token: '$2a$10$PJrPMBadu1NPdmnshBgFbeZG5cyzJHBLK8D73niNWb7bPz5GyKH.u'
+      }
+      db.users.insert user, (err, result) ->
+        User.fromAccessToken 'foobar', (err, user) ->
+          user.name.should.equal 'Kana Abe'
+          done()
+
+    it 'creates a user if there is no user', (done) ->
+      User.fromAccessToken 'foobar', (err, user) ->
+        user.name.should.equal 'Craig Spaeth'
+        done()
+
+    it 'updates a user if partner_ids have changed', (done) ->
+      user = _.extend {}, fixtures().users, partner_ids: []
+      db.users.insert user, ->
+        User.fromAccessToken 'foobar', (err, user) ->
+          user.partner_ids[0].toString().should.equal '5086df098523e60002000012'
           done()
 
   describe '#present', ->


### PR DESCRIPTION
In `fetchFromAccessToken`, we previously returned the user if we have one already, but this is too limiting for users who didn't used to have access to Writer but now do. This checks for differences between what's saved in the database and the JWT and allows for a user's info to be refreshed if it has changed. 