### PR TITLE
allow social embeds on feature and standard articles

### DIFF
--- a/src/client/apps/edit/components/content/section_tool/index.jsx
+++ b/src/client/apps/edit/components/content/section_tool/index.jsx
@@ -86,38 +86,51 @@ export class SectionTool extends Component {
             Text
           </SectionToolMenuItem>
 
-          <SectionToolMenuItem onClick={() => this.newSection("image_collection")}>
+          <SectionToolMenuItem
+            onClick={() => this.newSection("image_collection")}
+          >
             <IconEditImages />
             {isNews ? "Image" : "Images"}
           </SectionToolMenuItem>
 
-          {!isNews &&
+          {!isNews && (
             <SectionToolMenuItem onClick={() => this.newSection("video")}>
               <IconEditVideo />
               Video
             </SectionToolMenuItem>
-          }
+          )}
 
-          {!isPartnerChannel && !isNews &&
-            <SectionToolMenuItem onClick={() => this.newSection("embed")}>
-              <IconEditEmbed />
-              Embed
-            </SectionToolMenuItem>
-          }
+          {!isPartnerChannel &&
+            !isNews && (
+              <SectionToolMenuItem onClick={() => this.newSection("embed")}>
+                <IconEditEmbed />
+                Embed
+              </SectionToolMenuItem>
+            )}
 
-          {isNews && !firstSection &&
-            <SectionToolMenuItem onClick={() => this.newSection("social_embed")}>
-              <IconEditEmbed />
-              Social Embed
-            </SectionToolMenuItem>
-          }
+          {layout !== "classic" &&
+            !firstSection && (
+              <SectionToolMenuItem
+                onClick={() => this.newSection("social_embed")}
+              >
+                <IconEditEmbed />
+                Social Embed
+              </SectionToolMenuItem>
+            )}
         </SectionToolMenu>
       )
     }
   }
 
   render() {
-    const { article, firstSection, index, isEditing, isHero, sections } = this.props
+    const {
+      article,
+      firstSection,
+      index,
+      isEditing,
+      isHero,
+      sections,
+    } = this.props
     const { isOpen } = this.state
 
     const isFirstSection = sections && firstSection && sections.length === 0
@@ -173,23 +186,28 @@ const SectionToolContainer = styled.div`
   position: relative;
   margin-left: auto;
   margin-right: auto;
-  max-width: ${props => props.width ? props.width : "100%"};
+  max-width: ${props => (props.width ? props.width : "100%")};
   width: 100%;
   transition: max-height 0.15s linear, opacity 0.15s linear;
 
-  ${props => props.isEditing && `
+  ${props =>
+    props.isEditing &&
+    `
     z-index: -1;
-  `}
-  &:last-child {
+  `} &:last-child {
     opacity: 1;
     margin-top: 15px;
   }
-  ${props => props.isOpen && `
+  ${props =>
+    props.isOpen &&
+    `
     max-height: inherit;
-  `}
-  ${props => (props.isVisible && !props.isHero) && `
+  `} ${props =>
+    props.isVisible &&
+    !props.isHero &&
+    `
     padding-bottom: 40px;
-  `}
+  `};
 `
 
 export const SectionToolIcon = styled.div`
@@ -212,7 +230,7 @@ export const SectionToolIcon = styled.div`
     transition: fill 0.1s;
   }
   &::before {
-    content: '.';
+    content: ".";
     border-top: 2px solid black;
     position: absolute;
     top: 6px;
@@ -225,10 +243,15 @@ export const SectionToolIcon = styled.div`
     height: 20px;
     z-index: 2;
   }
-  ${props => (props.isVisible || props.isOpen) && `
+  ${props =>
+    (props.isVisible || props.isOpen) &&
+    `
     opacity: 1;
-  `}
-  ${props => (props.isVisible && !props.isOpen && !props.isHero) && `
+  `} ${props =>
+    props.isVisible &&
+    !props.isOpen &&
+    !props.isHero &&
+    `
     &::after {
       content: 'Add a section';
       width: 150px;

--- a/src/client/apps/edit/components/content/section_tool/index.jsx
+++ b/src/client/apps/edit/components/content/section_tool/index.jsx
@@ -247,7 +247,7 @@ export const SectionToolIcon = styled.div`
     (props.isVisible || props.isOpen) &&
     `
     opacity: 1;
-  `} ${props =>
+  `}; ${props =>
     props.isVisible &&
     !props.isOpen &&
     !props.isHero &&

--- a/src/client/apps/edit/components/content/section_tool/test/index.test.js
+++ b/src/client/apps/edit/components/content/section_tool/test/index.test.js
@@ -105,6 +105,7 @@ describe("SectionTool", () => {
         expect(component.find(IconEditImages).exists()).toBe(true)
         expect(component.find(IconEditVideo).exists()).toBe(true)
         expect(component.find(IconEditEmbed).exists()).toBe(true)
+        expect(component.find(IconEditEmbed).length).toBe(2)
       })
 
       it("Renders correct icons for Feature layout", () => {
@@ -115,7 +116,7 @@ describe("SectionTool", () => {
         expect(component.find(IconEditText).exists()).toBe(true)
         expect(component.find(IconEditImages).exists()).toBe(true)
         expect(component.find(IconEditVideo).exists()).toBe(true)
-        expect(component.find(IconEditEmbed).exists()).toBe(true)
+        expect(component.find(IconEditEmbed).length).toBe(2)
       })
 
       it("Renders correct icons for News layout", () => {
@@ -176,8 +177,14 @@ describe("SectionTool", () => {
       it("Can create an embed section", () => {
         const expectedIndex = props.sections.length
         const component = getWrapper(props)
-        component.find(SectionToolIcon).simulate("click")
-        component.find(IconEditEmbed).simulate("click")
+        component
+          .find(SectionToolIcon)
+          .at(0)
+          .simulate("click")
+        component
+          .find(IconEditEmbed)
+          .at(0)
+          .simulate("click")
 
         expect(props.newSectionAction.mock.calls[0][0]).toBe("embed")
         expect(props.newSectionAction.mock.calls[0][1]).toBe(expectedIndex)
@@ -192,6 +199,15 @@ describe("SectionTool", () => {
 
         expect(props.newSectionAction.mock.calls[0][0]).toBe("social_embed")
         expect(props.newSectionAction.mock.calls[0][1]).toBe(expectedIndex)
+      })
+
+      it("doesn not create a social embed section for classic articles", () => {
+        props.article.layout = "classic"
+        props.isPartnerChannel = true
+        const component = getWrapper(props)
+        component.find(SectionToolIcon).simulate("click")
+
+        expect(component.find(IconEditEmbed).exists()).toBe(false)
       })
     })
   })


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-793

This is the first part bit of work that adds social embeds to standard and feature articles. There is a subsequent PR in reaction that adds the social link to the UI. Ideally we'd want to bucket the two types of embeds into a togglable link but seeing that this is timely and needs to be used for EOY work we can take this approach and refactor to remove duplicated icons later.


![screen shot 2018-12-17 at 7 43 38 pm](https://user-images.githubusercontent.com/5201004/50124780-1e373400-0234-11e9-8bf4-66614ed7298d.png)

![screen shot 2018-12-17 at 7 43 48 pm](https://user-images.githubusercontent.com/5201004/50124778-1e373400-0234-11e9-9229-2e8d00d8c7ad.png)

