### PR TITLE
Update buildpack for deploy process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
 
   deploy-staging:
     docker:
-      - image: buildpack-deps:trusty
+      - image: circleci/node:8-stretch-browsers
     steps:
       - checkout
 
@@ -56,7 +56,7 @@ jobs:
 
   deploy-production:
     docker:
-      - image: buildpack-deps:trusty
+      - image: circleci/node:8-stretch-browsers
     steps:
       - checkout
 


### PR DESCRIPTION
Updates buildpack to `circleci/node:8-stretch-browsers` (matching force) so we can access yarn.