### PR TITLE
Update caching strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          name: Restore yarn cache
-          key: yarn-{{ checksum "yarn.lock" }}
+        keys:
+        - yarn-{{ checksum "yarn.lock" }}
+        - yarn-
 
       - run:
           name: Yarn install
-          command: yarn install
+          command: yarn --check-files
 
       - save_cache:
           name: Save yarn cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-        keys:
-        - yarn-{{ checksum "yarn.lock" }}
-        - yarn-
+          keys:
+            - yarn-{{ checksum "yarn.lock" }}
+            - yarn-
 
       - run:
           name: Yarn install


### PR DESCRIPTION
This does two things:

1. Provides a fallback caching strategy for `node_modules`. This means that if the `yarn.lock file` changes it won't have cache but it'll use the last good cache. It'll still have to install/remove some dependencies, but at least it won't have to install all of them
2. Updates the yarn install command to use the `--check-files` flag. This flag forces yarn to look at the actual contents of the `node_modules` directory. It's necessary for the cache fallback strategy. 

Also side note, `yarn` and `yarn install` are equivalent. 