### PR TITLE
Remove exclusion of `release` branch from `build-and-test` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ workflows:
             branches:
               ignore:
                 - staging
-                - release
       - deploy-staging:
           requires:
             - build-and-test


### PR DESCRIPTION
I believe there was a bug in 47978b4747060de92dacba7c032be0b071ff31e0
which results in `deploy-production` not running because it now requires
`build-and-test`, which is ignored when building the `release` branch.

This commit removes the exclusion of the `release` branch, hence
allowing `build-and-test` to run, hence allowing `deploy-production` to
run.