### PR TITLE
@eessex: Don't bother rebuilding the staging branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,9 @@ workflows:
       - build-and-test:
           filters:
             branches:
-              ignore: release
+              ignore:
+                - staging
+                - release
       - deploy-staging:
           requires:
             - build-and-test


### PR DESCRIPTION
It's minor, but the `staging` branch shouldn't need to be rebuilt since it's a copy of what just succeeded on `master`. It can end up marking safe release PRs as failing when there are spurious failures on the rebuild, as there were [here](https://circleci.com/workflow-run/7c8efe44-57ca-49a7-8d89-2c5fc39c9963).
