### PR TITLE
Setup /edit2 route, new actions for text

### DIFF
--- a/src/client/actions/edit/sectionActions.js
+++ b/src/client/actions/edit/sectionActions.js
@@ -73,6 +73,45 @@ export const onChangeSection = (key, value) => {
   }
 }
 
+export const onSplitTextSection = (sectionIndex, existingSectionBody, newSectionBody) => {
+  return (dispatch, getState) => {
+    const {
+      edit: { article },
+    } = getState()
+
+    dispatch(changeSection("body", existingSectionBody))
+    dispatch(newSection("text", sectionIndex + 1, { body: newSectionBody }))
+
+    if (!article.published) {
+      debouncedSaveDispatch(dispatch)
+    }
+  }
+}
+
+export const onMergeTextSections = (sectionIndex, newHtml) => {
+  return (dispatch, getState) => {
+    dispatch(changeSection("body", newHtml))
+    dispatch(removeSection(sectionIndex - 1))
+    dispatch(setSection(sectionIndex - 1))
+  }
+}
+
+export const onInsertBlockquote = (blockquoteHtml, beforeHtml, afterHtml) => {
+  return (dispatch, getState) => {
+    const {
+      edit: { sectionIndex },
+    } = getState()
+
+    dispatch(changeSection("body", blockquoteHtml))
+    if (afterHtml) {
+      dispatch(newSection("text", sectionIndex + 1, { body: afterHtml }))
+    }
+    if (beforeHtml) {
+      dispatch(newSection("text", sectionIndex, { body: beforeHtml }))
+    }
+  }
+}
+
 export const removeSection = sectionIndex => {
   return (dispatch, getState) => {
     const {

--- a/src/client/actions/edit/sectionActions.js
+++ b/src/client/actions/edit/sectionActions.js
@@ -103,15 +103,17 @@ export const maybeMergeTextSections = () => {
         sectionIndex
       },
     } = getState()
-    const sectionBefore = sections[sectionIndex - 1]
-    const sectionBeforeIsText = sectionBefore && sectionBefore.type === "text"
+    if (sections.length && sectionIndex !== 0) {
+      const sectionBefore = sections[sectionIndex - 1]
+      const sectionBeforeIsText = sectionBefore && sectionBefore.type === "text"
 
-    if (sectionBeforeIsText) {
-      const newHtml = sectionBefore.body + section.body
-      const strippedHtml = newHtml
-        .replace("<blockquote>", "<p>")
-        .replace("</blockquote>", "</p>")
-      dispatch(onMergeTextSections(strippedHtml))
+      if (sectionBeforeIsText) {
+        const newHtml = sectionBefore.body + section.body
+        const strippedHtml = newHtml
+          .replace("<blockquote>", "<p>")
+          .replace("</blockquote>", "</p>")
+        dispatch(onMergeTextSections(strippedHtml))
+      }
     }
   }
 }

--- a/src/client/actions/test/edit/sectionActions.test.js
+++ b/src/client/actions/test/edit/sectionActions.test.js
@@ -1,8 +1,12 @@
 import {
+  maybeMergeTextSections,
   newSection,
   newHeroSection,
   onChangeSection,
   onChangeHero,
+  onInsertBlockquote,
+  onMergeTextSections,
+  onSplitTextSection,
   removeSection,
   setSection,
 } from "client/actions/edit/sectionActions"
@@ -16,6 +20,13 @@ describe("sectionActions", () => {
     article = cloneDeep(FeatureArticle)
   })
 
+  it("#setSection sets sectionIndex to arg", () => {
+    const action = setSection(6)
+
+    expect(action.type).toBe("SET_SECTION")
+    expect(action.payload.sectionIndex).toBe(6)
+  })
+
   describe("#newSection", () => {
     it("Can create an embed section", () => {
       const action = newSection("embed", 3)
@@ -26,6 +37,17 @@ describe("sectionActions", () => {
       expect(section.url).toBe("")
       expect(section.layout).toBe("column_width")
       expect(section.height).toBe("")
+      expect(sectionIndex).toBe(3)
+    })
+
+    it("Can create a social_embed section", () => {
+      const action = newSection("social_embed", 3)
+      const { section, sectionIndex } = action.payload
+
+      expect(action.type).toBe("NEW_SECTION")
+      expect(section.type).toBe("social_embed")
+      expect(section.url).toBe("")
+      expect(section.layout).toBe("column_width")
       expect(sectionIndex).toBe(3)
     })
 
@@ -50,17 +72,6 @@ describe("sectionActions", () => {
       expect(sectionIndex).toBe(3)
     })
 
-    it("Can create a blockquote section", () => {
-      const action = newSection("blockquote", 3)
-      const { section, sectionIndex } = action.payload
-
-      expect(action.type).toBe("NEW_SECTION")
-      expect(section.type).toBe("text")
-      expect(section.body).toBe("")
-      expect(section.layout).toBe("blockquote")
-      expect(sectionIndex).toBe(3)
-    })
-
     it("Can create a video section", () => {
       const action = newSection("video", 3)
       const { section, sectionIndex } = action.payload
@@ -75,13 +86,12 @@ describe("sectionActions", () => {
     it("Can add attributes to a new section", () => {
       const body =
         "<p>The Precarious, Glamorous Lives of Independent Curators</p>"
-      const action = newSection("blockquote", 3, { body })
+      const action = newSection("text", 3, { body })
       const { section, sectionIndex } = action.payload
 
       expect(action.type).toBe("NEW_SECTION")
       expect(section.type).toBe("text")
       expect(section.body).toBe(body)
-      expect(section.layout).toBe("blockquote")
       expect(sectionIndex).toBe(3)
     })
   })
@@ -219,10 +229,266 @@ describe("sectionActions", () => {
     )
   })
 
-  it("#setSection sets sectionIndex to arg", () => {
-    const action = setSection(6)
+  describe("#onSplitTextSection", () => {
+    let dispatch
+    let getState
+    const sectionIndex = 0
+    beforeEach(() => {
+      dispatch = jest.fn()
+    })
+    const sectionOne = "<p>First section</p>"
+    const sectionTwo = "<p>Second section</p>"
 
-    expect(action.type).toBe("SET_SECTION")
-    expect(action.payload.sectionIndex).toBe(6)
+    it("Updates current section with updated html", () => {
+      getState = jest.fn(() => ({
+        edit: { article, sectionIndex },
+      }))
+      onSplitTextSection(sectionOne, sectionTwo)(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+
+      const { type, payload } = dispatch.mock.calls[2][0]
+      expect(type).toBe("CHANGE_SECTION")
+      expect(payload.value).toBe(sectionOne)
+    })
+
+    it("Adds a new section with new html", () => {
+      getState = jest.fn(() => ({
+        edit: { article, sectionIndex },
+      }))
+      onSplitTextSection(sectionOne, sectionTwo)(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+
+      const { type, payload } = dispatch.mock.calls[1][0]
+      expect(type).toBe("NEW_SECTION")
+      expect(payload.section.type).toBe("text")
+      expect(payload.section.body).toBe(sectionTwo)
+    })
+
+    it("Saves article if unpublished", done => {
+      article.published = false
+      getState = jest.fn(() => ({
+        edit: { article, sectionIndex },
+      }))
+      onSplitTextSection(sectionOne, sectionTwo)(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+
+      setTimeout(() => {
+        dispatch.mock.calls[3][0](dispatch, getState)
+        expect(dispatch.mock.calls[4][0].type).toBe("SAVE_ARTICLE")
+        done()
+      }, 500)
+    })
+  })
+
+  describe("#onInsertBlockquote", () => {
+    let dispatch
+    let getState
+    beforeEach(() => {
+      dispatch = jest.fn()
+    })
+
+    const blockquoteHtml = "<blockquote>a blockquote</blockquote>"
+    const beforeHtml = "<p>a text before</p>"
+    const afterHtml = "<p>a text after</p>"
+
+    it("Changes existing section with blockquote text and sets section to null", () => {
+      getState = jest.fn(() => ({
+        edit: { article },
+      }))
+      onInsertBlockquote(blockquoteHtml, "", "")(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+
+      const setSection = dispatch.mock.calls[1][0]
+      expect(setSection.type).toBe("SET_SECTION")
+      expect(setSection.payload.sectionIndex).toBe(null)
+
+      const changeSection = dispatch.mock.calls[2][0]
+      expect(changeSection.type).toBe("CHANGE_SECTION")
+      expect(changeSection.payload.key).toBe("body")
+      expect(changeSection.payload.value).toBe(blockquoteHtml)
+    })
+
+    it("Moves text before blockquote to new section", () => {
+      getState = jest.fn(() => ({
+        edit: { article, sectionIndex: 0 }
+      }))
+      onInsertBlockquote(blockquoteHtml, beforeHtml, "")(dispatch, getState)
+      const { type, payload: { section, sectionIndex } } = dispatch.mock.calls[1][0]
+
+      expect(type).toBe("NEW_SECTION")
+      expect(sectionIndex).toBe(0)
+      expect(section.type).toBe("text")
+      expect(section.body).toBe(beforeHtml)
+    })
+
+    it("Moves text after blockquote to new section", () => {
+      getState = jest.fn(() => ({
+        edit: { article, sectionIndex: 0 }
+      }))
+      onInsertBlockquote(blockquoteHtml, "", afterHtml)(dispatch, getState)
+      const { type, payload: { section, sectionIndex } } = dispatch.mock.calls[1][0]
+
+      expect(type).toBe("NEW_SECTION")
+      expect(sectionIndex).toBe(1)
+      expect(section.type).toBe("text")
+      expect(section.body).toBe(afterHtml)
+    })
+
+    it("Can handle blockquotes with before and after sections", () => {
+      getState = jest.fn(() => ({
+        edit: { article, sectionIndex: 0 }
+      }))
+      onInsertBlockquote(blockquoteHtml, beforeHtml, afterHtml)(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+
+      const afterSection = dispatch.mock.calls[1][0]
+      expect(afterSection.type).toBe("NEW_SECTION")
+      expect(afterSection.payload.sectionIndex).toBe(1)
+      expect(afterSection.payload.section.type).toBe("text")
+      expect(afterSection.payload.section.body).toBe(afterHtml)
+
+      const beforeSection = dispatch.mock.calls[2][0]
+      expect(beforeSection.type).toBe("NEW_SECTION")
+      expect(beforeSection.payload.sectionIndex).toBe(0)
+      expect(beforeSection.payload.section.type).toBe("text")
+      expect(beforeSection.payload.section.body).toBe(beforeHtml)
+
+      const setSection = dispatch.mock.calls[3][0]
+      expect(setSection.type).toBe("SET_SECTION")
+      expect(setSection.payload.sectionIndex).toBe(null)
+
+      const changeSection = dispatch.mock.calls[4][0]
+      expect(changeSection.type).toBe("CHANGE_SECTION")
+      expect(changeSection.payload.key).toBe("body")
+      expect(changeSection.payload.value).toBe(blockquoteHtml)
+    })
+
+    it("Calls save if a new section is added and unpublished", done => {
+      article.published = false
+      getState = jest.fn(() => ({
+        edit: { article, },
+        app: { channel: { type: "editorial" } },
+      }))
+      onInsertBlockquote(blockquoteHtml, beforeHtml, "")(dispatch, getState)
+      expect(dispatch.mock.calls[1][0].type).toBe("NEW_SECTION")
+
+      setTimeout(() => {
+        dispatch.mock.calls[3][0](dispatch, getState)
+        setTimeout(() => {
+          expect(dispatch.mock.calls[4][0].type).toBe("SAVE_ARTICLE")
+          done()
+        }, 550)
+      }, 550)
+    })
+  })
+
+  describe("#maybeMergeTextSections", () => {
+    let dispatch
+    let getState
+    let section
+    let sectionIndex
+
+    beforeEach(() => {
+      sectionIndex = 1
+      section = cloneDeep(article.sections[sectionIndex])
+      dispatch = jest.fn()
+    })
+    it("Calls #onMergeTextSections with new html if section before is text", () => {
+      getState = jest.fn(() => ({
+        edit: {
+          article,
+          section,
+          sectionIndex
+        }
+      }))
+      maybeMergeTextSections()(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+      dispatch.mock.calls[1][0](dispatch, getState)
+
+      const { type, payload } = dispatch.mock.calls[3][0]
+      expect(type).toBe("CHANGE_SECTION")
+      expect(payload.value).toMatch("Around two years ago")
+      expect(payload.value).toMatch("Land exhibitions, make influential contacts")
+    })
+
+    it("Does nothing if section before is not text", () => {
+      sectionIndex = 3
+      getState = jest.fn(() => ({
+        edit: {
+          article,
+          section,
+          sectionIndex
+        }
+      }))
+      maybeMergeTextSections()(dispatch, getState)
+      expect(dispatch).not.toBeCalled()
+    })
+
+    it("Strips blockquotes from html", () => {
+      getState = jest.fn(() => ({
+        edit: {
+          article,
+          section,
+          sectionIndex
+        }
+      }))
+      maybeMergeTextSections()(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+      dispatch.mock.calls[1][0](dispatch, getState)
+
+      const { type, payload } = dispatch.mock.calls[3][0]
+      expect(type).toBe("CHANGE_SECTION")
+      expect(payload.value).not.toMatch("<blockquote>")
+    })
+  })
+
+  describe("#onMergeTextSections", () => {
+    let dispatch
+    let getState
+    let section
+    let sectionIndex
+
+    beforeEach(() => {
+      sectionIndex = 1
+      section = cloneDeep(article.sections[sectionIndex])
+      dispatch = jest.fn()
+    })
+
+    it("Calls #onChangeSection with new html", () => {
+      getState = jest.fn(() => ({
+        edit: {
+          article,
+          section,
+          sectionIndex
+        }
+      }))
+      onMergeTextSections("<p>New html</p>")(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+      dispatch.mock.calls[1][0](dispatch, getState)
+      const { type, payload } = dispatch.mock.calls[2][0]
+
+      expect(type).toBe("CHANGE_SECTION")
+      expect(payload.value).toMatch("<p>New html</p>")
+    })
+
+    it("Calls #removeSection", () => {
+      getState = jest.fn(() => ({
+        edit: {
+          article,
+          section,
+          sectionIndex
+        },
+        app: { channel: { type: "editorial" } }
+      }))
+      onMergeTextSections("<p>New html</p>")(dispatch, getState)
+      dispatch.mock.calls[0][0](dispatch, getState)
+      dispatch.mock.calls[1][0](dispatch, getState)
+      dispatch.mock.calls[3][0](dispatch, getState)
+      dispatch.mock.calls[4][0](dispatch, getState)
+      const { type, payload: { data } } = dispatch.mock.calls[5][0]
+
+      expect(type).toBe("CHANGE_ARTICLE")
+      expect(data.sections.length).toBe(article.sections.length - 1)
+    })
   })
 })

--- a/src/client/actions/test/edit/sectionActions.test.js
+++ b/src/client/actions/test/edit/sectionActions.test.js
@@ -411,6 +411,19 @@ describe("sectionActions", () => {
       expect(payload.value).toMatch("Land exhibitions, make influential contacts")
     })
 
+    it("Does nothing if sectionIndex is 0", () => {
+      sectionIndex = 0
+      getState = jest.fn(() => ({
+        edit: {
+          article,
+          section,
+          sectionIndex
+        }
+      }))
+      maybeMergeTextSections()(dispatch, getState)
+      expect(dispatch).not.toBeCalled()
+    })
+
     it("Does nothing if section before is not text", () => {
       sectionIndex = 3
       getState = jest.fn(() => ({

--- a/src/client/apps/edit/components/content/section_container/index.jsx
+++ b/src/client/apps/edit/components/content/section_container/index.jsx
@@ -10,10 +10,13 @@ import { getSectionWidth } from "@artsy/reaction/dist/Components/Publishing/Sect
 import SectionImages from "../sections/images"
 import SectionSlideshow from "../sections/slideshow"
 import SectionText from "../sections/text"
+import { SectionText2 } from "../sections/text/index2"
 import SectionVideo from "../sections/video"
 import { ErrorBoundary } from "client/components/error/error_boundary"
 import { SectionEmbed } from "../sections/embed"
 import { SectionSocialEmbed } from "../sections/social_embed"
+// TODO: Remove after text2 is merged
+import { data as sd } from "sharify"
 
 export class SectionContainer extends Component {
   static propTypes = {
@@ -80,7 +83,11 @@ export class SectionContainer extends Component {
       }
 
       case "text": {
-        return <SectionText {...this.props} />
+        if (sd.IS_EDIT_2) {
+          return <SectionText2 {...this.props} />
+        } else {
+          return <SectionText {...this.props} />
+        }
       }
 
       case "video": {

--- a/src/client/apps/edit/components/content/section_container/index.jsx
+++ b/src/client/apps/edit/components/content/section_container/index.jsx
@@ -168,6 +168,7 @@ export default connect(
 const SectionWrapper = styled.div`
   position: relative;
   width: ${props => props.width};
+  max-width: 100%;
   margin: 0 auto;
   padding: ${props => props.isFillwidth ? 0 : "20px"};
 

--- a/src/client/apps/edit/components/content/section_list/index.jsx
+++ b/src/client/apps/edit/components/content/section_list/index.jsx
@@ -93,8 +93,8 @@ export class SectionList extends Component {
             {this.renderSectionList()}
           </DragContainer>
         ) : (
-          <div>{this.renderSectionList()}</div>
-        )}
+            <div>{this.renderSectionList()}</div>
+          )}
       </div>
     )
   }

--- a/src/client/apps/edit/components/content/sections/news/EditSourceControls.tsx
+++ b/src/client/apps/edit/components/content/sections/news/EditSourceControls.tsx
@@ -81,7 +81,7 @@ const Input = styled.input`
   background: white;
 `
 
-const LinkInput = Input.extend`
+const LinkInput = styled(Input)`
   margin-right: 0px;
 `
 

--- a/src/client/apps/edit/components/content/sections/text/index2.tsx
+++ b/src/client/apps/edit/components/content/sections/text/index2.tsx
@@ -1,5 +1,5 @@
-import SectionText from "client/apps/edit/components/content/sections/text"
 import React from "react"
+import SectionText from "../text"
 
 export const SectionText2: React.SFC = (props: any) => {
   return <SectionText {...props} />

--- a/src/client/apps/edit/components/content/sections/text/index2.tsx
+++ b/src/client/apps/edit/components/content/sections/text/index2.tsx
@@ -1,0 +1,6 @@
+import SectionText from "client/apps/edit/components/content/sections/text"
+import React from "react"
+
+export const SectionText2: React.SFC = (props: any) => {
+  return <SectionText {...props} />
+}

--- a/src/client/apps/edit/index.coffee
+++ b/src/client/apps/edit/index.coffee
@@ -11,3 +11,5 @@ app.set 'view engine', 'jade'
 
 app.get '/articles/new', routes.create
 app.get '/articles/:id/edit', routes.edit
+# TODO: Remove after text2
+app.get '/articles/:id/edit2', routes.edit

--- a/src/client/apps/edit/routes.coffee
+++ b/src/client/apps/edit/routes.coffee
@@ -27,6 +27,14 @@ sd = require('sharify').data
       channel = new Channel req.user.get('current_channel')
       res.locals.sd.CURRENT_CHANNEL = channel
 
+      # TODO: Remove after text2
+      isEdit2 = req.originalUrl is "/edit2"
+      isEditorial = channel.get("type") is "editorial"
+      if isEdit2 and isEditorial
+        res.locals.sd.IS_EDIT_2 = true
+      else
+        res.locals.sd.IS_EDIT_2 = false
+
       if (article.get('channel_id') or article.get('partner_channel_id')) isnt req.user.get('current_channel').id
         res.redirect "/switch_channel/#{article.get('channel_id') or article.get('partner_channel_id')}?redirect-to=#{req.url}"
       else

--- a/src/client/apps/edit/test/routes.test.coffee
+++ b/src/client/apps/edit/test/routes.test.coffee
@@ -102,3 +102,21 @@ describe 'routes', ->
         channel_id: null
       @res.redirect.calledOnce.should.be.true()
       @res.redirect.args[0][0].should.containEql '/switch_channel/1234?'
+
+  describe 'edit2', ->
+    beforeEach ->
+      @req.originalUrl = '/edit2'
+
+    it 'sets IS_EDIT_2 for editorial channel', ->
+      @req.user.set current_channel: id: '4d8cd73191a5c50ce200002b', type: 'editorial'
+      @routes.edit @req, @res
+      Backbone.sync.args[0][2].success a = _.extend fixtures().articles, channel_id: '4d8cd73191a5c50ce200002b'
+
+      @res.locals.sd.IS_EDIT_2.should.be.true()
+
+    it 'does not set IS_EDIT_2 for non-editorial channel', ->
+      @req.user.set current_channel: id: '4d8cd73191a5c50ce200002b', type: 'partner'
+      @routes.edit @req, @res
+      Backbone.sync.args[0][2].success a = _.extend fixtures().articles, channel_id: '4d8cd73191a5c50ce200002b'
+
+      @res.locals.sd.IS_EDIT_2.should.not.be.true()

--- a/src/client/assets/main.coffee
+++ b/src/client/assets/main.coffee
@@ -21,6 +21,8 @@ class Router extends Backbone.Router
   routes:
     'articles/new': 'articleEdit'
     'articles/:id/edit': 'articleEdit'
+    # TODO: Remove after text2
+    'articles/:id/edit2': 'articleEdit'
     'settings/curations/:id/edit': 'curationsEdit'
     'settings/channels/:id/edit': 'channelsEdit'
     'queue': 'queueEdit'


### PR DESCRIPTION
First of a few PRs for new Text component

- Sets up access to route `edit2` for editorial team (currently same as `/edit`)
- Adds redux actions related section changes triggered from new text component