### PR TITLE
@l2succes => Paragraph supports readonly

### DIFF
--- a/src/client/apps/edit/components/content/sections/video/index.jsx
+++ b/src/client/apps/edit/components/content/sections/video/index.jsx
@@ -72,6 +72,7 @@ export class SectionVideo extends Component {
             onChange={html => this.onChange("caption", html)}
             placeholder="Video Caption (required)"
             stripLinebreaks
+            isReadOnly={!editing}
           />
         </Video>
       )

--- a/src/client/apps/edit/components/content/sections/video/test/index.test.js
+++ b/src/client/apps/edit/components/content/sections/video/test/index.test.js
@@ -1,5 +1,6 @@
 import React from "react"
 import configureStore from "redux-mock-store"
+import { Editor } from "draft-js"
 import { Provider } from "react-redux"
 import { clone, extend } from "lodash"
 import { mount } from "enzyme"
@@ -123,6 +124,11 @@ describe("Video", () => {
       )
     })
 
+    it("Sets caption to readOnly if not editing", () => {
+      const component = getWrapper(props)
+      expect(component.find(Editor).props().readOnly).toBe(true)
+    })
+
     it("Renders a saved caption", () => {
       props.editing = true
       const component = getWrapper(props)
@@ -145,6 +151,7 @@ describe("Video", () => {
         .props.onChange(caption)
       expect(props.onChangeSectionAction.mock.calls[0][0]).toBe("caption")
       expect(props.onChangeSectionAction.mock.calls[0][1]).toBe(caption)
+      expect(component.find(Editor).props().readOnly).toBe(false)
     })
   })
 

--- a/src/client/components/draft/paragraph/paragraph.tsx
+++ b/src/client/components/draft/paragraph/paragraph.tsx
@@ -27,6 +27,7 @@ interface Props {
   placeholder?: string
   stripLinebreaks: boolean
   isDark?: boolean
+  isReadOnly?: boolean
 }
 
 interface State {
@@ -269,7 +270,7 @@ export class Paragraph extends Component<Props, State> {
   }
 
   render() {
-    const { hasLinks, isDark, placeholder } = this.props
+    const { hasLinks, isDark, isReadOnly, placeholder } = this.props
     const {
       editorState,
       selectionTarget,
@@ -314,6 +315,7 @@ export class Paragraph extends Component<Props, State> {
             handleReturn={this.handleReturn}
             onChange={this.onChange}
             placeholder={placeholder || "Start typing..."}
+            readOnly={isReadOnly}
             ref={ref => {
               this.editor = ref
             }}


### PR DESCRIPTION
QA for Paragraph changes -- adds `isReadOnly` prop to `Paragraph` component.

Also fixes https://artsyproduct.atlassian.net/browse/GROW-663 except for `feature` layouts -- which for some reason hide captions in Reaction (cc @owendodd, do we have a good reason for this?)

