### PR TITLE
Slug cleanup

### DIFF
--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -57,9 +57,16 @@ removeStopWords = (title) ->
     slug = _s.slugify stoppedTitle
   else
     slug = _s.slugify article.author?.name + ' ' + stoppedTitle
+
+  # Does not add the slug to the array if the same slug is already the last item in the slugs array
   return cb null, article if slug is _.last(article.slugs)
 
-  # Append published_at to slug if that slug already exists
+  # Moves the slug to the end of the slugs array if it already exists in the array
+  if article.slugs && article.slugs.includes(slug)
+    article.slugs.push(article.slugs.splice(article.slugs.indexOf(slug), 1)[0])
+    return cb null, article  
+
+  # Appends published_at to slug if that slug already exists
   db.articles.count { slugs: slug }, (err, count) ->
     return cb(err) if err
     if count
@@ -72,7 +79,13 @@ removeStopWords = (title) ->
 
       slug = slug + '-' + formatted_date
 
+      # Does not add date with appended slug if the last slug has the same date appended
       return cb null, article if slug is _.last(article.slugs)
+
+      # If the slug with the appended date already exists in the array it moves it to the end
+      if article.slugs && article.slugs.includes(slug)
+        article.slugs.push(article.slugs.splice(article.slugs.indexOf(slug), 1)[0])
+        return cb null, article 
 
     article.slugs = (article.slugs or []).concat slug
     cb(null, article)

--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -66,18 +66,18 @@ removeStopWords = (title) ->
     article.slugs.push(article.slugs.splice(article.slugs.indexOf(slug), 1)[0])
     return cb null, article  
 
-  # Appends published_at to slug if that slug already exists
+  # # Appends published_at to slug if that slug already exists
   db.articles.count { slugs: slug }, (err, count) ->
     return cb(err) if err
     if count
       format = if article.published then 'MM-DD-YY' else 'X'
-      published_date = new Date(article.published_at)
-      if moment(published_date).isValid()
-        formatted_date = moment(published_date).format(format)
+      publishedDate = new Date(article.published_at)
+      if moment(publishedDate).isValid()
+        formattedDate = moment(publishedDate).format(format)
       else
-        formatted_date = moment().format(format)
+        formattedDate = moment().format(format)
 
-      slug = slug + '-' + formatted_date
+      slug = slug + '-' + formattedDate
 
       # Does not add date with appended slug if the last slug has the same date appended
       return cb null, article if slug is _.last(article.slugs)

--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -64,7 +64,16 @@ removeStopWords = (title) ->
     return cb(err) if err
     if count
       format = if article.published then 'MM-DD-YY' else 'X'
-      slug = slug + '-' + moment(article.published_at).format(format)
+      published_date = new Date(article.published_at)
+      if moment(published_date).isValid()
+        formatted_date = moment(published_date).format(format)
+      else
+        formatted_date = moment().format(format)
+
+      slug = slug + '-' + formatted_date
+
+      return cb null, article if slug is _.last(article.slugs)
+
     article.slugs = (article.slugs or []).concat slug
     cb(null, article)
 

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -17,7 +17,7 @@ describe 'Save', ->
     app.use '/__gravity', gravity
     @server = app.listen 5000, ->
       done()
-    sandbox.useFakeTimers(new Date(2019,0,1,0,0,0))
+    sandbox.useFakeTimers(new Date(Date.UTC(2019, 0, 1, 0, 0, 0)))
 
   after ->
     @server.close()
@@ -112,7 +112,7 @@ describe 'Save', ->
           author: name: 'Molly'
           published_at: '2017-07-dsdfdf26T17:37:03.065Zsdfdf'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
+          article.slugs[0].should.equal 'molly-clockwork-12-31-18'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -125,7 +125,7 @@ describe 'Save', ->
           published: true
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
+          article.slugs[0].should.equal 'molly-clockwork-12-31-18'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -200,7 +200,7 @@ describe 'Save', ->
           published: false
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-1546318800'
+          article.slugs[0].should.equal 'molly-clockwork-1546300800'
           done()
       )(null, {
         slugs: ['molly-clockwork']

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -17,7 +17,11 @@ describe 'Save', ->
     app.use '/__gravity', gravity
     @server = app.listen 5000, ->
       done()
-    sandbox.useFakeTimers(new Date("Tue Jan 01 2019 00:00:00 GMT-0000").getTime())
+
+    date = new Date("Tue Jan 01 2019 00:00:00 GMT")
+    offset = date.getTimezoneOffset()
+    dateWithOffset = moment(date).add(offset, 'm').toDate();
+    sandbox.useFakeTimers(dateWithOffset)
 
   after ->
     @server.close()
@@ -112,7 +116,7 @@ describe 'Save', ->
           author: name: 'Molly'
           published_at: '2017-07-dsdfdf26T17:37:03.065Zsdfdf'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-12-31-18'
+          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -125,7 +129,7 @@ describe 'Save', ->
           published: true
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-12-31-18'
+          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -200,7 +204,7 @@ describe 'Save', ->
           published: false
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-1546300800'
+          article.slugs[0].should.equal 'molly-clockwork-1546318800'
           done()
       )(null, {
         slugs: ['molly-clockwork']

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -18,10 +18,10 @@ describe 'Save', ->
     @server = app.listen 5000, ->
       done()
 
-    date = new Date("Tue Jan 01 2019 00:00:00 GMT")
-    offset = date.getTimezoneOffset()
-    dateWithOffset = moment(date).add(offset, 'm').toDate();
-    sandbox.useFakeTimers(dateWithOffset)
+    date = new Date("Tue Jan 01 2019 00:00:00")
+    # offset = date.getTimezoneOffset()
+    # dateWithOffset = moment(date).add(offset, 'm').toDate();
+    sandbox.useFakeTimers(date)
 
   after ->
     @server.close()
@@ -197,14 +197,22 @@ describe 'Save', ->
         slugs: ['molly-clockwork']
       })
 
-    it 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->
+    it.only 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->
+      x = new Date()
+      console.log("date now",x)
+      os = x.getTimezoneOffset()
+      
+      sandbox.clock.tick(os * -60000)
+      y = new Date()
+      console.log("date now",y) 
+      
       Save.sanitizeAndSave( =>
         Save.generateSlugs {
           thumbnail_title: 'Clockwork'
           published: false
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-1546318800'
+          article.slugs[0].should.equal 'molly-clockwork-1546300800'
           done()
       )(null, {
         slugs: ['molly-clockwork']

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -130,6 +130,22 @@ describe 'Save', ->
         slugs: ['molly-clockwork']
       })
 
+    it 'moves the slug to the end of the slugs array and does not append a date if the slug is present elsewhere in the array', (done) ->
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: true
+          author: name: 'Molly'
+          slugs: ['molly-clockwork', 'molly-clockwork-2', 'molly-clockwork-3']
+          published_at: '2017-07-26T17:37:03.065Z'
+        }, (err, article) =>
+          article.slugs.length.should.equal 3
+          article.slugs[article.slugs.length-1].should.equal 'molly-clockwork'
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
     it 'does not append a date to the slug if a slug with that date exists in the slugs array for that article already', (done) ->
       Save.sanitizeAndSave( =>
         Save.generateSlugs {
@@ -141,6 +157,22 @@ describe 'Save', ->
         }, (err, article) =>
           article.slugs.length.should.equal 1
           article.slugs[0].should.equal 'molly-clockwork-07-26-17'
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
+    it 'does not append a date to the slug if a slug with that date exists in the slugs array for that article already, instead it moves the slug with the appended date to the end of the slugs array', (done) ->
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: true
+          author: name: 'Molly'
+          slugs: ['molly-clockwork-2','molly-clockwork-07-26-17', 'molly-clockwork-3']
+          published_at: '2017-07-26T17:37:03.065Z'
+        }, (err, article) =>
+          article.slugs.length.should.equal 3
+          article.slugs[article.slugs.length-1].should.equal 'molly-clockwork-07-26-17'
           done()
       )(null, {
         slugs: ['molly-clockwork']

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -196,7 +196,8 @@ describe 'Save', ->
         slugs: ['molly-clockwork']
       })
 
-    it 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->
+    it 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->     
+      # removing date offset to account for different timezones
       now = new Date()
       os = now.getTimezoneOffset()      
       sandbox.clock.tick(os * -60000)

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -17,7 +17,7 @@ describe 'Save', ->
     app.use '/__gravity', gravity
     @server = app.listen 5000, ->
       done()
-    sandbox.useFakeTimers(new Date(Date.UTC(2019, 0, 1, 0, 0, 0)))
+    sandbox.useFakeTimers(new Date(2019,0,1,0,0,0).getTime())
 
   after ->
     @server.close()
@@ -112,7 +112,7 @@ describe 'Save', ->
           author: name: 'Molly'
           published_at: '2017-07-dsdfdf26T17:37:03.065Zsdfdf'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-12-31-18'
+          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -125,7 +125,7 @@ describe 'Save', ->
           published: true
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-12-31-18'
+          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -200,7 +200,7 @@ describe 'Save', ->
           published: false
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-1546300800'
+          article.slugs[0].should.equal 'molly-clockwork-1546318800'
           done()
       )(null, {
         slugs: ['molly-clockwork']

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -19,8 +19,6 @@ describe 'Save', ->
       done()
 
     date = new Date("Tue Jan 01 2019 00:00:00")
-    # offset = date.getTimezoneOffset()
-    # dateWithOffset = moment(date).add(offset, 'm').toDate();
     sandbox.useFakeTimers(date)
     
 
@@ -199,13 +197,9 @@ describe 'Save', ->
       })
 
     it 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->
-      x = new Date()
-      console.log("date now",x)
-      os = x.getTimezoneOffset()
-      
+      now = new Date()
+      os = now.getTimezoneOffset()      
       sandbox.clock.tick(os * -60000)
-      y = new Date()
-      console.log("date now",y) 
       
       Save.sanitizeAndSave( =>
         Save.generateSlugs {

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -71,7 +71,7 @@ describe 'Save', ->
         article.slugs[0].should.equal 'molly-clockwork'
         done()
 
-    it 'appends a date to the slug if it exists already', (done) ->
+    it 'appends a date to the slug if it exists in the database already', (done) ->
       Save.sanitizeAndSave( =>
         Save.generateSlugs {
           thumbnail_title: 'Clockwork'
@@ -79,6 +79,67 @@ describe 'Save', ->
           author: name: 'Molly'
           published_at: '2017-07-26T17:37:03.065Z'
         }, (err, article) =>
+          article.slugs[0].should.equal 'molly-clockwork-07-26-17'
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
+    it 'does not append a date to the slug if it exists in the slugs array for that article already', (done) ->
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: true
+          slugs: ['molly-clockwork']
+          author: name: 'Molly'
+          published_at: '2017-07-26T17:37:03.065Z'
+        }, (err, article) =>
+          article.slugs.length.should.equal 1
+          article.slugs[0].should.equal 'molly-clockwork'
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
+    it 'appends the current date to the slug if the slug exists in the database already but the date is invalid', (done) ->
+      todays_date = moment().format('MM-DD-YY')
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: true
+          author: name: 'Molly'
+          published_at: '2017-07-dsdfdf26T17:37:03.065Zsdfdf'
+        }, (err, article) =>
+          article.slugs[0].should.equal 'molly-clockwork' + '-' + todays_date
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
+    it 'appends the current date to the slug if the slug exists in the database already but there is no publish date', (done) ->
+      todays_date = moment().format('MM-DD-YY')
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: true
+          author: name: 'Molly'
+        }, (err, article) =>
+          article.slugs[0].should.equal 'molly-clockwork' + '-' + todays_date
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
+    it 'does not append a date to the slug if a slug with that date exists in the slugs array for that article already', (done) ->
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: true
+          author: name: 'Molly'
+          slugs: ['molly-clockwork-07-26-17']
+          published_at: '2017-07-26T17:37:03.065Z'
+        }, (err, article) =>
+          article.slugs.length.should.equal 1
           article.slugs[0].should.equal 'molly-clockwork-07-26-17'
           done()
       )(null, {
@@ -94,6 +155,20 @@ describe 'Save', ->
           published_at: '2017-07-26T17:37:03.065Z'
         }, (err, article) =>
           article.slugs[0].should.equal 'molly-clockwork-1501090623'
+          done()
+      )(null, {
+        slugs: ['molly-clockwork']
+      })
+
+    it 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->
+      todays_date = moment().format('X')
+      Save.sanitizeAndSave( =>
+        Save.generateSlugs {
+          thumbnail_title: 'Clockwork'
+          published: false
+          author: name: 'Molly'
+        }, (err, article) =>
+          article.slugs[0].should.equal 'molly-clockwork' + '-' + todays_date
           done()
       )(null, {
         slugs: ['molly-clockwork']

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -162,7 +162,7 @@ describe 'Save', ->
         slugs: ['molly-clockwork']
       })
 
-    it 'does not append a date to the slug if a slug with that date exists in the slugs array for that article already, instead it moves the slug with the appended date to the end of the slugs array', (done) ->
+    it 'it moves the slug with the appended date to the end of the slugs array if a slug with that date exists in the slugs array for that article already', (done) ->
       Save.sanitizeAndSave( =>
         Save.generateSlugs {
           thumbnail_title: 'Clockwork'

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -17,7 +17,7 @@ describe 'Save', ->
     app.use '/__gravity', gravity
     @server = app.listen 5000, ->
       done()
-    sandbox.useFakeTimers(new Date(2019,0,1,0,0,0).getTime())
+    sandbox.useFakeTimers(new Date("Tue Jan 01 2019 00:00:00 GMT-0000").getTime())
 
   after ->
     @server.close()
@@ -112,7 +112,7 @@ describe 'Save', ->
           author: name: 'Molly'
           published_at: '2017-07-dsdfdf26T17:37:03.065Zsdfdf'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
+          article.slugs[0].should.equal 'molly-clockwork-12-31-18'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -125,7 +125,7 @@ describe 'Save', ->
           published: true
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
+          article.slugs[0].should.equal 'molly-clockwork-12-31-18'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -200,7 +200,7 @@ describe 'Save', ->
           published: false
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork-1546318800'
+          article.slugs[0].should.equal 'molly-clockwork-1546300800'
           done()
       )(null, {
         slugs: ['molly-clockwork']

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -11,14 +11,17 @@ moment = require 'moment'
 { ObjectId } = require 'mongojs'
 
 describe 'Save', ->
+  sandbox = sinon.sandbox.create();
 
   before (done) ->
     app.use '/__gravity', gravity
     @server = app.listen 5000, ->
       done()
+    sandbox.useFakeTimers(new Date(2019,0,1))
 
   after ->
     @server.close()
+    sandbox.restore()
 
   beforeEach (done) ->
     @removeStopWords = Save.__get__ 'removeStopWords'
@@ -102,7 +105,6 @@ describe 'Save', ->
       })
 
     it 'appends the current date to the slug if the slug exists in the database already but the date is invalid', (done) ->
-      todays_date = moment().format('MM-DD-YY')
       Save.sanitizeAndSave( =>
         Save.generateSlugs {
           thumbnail_title: 'Clockwork'
@@ -110,21 +112,20 @@ describe 'Save', ->
           author: name: 'Molly'
           published_at: '2017-07-dsdfdf26T17:37:03.065Zsdfdf'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork' + '-' + todays_date
+          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
           done()
       )(null, {
         slugs: ['molly-clockwork']
       })
 
     it 'appends the current date to the slug if the slug exists in the database already but there is no publish date', (done) ->
-      todays_date = moment().format('MM-DD-YY')
       Save.sanitizeAndSave( =>
         Save.generateSlugs {
           thumbnail_title: 'Clockwork'
           published: true
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork' + '-' + todays_date
+          article.slugs[0].should.equal 'molly-clockwork-01-01-19'
           done()
       )(null, {
         slugs: ['molly-clockwork']
@@ -193,14 +194,13 @@ describe 'Save', ->
       })
 
     it 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->
-      todays_date = moment().format('X')
       Save.sanitizeAndSave( =>
         Save.generateSlugs {
           thumbnail_title: 'Clockwork'
           published: false
           author: name: 'Molly'
         }, (err, article) =>
-          article.slugs[0].should.equal 'molly-clockwork' + '-' + todays_date
+          article.slugs[0].should.equal 'molly-clockwork-1546318800'
           done()
       )(null, {
         slugs: ['molly-clockwork']

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -17,7 +17,7 @@ describe 'Save', ->
     app.use '/__gravity', gravity
     @server = app.listen 5000, ->
       done()
-    sandbox.useFakeTimers(new Date(2019,0,1))
+    sandbox.useFakeTimers(new Date(2019,0,1,0,0,0))
 
   after ->
     @server.close()

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -22,6 +22,7 @@ describe 'Save', ->
     # offset = date.getTimezoneOffset()
     # dateWithOffset = moment(date).add(offset, 'm').toDate();
     sandbox.useFakeTimers(date)
+    
 
   after ->
     @server.close()
@@ -197,7 +198,7 @@ describe 'Save', ->
         slugs: ['molly-clockwork']
       })
 
-    it.only 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->
+    it 'appends unix timestamp for current date to the slug if the slug exists already and it is a draft and there is no publish date', (done) ->
       x = new Date()
       console.log("date now",x)
       os = x.getTimezoneOffset()


### PR DESCRIPTION
Fixed "Invalid Date" and duplicate slug issues. Changed functionality so the slug is moved to the end of the slugs array if it already exists somewhere in the array, instead of appending the date to the slug and adding that to the array. Added more tests for slug creation.

There is one tiny edgecase that might cause an issue in theory but seems really unlikely. If there are two articles with the same title the second will append the publish date to the slug. If a third article is created with that same title and has a publish date on the same day as the publish date of the second article, then the third article will have the same slug as the second. I could fix this by appending a date format with hours/minutes/seconds to the slug if the slug with the same publish date exists but this would require another call to the db to check or completely changing the existing call, or I could change the date format to include hours/minutes/seconds for all appended dates. Neither seems worth it since it seems like an unlikely edgecase, but I can fix it if necessary. 