### PR TITLE
[FEATURE Video] Add a field that allows the video duration to be edited

### DIFF
--- a/src/client/apps/edit/components/admin/components/article/article_publish_date.jsx
+++ b/src/client/apps/edit/components/admin/components/article/article_publish_date.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types"
 import React, { Component } from "react"
 import ReactDOM from "react-dom"
 import { avantgarde } from "@artsy/reaction/dist/Assets/Fonts"
+import { ButtonMedium } from './button_medium'
 
 export class ArticlePublishDate extends Component {
   static propTypes = {
@@ -166,6 +167,7 @@ export class ArticlePublishDate extends Component {
     )
   }
 }
+
 export const DateContainer = styled.div`
   display: flex;
   margin: 5px 0 40px 0;
@@ -180,21 +182,5 @@ export const InputGroup = styled.div`
   .bordered-input {
     border: none;
     margin-top: 0;
-  }
-`
-
-export const ButtonMedium = styled.button`
-  padding: 10px 20px;
-  color: ${props => (props.color ? props.color : "white")};
-  cursor: pointer;
-  background: ${props =>
-    props.background ? props.background : colors.grayMedium};
-  ${avantgarde("s11")} outline: none;
-  border: none;
-  width: -moz-available;
-  width: -webkit-fill-available;
-  transition: background 0.3s;
-  &:hover {
-    background: ${colors.purpleRegular};
   }
 `

--- a/src/client/apps/edit/components/admin/components/article/article_video_release_date.tsx
+++ b/src/client/apps/edit/components/admin/components/article/article_video_release_date.tsx
@@ -1,0 +1,97 @@
+import { Flex } from "@artsy/palette"
+import colors from "@artsy/reaction/dist/Assets/Colors"
+import { clone } from "lodash"
+import moment from "moment"
+import React, { Component } from "react"
+import { ArticleData } from "reaction/Components/Publishing/Typings"
+import styled from "styled-components"
+import { ButtonMedium } from "./button_medium"
+
+interface ArticleReleaseDateProps {
+  article: ArticleData
+  onChangeArticleAction: any
+}
+
+interface ArticleReleaseDateState {
+  hasChanged: boolean
+  releaseDate?: string
+}
+
+export class ArticleVideoReleaseDate extends Component<
+  ArticleReleaseDateProps,
+  ArticleReleaseDateState
+> {
+  constructor(props) {
+    super(props)
+
+    const { article } = props
+
+    this.state = {
+      hasChanged: false,
+      releaseDate:
+        article && article.media
+          ? moment(article.media.release_date).toISOString()
+          : undefined,
+    }
+  }
+
+  onMediaChange = (key, value) => {
+    const { article, onChangeArticleAction } = this.props
+    const media = clone(article.media) || {}
+
+    media[key] = value
+    onChangeArticleAction("media", media)
+  }
+
+  onMediaReleaseChange = () => {
+    this.setState({ hasChanged: false }, () => {
+      this.onMediaChange("release_date", this.state.releaseDate)
+    })
+  }
+
+  onDateChange = event => {
+    const date = moment(event.target.value).toISOString()
+
+    this.setState({ hasChanged: true, releaseDate: date })
+  }
+
+  render() {
+    const { hasChanged, releaseDate } = this.state
+
+    return (
+      <div className="field-group">
+        <label>Video Release Date</label>
+
+        <Container>
+          <Input
+            type="date"
+            className="bordered-input"
+            defaultValue={moment(releaseDate).format("YYYY-MM-DD")}
+            onChange={this.onDateChange}
+          />
+
+          <ButtonMedium
+            background={hasChanged ? colors.redMedium : undefined}
+            onClick={this.onMediaReleaseChange}
+          >
+            Update
+          </ButtonMedium>
+        </Container>
+      </div>
+    )
+  }
+}
+
+const Container = styled(Flex)`
+  margin-top: 5px;
+
+  button {
+    flex: 1;
+  }
+`
+
+const Input = styled.input`
+  width: 326px !important;
+  margin-right: 20px;
+  margin-top: 0 !important;
+`

--- a/src/client/apps/edit/components/admin/components/article/button_medium.tsx
+++ b/src/client/apps/edit/components/admin/components/article/button_medium.tsx
@@ -1,0 +1,20 @@
+import colors from "@artsy/reaction/dist/Assets/Colors"
+import { avantgarde } from "@artsy/reaction/dist/Assets/Fonts"
+import styled from "styled-components"
+
+export const ButtonMedium = styled.button.attrs<{ background?: string }>({})`
+  padding: 10px 20px;
+  color: ${props => (props.color ? props.color : "white")};
+  cursor: pointer;
+  background: ${props =>
+    props.background ? props.background : colors.grayMedium};
+  ${avantgarde("s11")};
+  outline: none;
+  border: none;
+  width: -moz-available;
+  width: -webkit-fill-available;
+  transition: background 0.3s;
+  &:hover {
+    background: ${colors.purpleRegular};
+  }
+`

--- a/src/client/apps/edit/components/admin/components/article/index.jsx
+++ b/src/client/apps/edit/components/admin/components/article/index.jsx
@@ -8,11 +8,14 @@ import PropTypes from "prop-types"
 import React, { Component } from "react"
 import { Col, Row } from "react-styled-flexboxgrid"
 import { avantgarde } from "@artsy/reaction/dist/Assets/Fonts"
+import { Flex, Theme } from "@artsy/palette"
+
 import { onChangeArticle } from "client/actions/edit/articleActions"
 import { AutocompleteList } from "/client/components/autocomplete2/list"
 import { ArticlePublishDate } from "./article_publish_date"
 import { RelatedArticleQuery } from "client/queries/related_articles"
 import ArticleAuthors from "./article_authors"
+import { ArticleVideoReleaseDate } from './article_video_release_date'
 
 export class AdminArticle extends Component {
   static propTypes = {
@@ -21,6 +24,19 @@ export class AdminArticle extends Component {
     channel: PropTypes.object,
     onChangeArticleAction: PropTypes.func,
     user: PropTypes.object,
+  }
+
+  constructor(props) {
+    super(props)
+
+    const { article: { media } } = this.props
+    const duration = (media || {}).duration || 0
+
+    this.state = {
+      min: Math.floor(Math.round(duration) / 60),
+      sec: Math.round(duration) % 60,
+      videoDurationHasFocus: false,
+    }
   }
 
   fetchArticles = (fetchedItems, cb) => {
@@ -52,130 +68,226 @@ export class AdminArticle extends Component {
     }
   }
 
+  onMediaChange = (key, value) => {
+    const { article, onChangeArticleAction } = this.props
+    const media = clone(article.media) || {}
+
+    media[key] = value
+    onChangeArticleAction("media", media)
+  }
+
+  onVideoDurationMinUpdated = event => {
+    this.setState({ min: event.target.value }, () => {
+      this.onMediaChange("duration", (this.state.min * 60) + this.state.sec)
+    })
+  }
+
+  onVideoDurationSecondUpdated = event => {
+    this.setState({ sec: event.target.value }, () => {
+      this.onMediaChange("duration", (this.state.min * 60) + this.state.sec)
+    })
+  }
+
   render() {
     const { article, apiURL, channel, onChangeArticleAction } = this.props
+    const { min, sec, videoDurationHasFocus } = this.state
 
     return (
-      <div>
-        <ArticleAuthors />
+      <Theme>
+        <div>
+          <ArticleAuthors/>
 
-        <Row>
-          <Col xs={6}>
-            {article.layout !== "news" && (
-              <Row>
-                <Col xs={6}>
-                  <div className="field-group">
-                    <label>Article Tier</label>
-                    <ButtonGroup>
-                      <Button
-                        active={article.tier === 1}
-                        onClick={() => onChangeArticleAction("tier", 1)}
-                      >
-                        Tier 1
-                      </Button>
-                      <Button
-                        active={article.tier === 2}
-                        onClick={() => onChangeArticleAction("tier", 2)}
-                      >
-                        Tier 2
-                      </Button>
-                    </ButtonGroup>
-                  </div>
-                </Col>
-                <Col xs={6}>
-                  <div className="field-group">
-                    <label>Magazine Feed</label>
-                    <ButtonGroup>
-                      <Button
-                        active={article.featured}
-                        onClick={() => onChangeArticleAction("featured", true)}
-                      >
-                        Yes
-                      </Button>
-                      <Button
-                        active={!article.featured}
-                        onClick={() => onChangeArticleAction("featured", false)}
-                      >
-                        No
-                      </Button>
-                    </ButtonGroup>
-                  </div>
-                </Col>
-              </Row>
-            )}
-
-            {channel.type === "editorial" &&
-              article.layout !== "news" && (
-                <div className="field-group">
-                  <label>Article Layout</label>
-                  <ButtonGroup>
-                    <Button
-                      active={article.layout === "standard"}
-                      onClick={() =>
-                        onChangeArticleAction("layout", "standard")
-                      }
-                    >
-                      Standard
-                    </Button>
-                    <Button
-                      active={article.layout === "feature"}
-                      onClick={() => onChangeArticleAction("layout", "feature")}
-                    >
-                      Feature
-                    </Button>
-                  </ButtonGroup>
-                </div>
+          <Row>
+            <Col xs={6}>
+              {article.layout !== "news" && (
+                <Row>
+                  <Col xs={6}>
+                    <div className="field-group">
+                      <label>Article Tier</label>
+                      <ButtonGroup>
+                        <Button
+                          active={article.tier === 1}
+                          onClick={() => onChangeArticleAction("tier", 1)}
+                        >
+                          Tier 1
+                        </Button>
+                        <Button
+                          active={article.tier === 2}
+                          onClick={() => onChangeArticleAction("tier", 2)}
+                        >
+                          Tier 2
+                        </Button>
+                      </ButtonGroup>
+                    </div>
+                  </Col>
+                  <Col xs={6}>
+                    <div className="field-group">
+                      <label>Magazine Feed</label>
+                      <ButtonGroup>
+                        <Button
+                          active={article.featured}
+                          onClick={() => onChangeArticleAction("featured", true)}
+                        >
+                          Yes
+                        </Button>
+                        <Button
+                          active={!article.featured}
+                          onClick={() => onChangeArticleAction("featured", false)}
+                        >
+                          No
+                        </Button>
+                      </ButtonGroup>
+                    </div>
+                  </Col>
+                </Row>
               )}
 
-            <div
-              className="field-group--inline flat-checkbox"
-              onClick={e =>
-                onChangeArticleAction("indexable", !article.indexable)
-              }
-            >
-              <input type="checkbox" checked={article.indexable} readOnly />
-              <label>Index for search</label>
-            </div>
+              <Row>
+                {channel.type === "editorial" &&
+                article.layout !== "news" && (
+                  <Col xs={6}>
+                    <div className="field-group">
+                      <label>Article Layout</label>
+                      <ButtonGroup>
+                        <Button
+                          active={article.layout === "standard"}
+                          onClick={() =>
+                            onChangeArticleAction("layout", "standard")
+                          }
+                        >
+                          Standard
+                        </Button>
+                        <Button
+                          active={article.layout === "feature"}
+                          onClick={() =>
+                            onChangeArticleAction("layout", "feature")
+                          }
+                        >
+                          Feature
+                        </Button>
+                      </ButtonGroup>
+                    </div>
+                  </Col>
+                )}
 
-            <div
-              className="field-group field-group--inline flat-checkbox"
-              onClick={() =>
-                onChangeArticleAction(
-                  "exclude_google_news",
-                  !article.exclude_google_news
-                )
-              }
-            >
-              <input
-                type="checkbox"
-                checked={article.exclude_google_news}
-                readOnly
-              />
-              <label>Exclude from Google News</label>
-            </div>
-          </Col>
+                {article.layout === "video" && (
+                  <Col xs={6}>
+                    <div className="field-group">
+                      <label>Video duration</label>
 
-          <Col xs={6}>
-            <ArticlePublishDate
-              article={article}
-              onChange={onChangeArticleAction}
-            />
+                      <InputGroup
+                        mt={0.5}
+                        mr={4}
+                        pr={2}
+                        flexDirection="row"
+                        alignItems="center"
+                        videoDurationHasFocus={videoDurationHasFocus}
+                        onClick={() =>
+                          this.setState({ videoDurationHasFocus: true })
+                        }
+                      >
+                        <input
+                          className="bordered-input"
+                          type="number"
+                          min="00"
+                          max="99"
+                          step="1"
+                          placeholder="00"
+                          defaultValue={min}
+                          onChange={this.onVideoDurationMinUpdated}
+                          onBlur={() =>
+                            this.setState({ videoDurationHasFocus: false })
+                          }
+                        />
+                        min
+                        <input
+                          className="bordered-input"
+                          type="number"
+                          min="00"
+                          max="60"
+                          step="1"
+                          placeholder="00"
+                          defaultValue={sec}
+                          onChange={this.onVideoDurationSecondUpdated}
+                          onBlur={() =>
+                            this.setState({ videoDurationHasFocus: false })
+                          }
+                        />
+                        sec
+                      </InputGroup>
+                    </div>
+                  </Col>
+                )}
+              </Row>
 
-            <div className="field-group">
-              <label>Related Articles</label>
-              <AutocompleteList
-                fetchItems={this.fetchArticles}
-                items={article.related_article_ids || []}
-                onSelect={results =>
-                  onChangeArticleAction("related_article_ids", results)
+              <div
+                className="field-group--inline flat-checkbox"
+                onClick={e =>
+                  onChangeArticleAction("indexable", !article.indexable)
                 }
-                placeholder="Search by title..."
-                url={`${apiURL}/articles?published=true&q=%QUERY`}
+              >
+                <input type="checkbox" checked={article.indexable} readOnly />
+                <label>Index for search</label>
+              </div>
+
+              <div
+                className="field-group field-group--inline flat-checkbox"
+                onClick={() =>
+                  onChangeArticleAction(
+                    "exclude_google_news",
+                    !article.exclude_google_news
+                  )
+                }
+              >
+                <input
+                  type="checkbox"
+                  checked={article.exclude_google_news}
+                  readOnly
+                />
+                <label>Exclude from Google News</label>
+              </div>
+            </Col>
+
+            <Col xs={6}>
+              <ArticlePublishDate
+                article={article}
+                onChange={onChangeArticleAction}
               />
-            </div>
-          </Col>
-        </Row>
-      </div>
+
+              {article.layout === "video" && (
+                <ArticleVideoReleaseDate
+                  article={article}
+                  onChangeArticleAction={onChangeArticleAction}
+                />)}
+
+              <div className="field-group">
+                <label>Related Articles</label>
+                <AutocompleteList
+                  fetchItems={this.fetchArticles}
+                  items={article.related_article_ids || []}
+                  onSelect={results =>
+                    onChangeArticleAction("related_article_ids", results)
+                  }
+                  placeholder="Search by title..."
+                  url={`${apiURL}/articles?published=true&q=%QUERY`}
+                />
+              </div>
+
+              {article.layout === "video" && (
+                <div
+                  className="field-group field-group--inline flat-checkbox"
+                  onClick={() =>
+                    this.onMediaChange("published", !article.media.published)
+                  }
+                >
+                  <input type="checkbox" checked={article.media.published} readOnly />
+                  <label>Video Published</label>
+                </div>
+              )}
+            </Col>
+          </Row>
+        </div>
+      </Theme>
     )
   }
 }
@@ -210,5 +322,15 @@ const ButtonGroup = styled.div`
     &:first-child {
       border-right: none;
     }
+  }
+`
+
+export const InputGroup = styled(Flex)`
+  border: 2px solid ${props => props.videoDurationHasFocus ? colors.purpleRegular : colors.grayRegular};
+  transition: border 0.3s;
+
+  .bordered-input {
+    border: none;
+    margin-top: 0;
   }
 `

--- a/src/client/apps/edit/components/admin/test/components/article/index.test.js
+++ b/src/client/apps/edit/components/admin/test/components/article/index.test.js
@@ -9,6 +9,7 @@ import { AdminArticle } from "../../../components/article"
 import { ArticleAuthors } from "../../../components/article/article_authors"
 import { ArticlePublishDate } from "../../../components/article/article_publish_date"
 import { AutocompleteList } from "/client/components/autocomplete2/list"
+import { ButtonMedium } from '../../../components/article/button_medium'
 require("typeahead.js")
 
 jest.mock("superagent", () => {
@@ -260,6 +261,61 @@ describe("AdminArticle", () => {
         "exclude_google_news"
       )
       expect(props.onChangeArticleAction.mock.calls[0][1]).toBe(false)
+    })
+
+    it("Can change video duration", () => {
+      props.article.layout = "video"
+      props.article.media = { duration: 212 }
+
+      const component = getWrapper(props)
+
+      const inputForMin = component.find("input[type='number']").at(0)
+      const inputForSec = component.find("input[type='number']").at(1)
+
+      expect(inputForMin.props().defaultValue).toEqual(3)
+      expect(inputForSec.props().defaultValue).toEqual(32)
+
+      inputForMin.simulate('change', { target: { value: 10 }})
+      inputForSec.simulate('change', { target: { value: 30 }})
+
+      expect(props.onChangeArticleAction.mock.calls[0][0]).toEqual("media")
+      expect(props.onChangeArticleAction.mock.calls[0][1]).toEqual({ duration: 632 })
+
+      expect(props.onChangeArticleAction.mock.calls[1][0]).toEqual("media")
+      expect(props.onChangeArticleAction.mock.calls[1][1]).toEqual({ duration: 630 })
+    })
+
+    it("Can change video release date", () => {
+      props.article.layout = "video"
+      props.article.media = { release_date: "2017-02-07" }
+
+      const component = getWrapper(props)
+      component
+        .find('input[type="date"]')
+        .at(1)
+        .simulate("change", { target: { value: "2017-02-07" } })
+
+      component
+        .find(ButtonMedium)
+        .at(1)
+        .simulate("click")
+
+      expect(props.onChangeArticleAction.mock.calls[0][0]).toEqual("media")
+      expect(props.onChangeArticleAction.mock.calls[0][1].release_date).toMatch("2017-02-07")
+    })
+
+    it("Can change video published", () => {
+      props.article.layout = "video"
+      props.article.media = { published: false }
+
+      const component = getWrapper(props)
+      component
+        .find(".flat-checkbox")
+        .at(2)
+        .simulate("click")
+
+      expect(props.onChangeArticleAction.mock.calls[0][0]).toBe("media")
+      expect(props.onChangeArticleAction.mock.calls[0][1]).toEqual({ published: true })
     })
   })
 })

--- a/src/client/apps/edit/components/content/article_layouts/test/video.test.js
+++ b/src/client/apps/edit/components/content/article_layouts/test/video.test.js
@@ -55,23 +55,4 @@ describe("EditVideo", () => {
     component.instance().onMediaChange("published", false)
     expect(props.onChangeArticleAction.mock.calls[3][1].published).toBe(false)
   })
-
-  it("toggles published state on media", () => {
-    const component = getWrapper(props)
-    component.find(EditVideoPublished).simulate("click")
-
-    expect(props.onChangeArticleAction.mock.calls[0][1].published).toBe(false)
-    expect(props.onChangeArticleAction.mock.calls[0][1].published).not.toBe(
-      props.article.media.published
-    )
-  })
-
-  it("sets release_date on media", () => {
-    const component = getWrapper(props)
-    const input = component.find('input[type="date"]')
-    input.simulate("change", { target: { value: "2017-02-07" } })
-    expect(props.onChangeArticleAction.mock.calls[0][1].release_date).toMatch(
-      "2017-02-07"
-    )
-  })
 })

--- a/src/client/apps/edit/components/content/article_layouts/video.jsx
+++ b/src/client/apps/edit/components/content/article_layouts/video.jsx
@@ -39,11 +39,6 @@ export class EditVideo extends Component {
     onChangeArticleAction("media", media)
   }
 
-  onDateChange = e => {
-    const date = moment(e.target.value).toISOString()
-    this.onMediaChange("release_date", date)
-  }
-
   editDescription = () => {
     const { article, onChangeArticleAction } = this.props
 
@@ -139,25 +134,6 @@ export class EditVideo extends Component {
           />
         </EditVideoInput>
 
-        <EditVideoPublished
-          className="field-group--inline flat-checkbox"
-          onClick={e => this.onMediaChange("published", !media.published)}
-          name="media.published"
-        >
-          <input type="checkbox" checked={media.published} readOnly />
-          <label>Video Published</label>
-        </EditVideoPublished>
-
-        <EditVideoReleaseDate>
-          <label>Release Date</label>
-          <input
-            type="date"
-            className="bordered-input bordered-input-dark"
-            defaultValue={moment(media.release_date).format("YYYY-MM-DD")}
-            onChange={this.onDateChange}
-          />
-        </EditVideoReleaseDate>
-
         <MaxWidthContainer>
           <VideoAbout
             article={article}
@@ -194,17 +170,6 @@ const EditVideoInput = styled.div`
 const EditCoverInput = styled.div`
   top: 50px;
 `
-export const EditVideoPublished = styled.div`
-  top: 80px;
-`
-const EditVideoReleaseDate = styled.div`
-  top: 120px;
-  label {
-    display: block;
-    text-align: right;
-    ${avantgarde("s13")};
-  }
-`
 
 export const EditVideoContainer = styled.div`
   position: relative;
@@ -236,9 +201,7 @@ export const EditVideoContainer = styled.div`
     position: relative;
   }
   ${EditVideoInput},
-  ${EditCoverInput},
-  ${EditVideoPublished},
-  ${EditVideoReleaseDate} {
+  ${EditCoverInput} {
     z-index: 10;
     position: absolute;
     right: 20px;


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-959

This adds a duration input to the article section.

 * I went with two inputs rather than using a single input that holds a duration in the `mm:ss` format so we don't have to parse/format the duration value and the browser will take care of validating the user input.
 * I used `min` and `sec` to indicate which input refers to what unit as a starter, but I'm also open to other styles as this looks a lot different from what's in Zeplin (`mm:ss`)

## Screenshot

<img width="576" alt="video-duration" src="https://user-images.githubusercontent.com/386234/49134795-292f3080-f328-11e8-96ea-3f9290de5ead.png">
