### PR TITLE
@xtina-starr => Section container

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,8 @@
   },
   "rules": {
     "camelcase": 0,
+    "comma-dangle": ["error", "never"],
+    "jsx-quotes": "prefer-double",
     "no-mixed-operators": 0,
     "no-new": 0,
     "react/jsx-indent": 0,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@artsy/express-reloadable": "^1.3.0",
     "@artsy/palette": "^2.10.0",
-    "@artsy/reaction": "^3.10.11",
+    "@artsy/reaction": "^4.5.2",
     "@babel/cli": "7.0.0-rc.2",
     "@babel/core": "7.0.0-rc.2",
     "@babel/node": "7.0.0-rc.2",

--- a/src/client/apps/edit/components/content/section_container/index.jsx
+++ b/src/client/apps/edit/components/content/section_container/index.jsx
@@ -169,7 +169,7 @@ const SectionWrapper = styled.div`
   `}
 `
 
-const HoverControls = styled.div`
+export const HoverControls = styled.div`
   position: absolute;
   width: 100%;
   height: 100%;

--- a/src/client/apps/edit/components/content/section_container/index.jsx
+++ b/src/client/apps/edit/components/content/section_container/index.jsx
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types"
 import React, { Component } from "react"
 import styled from "styled-components"
+import { color } from "@artsy/palette"
 import { connect } from "react-redux"
-import colors from "@artsy/reaction/dist/Assets/Colors"
 import { IconDrag } from "@artsy/reaction/dist/Components/Publishing/Icon/IconDrag"
 import { RemoveButton } from "client/components/remove_button"
 import { removeSection } from "client/actions/edit/sectionActions"
@@ -97,37 +97,47 @@ export class SectionContainer extends Component {
     const { article, isHero, section } = this.props
     const { layout, type } = section
     const sectionWidth = getSectionWidth(section, article.layout)
+    const isEditing = this.isEditing()
+    const isFillwidth = section.layout === "fillwidth"
 
     return (
       <ErrorBoundary>
         <SectionWrapper
           className="SectionContainer"
-          data-editing={this.isEditing()}
-          data-type={type}
+          data-editing={isEditing}
+          data-type={type} // TODO: remove css dependent on data-type & editing
           width={sectionWidth}
           isHero={isHero}
+          isFillwidth={isFillwidth}
         >
-          <div
-            className="SectionContainer__hover-controls"
+          <HoverControls
             onClick={this.onSetEditing}
+            isEditing={isEditing}
+            type={type}
           >
-            {!isHero && (
-              <div className="button-drag">
-                <IconDrag background={colors.grayMedium} />
-              </div>
-            )}
-            <RemoveButton
-              onClick={this.onRemoveSection}
-              background={colors.grayMedium}
-            />
-          </div>
+            {!isEditing &&
+              <>
+                {!isHero && (
+                  <DragButtonContainer isFillwidth={isFillwidth}>
+                    <IconDrag background={color("black30")} />
+                  </DragButtonContainer>
+                )}
+
+                <RemoveButtonContainer isFillwidth={isFillwidth}>
+                  <RemoveButton
+                    onClick={this.onRemoveSection}
+                    background={color("black30")}
+                  />
+                </RemoveButtonContainer>
+              </>
+            }
+          </HoverControls>
 
           {this.getSectionComponent()}
 
-          <div
-            className="SectionContainer__container-bg"
-            onClick={this.onSetEditing}
-          />
+          {isEditing &&
+            <ContainerBackground onClick={this.onSetEditing} />
+          }
         </SectionWrapper>
       </ErrorBoundary>
     )
@@ -149,9 +159,65 @@ export default connect(
 )(SectionContainer)
 
 const SectionWrapper = styled.div`
+  position: relative;
   width: ${props => props.width};
   margin: 0 auto;
+  padding: ${props => props.isFillwidth ? 0 : "20px"};
+
   ${props => props.isHero && `
     margin-top: 20px;
+  `}
+`
+
+const HoverControls = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border: 1px solid ${color("black30")};
+  top: 0;
+  left: 0;
+  opacity: 0;
+  &:hover {
+    opacity: 1;
+  }
+  ${props => props.isEditing && `
+    opacity: 1;
+    border-color: ${props.type === "text" ? color("white100") : color("black100")};
+  `}
+`
+
+const ContainerBackground = styled.div`
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1;
+`
+
+const IconContainer = styled.div`
+  width: 30px;
+  position: absolute;
+  right: -15px;
+  cursor: pointer;
+  ${props => props.isFillwidth && `
+    right: 18px;
+  `}
+`
+
+const RemoveButtonContainer = styled(IconContainer)`
+  top: -15px;
+  &:hover circle {
+    fill: ${color("red100")}
+  }
+  ${props => props.isFillwidth && `
+    top: 20px;
+  `}
+`
+
+const DragButtonContainer = styled(IconContainer)`
+  top: 25px;
+  ${props => props.isFillwidth && `
+    top: 60px;
   `}
 `

--- a/src/client/apps/edit/components/content/section_container/index.jsx
+++ b/src/client/apps/edit/components/content/section_container/index.jsx
@@ -1,11 +1,12 @@
 import PropTypes from "prop-types"
 import React, { Component } from "react"
+import styled from "styled-components"
 import { connect } from "react-redux"
 import colors from "@artsy/reaction/dist/Assets/Colors"
 import { IconDrag } from "@artsy/reaction/dist/Components/Publishing/Icon/IconDrag"
 import { RemoveButton } from "client/components/remove_button"
 import { removeSection } from "client/actions/edit/sectionActions"
-
+import { getSectionWidth } from "@artsy/reaction/dist/Components/Publishing/Sections/SectionContainer"
 import SectionImages from "../sections/images"
 import SectionSlideshow from "../sections/slideshow"
 import SectionText from "../sections/text"
@@ -93,16 +94,18 @@ export class SectionContainer extends Component {
   }
 
   render() {
-    const { isHero, section } = this.props
+    const { article, isHero, section } = this.props
     const { layout, type } = section
+    const sectionWidth = getSectionWidth(section, article.layout)
 
     return (
       <ErrorBoundary>
-        <div
+        <SectionWrapper
           className="SectionContainer"
           data-editing={this.isEditing()}
-          data-layout={layout || "column_width"}
           data-type={type}
+          width={sectionWidth}
+          isHero={isHero}
         >
           <div
             className="SectionContainer__hover-controls"
@@ -125,7 +128,7 @@ export class SectionContainer extends Component {
             className="SectionContainer__container-bg"
             onClick={this.onSetEditing}
           />
-        </div>
+        </SectionWrapper>
       </ErrorBoundary>
     )
   }
@@ -144,3 +147,11 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(SectionContainer)
+
+const SectionWrapper = styled.div`
+  width: ${props => props.width};
+  margin: 0 auto;
+  ${props => props.isHero && `
+    margin-top: 20px;
+  `}
+`

--- a/src/client/apps/edit/components/content/section_container/index.styl
+++ b/src/client/apps/edit/components/content/section_container/index.styl
@@ -83,36 +83,3 @@
     .button-drag
       right 18px
       top 60px
-
-[data-layout='classic']
-  [data-layout='column_width'], [data-layout='blockquote']
-    max-width classic-body-w-margin
-    margin 0 auto
-  [data-layout='overflow_fillwidth']
-    max-width classic-overflow-w-margin
-    margin 0 auto
-  .edit-section--hero
-    margin 40px auto 20px auto
-    [data-layout='column_width'], [data-layout='overflow_fillwidth']
-      max-width 1140px
-
-[data-layout='standard']
-  [data-layout='column_width'], [data-type=image_set]
-    max-width standard-body-w-margin
-    margin 0 auto
-  [data-layout='overflow_fillwidth'], [data-layout='blockquote']
-    max-width standard-overflow-w-margin
-
-[data-layout='feature']
-  [data-layout='column_width'], [data-type=image_set]
-    max-width feature-body-w-margin
-    margin 0 auto
-  [data-layout='overflow_fillwidth']
-    max-width feature-overflow-w-margin
-    margin 0 auto
-  [data-layout='blockquote']
-    max-width feature-blockquote-width
-    margin 0 auto
-  [data-layout='fillwidth']
-    max-width 100%
-    padding 0 0 20px 0

--- a/src/client/apps/edit/components/content/section_container/index.styl
+++ b/src/client/apps/edit/components/content/section_container/index.styl
@@ -1,13 +1,5 @@
 @import '../../stylus_lib'
 
-@keyframes fadein
-  0% {
-    opacity 0
-  }
-  100% {
-    opacity 1
-  }
-
 .edit-section__placeholder
   min-height 150px
   display flex

--- a/src/client/apps/edit/components/content/section_container/index.styl
+++ b/src/client/apps/edit/components/content/section_container/index.styl
@@ -8,57 +8,6 @@
     opacity 1
   }
 
-.SectionContainer
-  animation fadein 0.15s
-  z-index 1
-  transition transform .15s
-  width 100%
-  position relative
-  padding 20px
-
-.SectionContainer__hover-controls
-  position absolute
-  width 100%
-  height 100%
-  border 1px solid rgba(100,100,100,0.33)
-  top 0
-  left 0
-  opacity 0
-  .button-drag,
-  .RemoveButton
-    position absolute
-    right -15px
-    width 30px
-  .RemoveButton
-    top -15px
-    &:hover circle
-      fill red-color
-  .button-drag
-    top 25px
-
-.SectionContainer__container-bg
-  width 100%
-  height 100%
-  position fixed
-  top 0
-  left 0
-  z-index 1
-  display none
-
-.SectionContainer:hover
-  .SectionContainer__hover-controls
-    opacity 1
-.SectionContainer[data-editing=true]
-  .SectionContainer__hover-controls
-    opacity 1
-    border 1px solid rgba(100,100,100,1)
-    .button-drag,
-    .RemoveButton
-      opacity 0
-  .SectionContainer__container-bg
-    display block
-    z-index -1
-
 .edit-section__placeholder
   min-height 150px
   display flex
@@ -71,15 +20,3 @@
       min-width 100%
     a
       background-size 1px 1px
-
-[data-layout='fillwidth']
-  &[data-editing='false']
-     .SectionContainer__hover-controls
-        z-index 100
-  .SectionContainer__hover-controls
-    .RemoveButton
-      right 18px
-      top 20px
-    .button-drag
-      right 18px
-      top 60px

--- a/src/client/apps/edit/components/content/section_container/test/index.test.js
+++ b/src/client/apps/edit/components/content/section_container/test/index.test.js
@@ -11,7 +11,7 @@ import { SectionText } from "../../sections/text/index.jsx"
 import { SectionEmbed } from "../../sections/embed"
 import { SectionImages } from "../../sections/images"
 import { SectionVideo } from "../../sections/video"
-import { SectionContainer } from "../index"
+import { SectionContainer, HoverControls } from "../index"
 require("typeahead.js")
 
 describe("SectionContainer", () => {
@@ -58,16 +58,23 @@ describe("SectionContainer", () => {
   })
 
   it("Renders drag and remove icons", () => {
+    props.sectionIndex = 0
     const component = getWrapper(props)
     expect(component.find(RemoveButton).length).toBe(1)
     expect(component.find(IconDrag).length).toBe(1)
+  })
+
+  it("Does not renders drag and remove icons if editing", () => {
+    const component = getWrapper(props)
+    expect(component.find(RemoveButton).length).toBe(0)
+    expect(component.find(IconDrag).length).toBe(0)
   })
 
   it("Calls onSetEditing with index on section click", () => {
     props.sectionIndex = 0
     const component = getWrapper(props)
     component
-      .find(".SectionContainer__hover-controls")
+      .find(HoverControls)
       .at(0)
       .simulate("click")
     expect(props.onSetEditing.mock.calls[0][0]).toBe(props.index)
@@ -77,13 +84,14 @@ describe("SectionContainer", () => {
     const component = getWrapper(props)
 
     component
-      .find(".SectionContainer__hover-controls")
+      .find(HoverControls)
       .at(0)
       .simulate("click")
     expect(props.onSetEditing.mock.calls[0][0]).toBe(null)
   })
 
   it("Can remove a section click", () => {
+    props.sectionIndex = 0
     const component = getWrapper(props)
     component
       .find(RemoveButton)
@@ -125,8 +133,7 @@ describe("SectionContainer", () => {
     })
 
     it("Can render a text section", () => {
-      props.sectionIndex = 0
-      props.section = { type: "text" }
+      props.section = { type: "text", body: "" }
       const component = getWrapper(props)
       expect(component.find(SectionText).length).toBe(1)
     })

--- a/src/client/apps/edit/components/content/section_controls/index.jsx
+++ b/src/client/apps/edit/components/content/section_controls/index.jsx
@@ -6,8 +6,10 @@
 import styled from "styled-components"
 import PropTypes from "prop-types"
 import React, { Component } from "react"
+import { color } from "@artsy/palette"
 import { connect } from "react-redux"
 import LayoutControls from "./layout"
+import { getSectionWidth } from "@artsy/reaction/dist/Components/Publishing/Sections/SectionContainer"
 
 export class SectionControls extends Component {
   static propTypes = {
@@ -112,21 +114,26 @@ export class SectionControls extends Component {
   }
 
   render() {
-    const { children, disabledAlert, isHero, showLayouts } = this.props
+    const { article, children, disabledAlert, isHero, section, showLayouts } = this.props
     const { insideComponent } = this.state
 
     const outsidePosition = isHero ? "relative" : "absolute"
     const position = insideComponent ? "fixed" : outsidePosition
     const bottom = this.getPositionBottom()
+    const sectionWidth = getSectionWidth(section, article.layout)
+    const isFillwidth = section.layout === "fillwidth"
 
     return (
       <SectionControlsContainer
         innerRef={node => {
           this.controls = node
         }}
-        className={"SectionControls edit-controls"}
+        className="SectionControls edit-controls"
         position={position}
         bottom={bottom}
+        isFillwidth={isFillwidth}
+        isHero={isHero}
+        width={sectionWidth}
       >
         {showLayouts && <LayoutControls disabledAlert={disabledAlert} />}
 
@@ -136,7 +143,9 @@ export class SectionControls extends Component {
   }
 }
 const mapStateToProps = state => ({
+  article: state.edit.article,
   channel: state.app.channel,
+  section: state.edit.section
 })
 
 export default connect(mapStateToProps)(SectionControls)
@@ -144,4 +153,15 @@ export default connect(mapStateToProps)(SectionControls)
 const SectionControlsContainer = styled.div`
   bottom: ${props => props.bottom};
   position: ${props => props.position};
+  width: ${props => props.width};
+  margin-left: ${props => props.isFillwidth ? 0 : "-20px"};
+  background: ${color("black100")};
+  z-index: 5;
+  max-width: calc(100vw - 110px);
+
+  ${props => props.isHero && `
+    width: calc(100% + 40px);
+    padding-top: 20px;
+    margin-top: -20px;
+  `}
 `

--- a/src/client/apps/edit/components/content/section_controls/index.jsx
+++ b/src/client/apps/edit/components/content/section_controls/index.jsx
@@ -18,6 +18,7 @@ export class SectionControls extends Component {
     disabledAlert: PropTypes.func,
     isHero: PropTypes.bool,
     showLayouts: PropTypes.bool,
+    section: PropTypes.object
   }
 
   state = {
@@ -121,19 +122,20 @@ export class SectionControls extends Component {
     const position = insideComponent ? "fixed" : outsidePosition
     const bottom = this.getPositionBottom()
     const sectionWidth = getSectionWidth(section, article.layout)
-    const isFillwidth = section.layout === "fillwidth"
+    const isFillwidth = !isHero && section.layout === "fillwidth"
 
     return (
       <SectionControlsContainer
         innerRef={node => {
           this.controls = node
         }}
-        className="SectionControls edit-controls"
+        className="edit-controls"
         position={position}
         bottom={bottom}
         isFillwidth={isFillwidth}
         isHero={isHero}
         width={sectionWidth}
+        type={!isHero && section.type}
       >
         {showLayouts && <LayoutControls disabledAlert={disabledAlert} />}
 
@@ -158,6 +160,9 @@ const SectionControlsContainer = styled.div`
   background: ${color("black100")};
   z-index: 5;
   max-width: calc(100vw - 110px);
+  ${props => props.type === "social_embed" && `
+    padding-top: 20px;
+  `}
 
   ${props => props.isHero && `
     width: calc(100% + 40px);

--- a/src/client/apps/edit/components/content/section_controls/index.styl
+++ b/src/client/apps/edit/components/content/section_controls/index.styl
@@ -1,11 +1,4 @@
 .edit-controls
-  background black
-  z-index 5
-  height auto
-  top inherit
-  width 100%
-  max-width calc(100vw \- 110px)
-  margin-left -20px
   &__layout
     width 100%
     text-align center
@@ -46,42 +39,6 @@
   &[name=image_set]
     background-image url(/icons/edit_image_set_slideshow.svg)
     background-size 22px
-
-[data-layout='standard'] .SectionContainer
-  &[data-layout=column_width] .edit-controls
-    max-width standard-body-w-margin
-  &[data-layout=overflow_fillwidth],
-  &[data-type=image_set]
-    .edit-controls
-      max-width standard-overflow-w-margin
-
-[data-layout='classic']
-  .SectionContainer
-    &[data-layout=column_width] .edit-controls
-      max-width classic-body-w-margin
-    &[data-layout=overflow_fillwidth],
-    &[data-type=image_set]
-      .edit-controls
-        max-width classic-overflow-w-margin
-  .edit-section--hero
-    .SectionContainer
-      &[data-layout=column_width]
-      &[data-layout=overflow_fillwidth]
-        .edit-controls
-          min-width calc(100% + 40px)
-          margin-top -20px
-          margin-bottom 30px
-          padding-top 20px
-
-[data-layout='feature'] .SectionContainer
-  &[data-layout=column_width] .edit-controls
-    max-width feature-body-w-margin
-  &[data-layout=fillwidth] .edit-controls
-    margin-left 0
-  &[data-layout=overflow_fillwidth],
-  &[data-type=image_set]
-    .edit-controls
-      max-width feature-overflow-w-margin
 
 [data-layout='news'] .SectionContainer
   &[data-type=image_collection]

--- a/src/client/apps/edit/components/content/sections/images/index.styl
+++ b/src/client/apps/edit/components/content/sections/images/index.styl
@@ -116,14 +116,7 @@
     width 100%
     margin-right 0
 
-[data-layout='standard']
-  .SectionContainer[data-type=image_set][data-editing=true]
-    max-width standard-overflow-w-margin
-
 [data-layout='feature']
-  .SectionContainer[data-type=image_set][data-editing=true]
-    max-width feature-overflow-w-margin
-    margin 0 auto
   .SectionContainer[data-type=image_collection][data-layout=fillwidth]
     .drag-container
       flex-direction column
@@ -140,6 +133,3 @@
       &:hover circle
         fill red-color
 
-[data-layout='classic']
-  .SectionContainer[data-type=image_set][data-editing=true]
-    max-width classic-overflow-w-margin

--- a/src/client/apps/edit/components/content/sections/social_embed/controls.jsx
+++ b/src/client/apps/edit/components/content/sections/social_embed/controls.jsx
@@ -28,28 +28,27 @@ export class SocialEmbedControls extends Component {
     const { onChangeSectionAction, section } = this.props
 
     return (
-      <div className="SocialEmbedControls">
-        <SectionControls section={section}>
-          <Row>
-            <Col xs={12}>
-              <h2>Social URL</h2>
-              <input
-                autoFocus
-                className="bordered-input bordered-input-dark"
-                value={section.url || ""}
-                onChange={e => onChangeSectionAction("url", e.target.value)}
-                placeholder="https://www.instagram.com/"
-              />
-            </Col>
-          </Row>
-        </SectionControls>
-      </div>
+      <SectionControls>
+        <Row>
+          <Col xs={12}>
+            <h2>Social URL</h2>
+            <input
+              autoFocus
+              className="bordered-input bordered-input-dark"
+              value={section.url || ""}
+              onChange={e => onChangeSectionAction("url", e.target.value)}
+              placeholder="https://www.instagram.com/"
+            />
+          </Col>
+        </Row>
+      </SectionControls>
     )
   }
 }
 
 const mapStateToProps = state => ({
   sectionIndex: state.edit.sectionIndex,
+  section: state.edit.section
 })
 
 const mapDispatchToProps = {

--- a/src/client/apps/edit/components/content/sections/social_embed/index.jsx
+++ b/src/client/apps/edit/components/content/sections/social_embed/index.jsx
@@ -9,16 +9,16 @@ export const SectionSocialEmbed = props => {
   const { editing, section } = props
 
   return (
-    <section className="SectionEmbed">
-      {editing && <SocialEmbedControls section={section} />}
+    <section>
+      {editing && <SocialEmbedControls />}
 
       {section.url ? (
         <SocialEmbed section={section} />
       ) : (
-        <div className="edit-section__placeholder">
-          Add Twitter or Instagram URL above
+          <div className="edit-section__placeholder">
+            Add Twitter or Instagram URL above
         </div>
-      )}
+        )}
     </section>
   )
 }

--- a/src/client/apps/edit/components/content/sections/social_embed/test/controls.test.js
+++ b/src/client/apps/edit/components/content/sections/social_embed/test/controls.test.js
@@ -10,6 +10,7 @@ import { SocialEmbedControls } from "../controls"
 describe("SocialEmbedControls", () => {
   let props
   let section
+  let article
 
   SectionControls.prototype.isScrollingOver = jest.fn()
   SectionControls.prototype.isScrolledPast = jest.fn()
@@ -39,8 +40,10 @@ describe("SocialEmbedControls", () => {
 
   beforeEach(() => {
     section = cloneDeep(NewsArticle.sections[2])
+    article = cloneDeep(NewsArticle)
 
     props = {
+      article,
       onChangeSectionAction: jest.fn(),
       removeSectionAction: jest.fn(),
       section,

--- a/src/client/apps/edit/components/content/sections/text/index.jsx
+++ b/src/client/apps/edit/components/content/sections/text/index.jsx
@@ -182,10 +182,6 @@ export class SectionText extends Component {
       )
 
       if (newState) {
-        if (hasBlockquote) {
-          // remove layout/blockquotes when merging sections together
-          onChangeSectionAction("layout", null)
-        }
         this.onChange(newState)
         removeSectionAction(beforeIndex)
         onSetEditing(beforeIndex)
@@ -346,7 +342,6 @@ export class SectionText extends Component {
       Config.composedDecorator(article.layout)
     )
     this.onChange(stateWithBlockquote)
-    onChangeSectionAction("layout", "blockquote")
     // Add new blocks before/after if applicable
     if (afterBlock) {
       newSectionAction("text", index + 1, { body: afterBlock })

--- a/src/client/apps/edit/components/content/sections/text/test/index.test.js
+++ b/src/client/apps/edit/components/content/sections/text/test/index.test.js
@@ -209,8 +209,6 @@ describe("SectionText", () => {
       expect(props.onChangeSectionAction.mock.calls[0][1]).toBe(
         "<blockquote>A blockquote.</blockquote>"
       )
-      expect(props.onChangeSectionAction.mock.calls[1][0]).toBe("layout")
-      expect(props.onChangeSectionAction.mock.calls[1][1]).toBe("blockquote")
       expect(props.newSectionAction).not.toBeCalled()
     })
 
@@ -226,8 +224,6 @@ describe("SectionText", () => {
       expect(props.onChangeSectionAction.mock.calls[0][1]).toBe(
         "<blockquote>A blockquote.</blockquote>"
       )
-      expect(props.onChangeSectionAction.mock.calls[1][0]).toBe("layout")
-      expect(props.onChangeSectionAction.mock.calls[1][1]).toBe("blockquote")
       expect(props.newSectionAction.mock.calls[0][0]).toBe("text")
       expect(props.newSectionAction.mock.calls[0][1]).toBe(props.index + 1)
       expect(props.newSectionAction.mock.calls[0][2].body).toBe(
@@ -247,8 +243,6 @@ describe("SectionText", () => {
       expect(props.onChangeSectionAction.mock.calls[0][1]).toBe(
         "<blockquote>A blockquote.</blockquote>"
       )
-      expect(props.onChangeSectionAction.mock.calls[1][0]).toBe("layout")
-      expect(props.onChangeSectionAction.mock.calls[1][1]).toBe("blockquote")
       expect(props.newSectionAction.mock.calls[0][0]).toBe("text")
       expect(props.newSectionAction.mock.calls[0][1]).toBe(props.index)
       expect(props.newSectionAction.mock.calls[0][2].body).toBe(
@@ -368,8 +362,6 @@ describe("SectionText", () => {
       expect(handleBackspace).toBe("handled")
       expect(props.removeSectionAction.mock.calls[0][0]).toBe(props.index - 1)
       expect(component.state().html).toMatch("<p>Hello</p>")
-      expect(props.onChangeSectionAction.mock.calls[0][0]).toBe("layout")
-      expect(props.onChangeSectionAction.mock.calls[0][1]).toBeFalsy()
       expect(component.state().html).toMatch(
         article.sections[props.index - 1].body
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,20 +17,20 @@
     react "^16.3.2"
     styled-system "^2.2.5"
 
-"@artsy/palette@^2.17.4":
-  version "2.17.4"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.17.4.tgz#0a69a461b4bfe17bae3c7130c5cd1c72a67b9af9"
+"@artsy/palette@^2.18.0":
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.18.1.tgz#876055f1cb85f32f18a1953aeef8a18aefee8bc6"
   dependencies:
     rc-slider "^8.6.2"
     react "^16.5.0"
     styled-reset "^1.3.7"
     styled-system "^3.0.3"
 
-"@artsy/reaction@^3.10.11":
-  version "3.10.11"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-3.10.11.tgz#0bcceab1e047b645ce6b39d8f4f570c1661708bc"
+"@artsy/reaction@^4.5.2":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-4.5.3.tgz#6f139020d4684a76c8410bc8e94253a4e07f6db0"
   dependencies:
-    "@artsy/palette" "^2.17.4"
+    "@artsy/palette" "^2.18.0"
     cheerio "^1.0.0-rc.2"
     farce "^0.2.6"
     formik "^0.11.11"
@@ -68,6 +68,7 @@
     react-transition-group "^2.3.0"
     react-url-query "^1.1.4"
     react-waypoint "^7.3.3"
+    relay-mock-network-layer "^1.2.0"
     relay-runtime "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-runtime-1.5.0-artsy.3.tgz"
     serialize-javascript "^1.5.0"
     sharify "^0.1.6"
@@ -924,6 +925,10 @@
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
+
+"@types/graphql@^0.9.0":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.9.4.tgz#cdeb6bcbef9b6c584374b81aa7f48ecf3da404fa"
 
 "@types/jest@^21.1.9":
   version "21.1.9"
@@ -3511,6 +3516,10 @@ depd@1.1.0, depd@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
 
+deprecated-decorator@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
+
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
@@ -5005,6 +5014,15 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+graphql-tools@^1.2.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-1.2.3.tgz#079bf4d157e46c0a0bae9fec117e0eea6e03ba2c"
+  dependencies:
+    deprecated-decorator "^0.1.6"
+    uuid "^3.0.1"
+  optionalDependencies:
+    "@types/graphql" "^0.9.0"
 
 graphql@^0.13.0:
   version "0.13.1"
@@ -8944,7 +8962,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
+"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 
@@ -9528,6 +9546,12 @@ regjsparser@^0.3.0:
     relay-runtime "1.5.0-artsy.5"
     signedsource "^1.0.0"
     yargs "^9.0.0"
+
+relay-mock-network-layer@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/relay-mock-network-layer/-/relay-mock-network-layer-1.2.0.tgz#bcf30aa2d8c9c840f6c5744d008663c2f57a7819"
+  dependencies:
+    graphql-tools "^1.2.1"
 
 relay-runtime@1.5.0-artsy.5, "relay-runtime@https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-runtime-1.5.0-artsy.3.tgz", "relay-runtime@https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-runtime-1.5.0-artsy.5.tgz":
   version "1.5.0-artsy.5"
@@ -11371,6 +11395,10 @@ uuid@2.x.x:
 uuid@3.0.0, uuid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
+
+uuid@^3.0.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 uuid@^3.1.0:
   version "3.2.1"


### PR DESCRIPTION
Follows up https://github.com/artsy/reaction/pull/1278

- Updates `eslint` config to match new `prettier` rules
- Removes addition/removal of `section.layout` for `<blockquote>` text in `Text` component
- Updates `SectionContainer` and `SectionControls` to use new Reaction `getSectionWidth` to determine width
- Converts some css from above components to `styled` component

TODO: Backfill to remove existing `section.layout: "blockquote"`