### PR TITLE
add new has_gradient_overlay property

### DIFF
--- a/src/api/apps/graphql/schemas/display.js
+++ b/src/api/apps/graphql/schemas/display.js
@@ -16,7 +16,7 @@ const unitSchema = Joi.object()
     cover_img_url: Joi.string(),
     disclaimer: Joi.string(),
     headline: Joi.string(),
-    has_gradient_overlay: Joi.boolean(),
+    has_cover_overlay: Joi.boolean(),
     layout: Joi.string(),
     link: Joi.object().keys({
       text: Joi.string(),

--- a/src/api/apps/graphql/schemas/display.js
+++ b/src/api/apps/graphql/schemas/display.js
@@ -16,6 +16,7 @@ const unitSchema = Joi.object()
     cover_img_url: Joi.string(),
     disclaimer: Joi.string(),
     headline: Joi.string(),
+    has_gradient_overlay: Joi.boolean(),
     layout: Joi.string(),
     link: Joi.object().keys({
       text: Joi.string(),

--- a/src/client/apps/settings/client/curations/display/components/canvas/index.jsx
+++ b/src/client/apps/settings/client/curations/display/components/canvas/index.jsx
@@ -29,16 +29,16 @@ export class Canvas extends React.Component {
           setActiveLayout={this.setActiveLayout}
         />
         {this.state.activeLayout === "overlay" && (
-          <GradientOverlayContainer>
+          <CoverOverlayContainer>
             <input
               type="checkbox"
-              defaultValue={campaign.canvas.has_gradient_overlay}
+              defaultValue={campaign.canvas.has_cover_overlay}
               onClick={e =>
-                onChange("canvas.has_gradient_overlay", e.target.checked, index)
+                onChange("canvas.has_cover_overlay", e.target.checked, index)
               }
             />
             <label>Canvas Gradient Overlay</label>
-          </GradientOverlayContainer>
+          </CoverOverlayContainer>
         )}
         <Row className="display-admin__section--canvas">
           <Col lg>
@@ -64,7 +64,7 @@ Canvas.propTypes = {
   onChange: PropTypes.func.isRequired,
 }
 
-export const GradientOverlayContainer = styled.div`
+export const CoverOverlayContainer = styled.div`
   display: inline-block;
   label {
     display: inline;

--- a/src/client/apps/settings/client/curations/display/components/canvas/index.jsx
+++ b/src/client/apps/settings/client/curations/display/components/canvas/index.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types"
 import React from "react"
 import { Col, Row } from "react-styled-flexboxgrid"
+import styled from "styled-components"
 import { CanvasControls } from "./canvas_controls.jsx"
 import { CanvasImages } from "./canvas_images.jsx"
 import { CanvasText } from "./canvas_text.jsx"
@@ -27,6 +28,18 @@ export class Canvas extends React.Component {
           activeLayout={this.state.activeLayout}
           setActiveLayout={this.setActiveLayout}
         />
+        {this.state.activeLayout === "overlay" && (
+          <GradientOverlayContainer>
+            <input
+              type="checkbox"
+              defaultValue={campaign.canvas.has_gradient_overlay}
+              onClick={e =>
+                onChange("canvas.has_gradient_overlay", e.target.checked, index)
+              }
+            />
+            <label>Canvas Gradient Overlay</label>
+          </GradientOverlayContainer>
+        )}
         <Row className="display-admin__section--canvas">
           <Col lg>
             <CanvasText campaign={campaign} index={index} onChange={onChange} />
@@ -50,3 +63,11 @@ Canvas.propTypes = {
   index: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
 }
+
+export const GradientOverlayContainer = styled.div`
+  display: inline-block;
+  label {
+    display: inline;
+    margin-left: 20px;
+  }
+`

--- a/src/client/apps/settings/client/curations/display/components/canvas/index.jsx
+++ b/src/client/apps/settings/client/curations/display/components/canvas/index.jsx
@@ -32,12 +32,12 @@ export class Canvas extends React.Component {
           <CoverOverlayContainer>
             <input
               type="checkbox"
-              defaultValue={campaign.canvas.has_cover_overlay}
+              defaultChecked={campaign.canvas.has_cover_overlay}
               onClick={e =>
                 onChange("canvas.has_cover_overlay", e.target.checked, index)
               }
             />
-            <label>Canvas Gradient Overlay</label>
+            <label>Canvas Cover Overlay</label>
           </CoverOverlayContainer>
         )}
         <Row className="display-admin__section--canvas">

--- a/src/client/apps/settings/client/curations/display/test/components/canvas/index.test.js
+++ b/src/client/apps/settings/client/curations/display/test/components/canvas/index.test.js
@@ -21,6 +21,10 @@ describe("Canvas", () => {
     onChange: jest.fn(),
   }
 
+  afterEach(() => {
+    props.onChange.mockReset()
+  })
+
   it("Renders layout controls and input components", () => {
     const component = mount(<Canvas {...props} />)
     expect(component.find(CanvasControls).length).toBe(1)
@@ -41,6 +45,20 @@ describe("Canvas", () => {
     ).toBe(true)
   })
 
+  it("Sets the canvas gradient overlay correctly", () => {
+    const component = mount(<Canvas {...props} />)
+    component
+      .find('input[type="checkbox"]')
+      .at(0)
+      .simulate("click", { target: { checked: true } })
+
+    expect(props.onChange.mock.calls[0][0]).toMatch(
+      "canvas.has_gradient_overlay"
+    )
+    expect(props.onChange.mock.calls[0][1]).toBe(true)
+    expect(props.onChange.mock.calls[0][2]).toBe(props.index)
+  })
+
   it("Changes the canvas layout on button click", () => {
     const component = mount(<Canvas {...props} />)
     component
@@ -58,6 +76,7 @@ describe("Canvas", () => {
       const component = mount(<Canvas {...props} />)
       expect(component.find(CharacterLimit).length).toBe(3)
       expect(component.find('input[type="file"]').length).toBe(2)
+      expect(component.find('input[type="checkbox"]').length).toBe(1)
       expect(component.text()).toMatch("Body")
       expect(component.text()).toMatch("CTA Text")
       expect(component.text()).toMatch("CTA Link")

--- a/src/client/apps/settings/client/curations/display/test/components/canvas/index.test.js
+++ b/src/client/apps/settings/client/curations/display/test/components/canvas/index.test.js
@@ -45,16 +45,14 @@ describe("Canvas", () => {
     ).toBe(true)
   })
 
-  it("Sets the canvas gradient overlay correctly", () => {
+  it("Sets the canvas cover overlay correctly", () => {
     const component = mount(<Canvas {...props} />)
     component
       .find('input[type="checkbox"]')
       .at(0)
       .simulate("click", { target: { checked: true } })
 
-    expect(props.onChange.mock.calls[0][0]).toMatch(
-      "canvas.has_gradient_overlay"
-    )
+    expect(props.onChange.mock.calls[0][0]).toMatch("canvas.has_cover_overlay")
     expect(props.onChange.mock.calls[0][1]).toBe(true)
     expect(props.onChange.mock.calls[0][2]).toBe(props.index)
   })

--- a/src/client/apps/settings/client/curations/display/test/components/canvas/index.test.js
+++ b/src/client/apps/settings/client/curations/display/test/components/canvas/index.test.js
@@ -21,7 +21,7 @@ describe("Canvas", () => {
     onChange: jest.fn(),
   }
 
-  afterEach(() => {
+  beforeEach(() => {
     props.onChange.mockReset()
   })
 


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-1009

This adds a new `has_gradient_overlay` property to the canvas model which will allow admins to control whether or not there is an overlay.

![screen shot 2018-11-21 at 3 10 38 pm](https://user-images.githubusercontent.com/5201004/48866893-62085c00-eda2-11e8-84e5-4524a6050261.png)

To Do:
- [ ] Conditionally display an overlay in reaction: https://github.com/artsy/reaction/pull/1576