### PR TITLE
@kanaabe => Debounce PlainText change, fix tab-toggle

### DIFF
--- a/src/client/apps/edit/components/header/index.jsx
+++ b/src/client/apps/edit/components/header/index.jsx
@@ -1,21 +1,24 @@
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import * as Actions from 'client/actions/edit/articleActions'
+import { deleteArticle, publishArticle, saveArticle } from 'client/actions/edit/articleActions'
+import { changeView } from 'client/actions/edit/editActions'
 import Icon from '@artsy/reaction/dist/Components/Icon'
 import colors from '@artsy/reaction/dist/Assets/Colors'
 
 export class EditHeader extends Component {
   static propTypes = {
-    actions: PropTypes.any,
     article: PropTypes.object,
     beforeUnload: PropTypes.func,
+    changeViewAction: PropTypes.func,
     channel: PropTypes.object,
+    deleteArticleAction: PropTypes.func,
     edit: PropTypes.object,
     forceURL: PropTypes.string,
-    isAdmin: PropTypes.bool
+    isAdmin: PropTypes.bool,
+    publishArticleAction: PropTypes.func,
+    saveArticleAction: PropTypes.func
   }
 
   isPublishable = () => {
@@ -37,26 +40,26 @@ export class EditHeader extends Component {
   }
 
   onPublish = () => {
-    const { actions } = this.props
+    const { publishArticleAction } = this.props
 
     if (this.isPublishable()) {
-      actions.publishArticle()
+      publishArticleAction()
     }
   }
 
   onSave = () => {
-    const { actions } = this.props
+    const { saveArticleAction } = this.props
 
     this.removeUnsavedAlert()
-    actions.saveArticle()
+    saveArticleAction()
   }
 
   onDelete = () => {
-    const { actions } = this.props
+    const { deleteArticleAction } = this.props
 
     if (confirm('Are you sure?')) {
       this.removeUnsavedAlert()
-      actions.deleteArticle()
+      deleteArticleAction()
     }
   }
 
@@ -110,13 +113,12 @@ export class EditHeader extends Component {
   render () {
     const {
       article,
-      actions,
+      changeViewAction,
       channel,
       edit,
       forceURL,
       isAdmin
     } = this.props
-    const { changeView } = actions
     const { activeView, isDeleting } = edit
     const { grayMedium, greenRegular } = colors
 
@@ -127,7 +129,7 @@ export class EditHeader extends Component {
           <div className='EditHeader__tabs'>
             <button
               className='avant-garde-button check'
-              onClick={() => changeView('content')}
+              onClick={() => changeViewAction('content')}
               data-active={activeView === 'content'}
             >
               <span>Content</span>
@@ -140,7 +142,7 @@ export class EditHeader extends Component {
 
             <button
               className='avant-garde-button check'
-              onClick={() => changeView('display')}
+              onClick={() => changeViewAction('display')}
               data-active={activeView === 'display'}
             >
               <span>Display</span>
@@ -154,7 +156,7 @@ export class EditHeader extends Component {
             {isAdmin &&
               <button
                 className='avant-garde-button'
-                onClick={() => changeView('admin')}
+                onClick={() => changeViewAction('admin')}
                 data-active={activeView === 'admin'}
               >
                 Admin
@@ -220,9 +222,12 @@ const mapStateToProps = (state) => ({
   isAdmin: state.app.isAdmin
 })
 
-const mapDispatchToProps = (dispatch) => ({
-  actions: bindActionCreators(Actions, dispatch)
-})
+const mapDispatchToProps = {
+  changeViewAction: changeView,
+  deleteArticleAction: deleteArticle,
+  publishArticleAction: publishArticle,
+  saveArticleAction: saveArticle
+}
 
 export default connect(
   mapStateToProps,

--- a/src/client/apps/edit/components/header/test/index.test.js
+++ b/src/client/apps/edit/components/header/test/index.test.js
@@ -18,21 +18,19 @@ describe('Edit Header Controls', () => {
 
   beforeEach(() => {
     props = {
-      actions: {
-        changeView: jest.fn(),
-        deleteArticle: jest.fn(),
-        publishArticle: jest.fn(),
-        saveArticle: jest.fn()
-      },
       beforeUnload: jest.fn(),
       article: clone(Fixtures.StandardArticle),
+      changeViewAction: jest.fn(),
       channel: { type: 'partner' },
+      deleteArticleAction: jest.fn(),
       edit: {
         isSaved: true,
         isSaving: false,
         isPublishing: false
       },
-      isAdmin: false
+      isAdmin: false,
+      publishArticleAction: jest.fn(),
+      saveArticleAction: jest.fn()
     }
   })
 
@@ -93,7 +91,7 @@ describe('Edit Header Controls', () => {
       const button = component.find('button').at(1)
       button.simulate('click')
 
-      expect(props.actions.changeView.mock.calls[0][0]).toBe('display')
+      expect(props.changeViewAction.mock.calls[0][0]).toBe('display')
     })
 
     it('Publishes an article on button click', () => {
@@ -102,7 +100,7 @@ describe('Edit Header Controls', () => {
       const button = component.find('button').at(2)
       button.simulate('click')
 
-      expect(props.actions.publishArticle).toBeCalled()
+      expect(props.publishArticleAction).toBeCalled()
     })
 
     it('Unpublishes an article on button click', () => {
@@ -112,7 +110,7 @@ describe('Edit Header Controls', () => {
       const button = component.find('button').at(2)
       button.simulate('click')
 
-      expect(props.actions.publishArticle).toBeCalled()
+      expect(props.publishArticleAction).toBeCalled()
     })
 
     xit('Calls auto-link on button click', () => {
@@ -125,7 +123,7 @@ describe('Edit Header Controls', () => {
       button.simulate('click')
 
       expect(global.confirm.mock.calls.length).toBe(1)
-      expect(props.actions.deleteArticle.mock.calls.length).toBe(1)
+      expect(props.deleteArticleAction.mock.calls.length).toBe(1)
     })
 
     it('Saves an article on button click', () => {
@@ -133,7 +131,7 @@ describe('Edit Header Controls', () => {
       const button = component.find('button').at(4)
       button.simulate('click')
 
-      expect(props.actions.saveArticle.mock.calls.length).toBe(1)
+      expect(props.saveArticleAction.mock.calls.length).toBe(1)
     })
 
     it('Saves a published article on button click', () => {
@@ -142,7 +140,7 @@ describe('Edit Header Controls', () => {
       const button = component.find('button').at(4)
       button.simulate('click')
 
-      expect(props.actions.saveArticle.mock.calls.length).toBe(1)
+      expect(props.saveArticleAction.mock.calls.length).toBe(1)
     })
 
     it('Removes beforeUnload listener on click', () => {

--- a/src/client/components/rich_text/components/plain_text.jsx
+++ b/src/client/components/rich_text/components/plain_text.jsx
@@ -1,3 +1,4 @@
+import { debounce } from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { ContentState, Editor, EditorState } from 'draft-js'
@@ -37,10 +38,14 @@ export class PlainText extends React.Component {
 
     if (currentContentState !== newContentState) {
       // There was a change in the content
-      this.onContentChange(newContent)
+      this.debouncedOnContentChange(newContent)
     }
     this.setState({ editorState })
   }
+
+  debouncedOnContentChange = debounce((content) => {
+    this.onContentChange(content)
+  }, 500)
 
   onContentChange = (content) => {
     if (this.props.name) {

--- a/src/client/components/rich_text/components/plain_text.jsx
+++ b/src/client/components/rich_text/components/plain_text.jsx
@@ -16,6 +16,9 @@ export class PlainText extends React.Component {
 
     const editorState = this.setEditorState()
     this.state = { editorState }
+    this.debouncedOnContentChange = debounce((content) => {
+      this.onContentChange(content)
+    }, 250)
   }
 
   setEditorState () {
@@ -42,10 +45,6 @@ export class PlainText extends React.Component {
     }
     this.setState({ editorState })
   }
-
-  debouncedOnContentChange = debounce((content) => {
-    this.onContentChange(content)
-  }, 500)
 
   onContentChange = (content) => {
     if (this.props.name) {

--- a/src/client/components/rich_text/test/components/plain_text.test.js
+++ b/src/client/components/rich_text/test/components/plain_text.test.js
@@ -64,6 +64,9 @@ describe('PlainText', () => {
     )
     wrapper.instance().refs.editor.focus()
     wrapper.find('.public-DraftEditor-content').simulate('keyUp', { keyCode: 70, which: 70 })
-    expect(wrapper.instance().props.onChange).toHaveBeenCalled()
+    setTimeout(
+      () => expect(wrapper.instance().props().onChange).toHaveBeenCalled(),
+      250
+    )
   })
 })


### PR DESCRIPTION
Taking a stab at fixing up our plainText saving issues -- scrapped the redux state idea for a simpler solution, debouncing changes to the redux state from the text component.  I believe the culprit of this bug is a [race condition](https://draftjs.org/docs/advanced-topics-editorstate-race-conditions.html) between the local editorState and the redux action `onChangeArticle`.

This also fixes a bug introduced in [this PR](https://github.com/artsy/positron/pull/1714), where `changeView` was not being imported correctly. It also removes the use of `bindActionCreators` in favor of explicitly defining each action. 