### PR TITLE
Run tests for positron before production deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,8 @@ workflows:
             branches:
               only: master
       - deploy-production:
+          requires:
+            - build-and-test
           filters:
             branches:
               only: release


### PR DESCRIPTION
The tests are cheap to run, and, from a gut feeling, it provides
developer confidence to see a passing test suite before a production
deploy.

More tactically, in the event that code is pushed to `release` (think
hot-fix scenario), then running a test build before a merge to `release`
will ensure that we catch any possible regressions from the integration
between `release` with `master. 