### PR TITLE
Elasticsearch docker config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     working_directory: ~/positron
     docker:
       - image: circleci/node:8-stretch-browsers
-      - image: circleci/elasticsearch
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.4.0
       - image: circleci/mongo:3
 
     steps:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,9 +3408,9 @@ deepmerge@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
 
-default-require-extensions@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
   dependencies:
     strip-bom "^3.0.0"
 
@@ -8843,7 +8843,7 @@ react-lazy-load-image-component@^1.1.1:
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
Use elasticsearch's docker image for circle config rather than non-existent (maybe recently deprecated?) `circleci/elasticsearch`.