### PR TITLE
Video credits allow linebreaks

### DIFF
--- a/src/client/apps/edit/components/content/article_layouts/video.jsx
+++ b/src/client/apps/edit/components/content/article_layouts/video.jsx
@@ -93,6 +93,7 @@ export class EditVideo extends Component {
     return (
       <Text layout={article.layout}>
         <Paragraph
+          allowEmptyLines
           html={credits || ""}
           hasLinks
           onChange={html => this.onMediaChange("credits", html)}

--- a/src/client/components/draft/paragraph/paragraph.tsx
+++ b/src/client/components/draft/paragraph/paragraph.tsx
@@ -23,6 +23,7 @@ import {
 
 interface Props {
   allowedStyles?: AllowedStyles
+  allowEmptyLines?: boolean
   html?: string
   hasLinks: boolean
   onChange: (html: string) => void
@@ -51,6 +52,7 @@ export class Paragraph extends Component<Props, State> {
   private allowedStyles: StyleMap
   private debouncedOnChange
   static defaultProps = {
+    allowEmptyLines: false,
     hasLinks: false,
     stripLinebreaks: false,
   }
@@ -86,13 +88,14 @@ export class Paragraph extends Component<Props, State> {
   }
 
   editorStateToHTML = (editorState: EditorState) => {
-    const { stripLinebreaks } = this.props
+    const { allowEmptyLines, stripLinebreaks } = this.props
     const currentContent = editorState.getCurrentContent()
 
     return convertDraftToHtml(
       currentContent,
       this.allowedStyles,
-      stripLinebreaks
+      stripLinebreaks,
+      allowEmptyLines
     )
   }
 
@@ -120,11 +123,13 @@ export class Paragraph extends Component<Props, State> {
 
   handleReturn = e => {
     const { editorState } = this.state
-    const { stripLinebreaks } = this.props
+    const { stripLinebreaks, allowEmptyLines } = this.props
 
     if (stripLinebreaks) {
       // Do nothing if linebreaks are disallowed
       return "handled"
+    } else if (allowEmptyLines) {
+      return "not-handled"
     } else {
       // Maybe split-block, but don't create empty paragraphs
       return handleReturn(e, editorState)

--- a/src/client/components/draft/paragraph/test/paragraph.test.tsx
+++ b/src/client/components/draft/paragraph/test/paragraph.test.tsx
@@ -158,6 +158,17 @@ describe("Paragraph", () => {
       expect(component.state().html).toBe("<p>A paragraph</p>")
     })
 
+    it("Preserves empty blocks if props.allowEmptyLines", () => {
+      props.allowEmptyLines = true
+      props.html = "<p>A paragraph</p><p></p><h1></h1><h2></h2>"
+      const component = getWrapper(props)
+      const instance = component.instance() as Paragraph
+      const editorState = instance.editorStateFromHTML(component.props().html)
+      instance.onChange(editorState)
+
+      expect(component.state().html).toBe("<p>A paragraph</p><p><br /></p>")
+    })
+
     it("Removes disallowed styles", () => {
       props.html = htmlWithDisallowedStyles
       const component = getWrapper(props)
@@ -334,6 +345,14 @@ describe("Paragraph", () => {
     })
 
     it("Returns not-handled if linebreaks are allowed", () => {
+      const component = getWrapper(props).instance() as Paragraph
+      const handleReturn = component.handleReturn({})
+
+      expect(handleReturn).toBe("not-handled")
+    })
+
+    it("Returns not-handled if allowEmptyLines", () => {
+      props.allowEmptyLines = true
       const component = getWrapper(props).instance() as Paragraph
       const handleReturn = component.handleReturn({})
 

--- a/src/client/components/draft/paragraph/utils/convert.tsx
+++ b/src/client/components/draft/paragraph/utils/convert.tsx
@@ -46,7 +46,8 @@ export const convertHtmlToDraft = (
 export const convertDraftToHtml = (
   currentContent: ContentState,
   allowedStyles: StyleMap,
-  stripLinebreaks: boolean
+  stripLinebreaks: boolean = false,
+  allowEmptyLines: boolean = false
 ) => {
   const styles = styleNamesFromMap(allowedStyles)
 
@@ -56,7 +57,9 @@ export const convertDraftToHtml = (
     blockToHTML,
   })(currentContent)
 
-  const formattedHtml = removeEmptyParagraphs(html)
+  const formattedHtml = allowEmptyLines
+    ? preserveEmptyParagraphs(html)
+    : removeEmptyParagraphs(html)
 
   if (stripLinebreaks) {
     return stripParagraphLinebreaks(formattedHtml)
@@ -200,4 +203,11 @@ export const removeEmptyParagraphs = (html: string) => {
     .replace(/<p><\/p>/g, "")
     .replace(/<p><br \/><\/p>/g, "")
     .replace(/<p><br><\/p>/g, "")
+}
+
+/**
+ * insert br to render empty paragraphs
+ */
+export const preserveEmptyParagraphs = (html: string) => {
+  return html.replace(/<p><\/p>/g, "<p><br /></p>")
 }

--- a/src/client/components/draft/paragraph/utils/test/convert.test.tsx
+++ b/src/client/components/draft/paragraph/utils/test/convert.test.tsx
@@ -284,7 +284,8 @@ describe("#convertDraftToHtml", () => {
   const getHtmlFromContentState = (
     html,
     hasLinks = false,
-    stripLinebreaks = false
+    stripLinebreaks = false,
+    allowEmptyLines = false
   ) => {
     // Get unstripped content state
     const currentContent = convertFromHTML({
@@ -294,7 +295,8 @@ describe("#convertDraftToHtml", () => {
     return convertDraftToHtml(
       currentContent,
       paragraphStyleMap,
-      stripLinebreaks
+      stripLinebreaks,
+      allowEmptyLines
     )
   }
 
@@ -371,6 +373,15 @@ describe("#convertDraftToHtml", () => {
       const convertedHtml = getHtmlFromContentState(html, false, true)
 
       expect(convertedHtml).toBe("<p>a paragraph a paragraph</p>")
+    })
+
+    it("Can preserve linebreaks if allowEmptyLines", () => {
+      const html = "<p>a paragraph</p><p></p><p>a paragraph</p>"
+      const convertedHtml = getHtmlFromContentState(html, false, false, true)
+
+      expect(convertedHtml).toBe(
+        "<p>a paragraph</p><p><br /></p><p>a paragraph</p>"
+      )
     })
 
     describe("Disallowed blocks", () => {


### PR DESCRIPTION
Updates `Paragraph` component to optionally support empty lines, and sets prop to true on `media.credits` field.

Addresses: https://artsyproduct.atlassian.net/browse/GROW-961