### PR TITLE
Fixes the test for SuperArticle count that randomly fails

### DIFF
--- a/src/api/apps/articles/test/model/index/index.test.coffee
+++ b/src/api/apps/articles/test/model/index/index.test.coffee
@@ -155,10 +155,10 @@ describe 'Article', ->
           related_articles: [ObjectId('5086df098523e60002000018')]
         }
       , ->
-      id = '5086df098523e60002000018'
-      Article.getSuperArticleCount(id)
-      .then (count) =>
-        count.should.equal 1
+        id = '5086df098523e60002000018'
+        Article.getSuperArticleCount(id)
+        .then (count) =>
+          count.should.equal 1
 
   describe '#promisedMongoFetch', ->
     it 'returns results, counts, and totals', ->


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-1036

I was working on GROW-746 and trying to convert CoffeeScript to TypeScript as well as switching from Mocha to Jest with the hope of GROW-1036 getting fixed for free, but sadly it didn't fix the issue. But 
 one thing I noticed after converting to ES6 is that there is a missing indent in the test, which seems to have caused CoffeeScript to interpret this test as:

```js
call(arg1, arg2, function() { })
do_stuff()
```

Instead of:

```js
call(arg1, arg2, function() { do_stuff() })
```

So the assertion was not guaranteed to be called after the fabricate function completes the execution.