### PR TITLE
Add heroku login to production step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ jobs:
           name: Yarn assets
           command: |
             curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+            bash .circleci/setup_heroku.sh
             yarn install
             yarn assets
             yarn bucket-assets -b positron-production


### PR DESCRIPTION
Confirmed that staging is deploying assets correctly, missed login step for production deploy.