### PR TITLE
add health check endpoint /api/health

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -47,7 +47,7 @@ spec:
           readinessProbe:
             httpGet:
               port: 3005
-              path: /health
+              path: /api/health
               httpHeaders:
                 - name: X-FORWARDED-PROTO
                   value: https

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -47,7 +47,7 @@ spec:
           readinessProbe:
             httpGet:
               port: 3005
-              path: /health
+              path: /api/health
               httpHeaders:
                 - name: X-FORWARDED-PROTO
                   value: https

--- a/src/api/apps/health/index.js
+++ b/src/api/apps/health/index.js
@@ -1,0 +1,7 @@
+import express from "express"
+
+const app = (module.exports = express())
+
+app.get("/health", (req, res) => {
+  return res.status(200).end()
+})

--- a/src/api/index.coffee
+++ b/src/api/index.coffee
@@ -40,6 +40,7 @@ app.use require './apps/authors'
 app.use require './apps/graphql/index.js'
 app.use require './apps/search/index.js'
 app.use require './apps/sessions/index.js'
+app.use require './apps/health/index.js'
 
 if SENTRY_PRIVATE_DSN
   app.use RavenServer.errorHandler()


### PR DESCRIPTION
Adds the health check endpoint `/api/health` and use it for Kubernetes health checks

After deploy - run: `hokusai [staging|production] update` to change the Kubernetes resource definitions to use the new path in `readinessProbe`.  See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes