### PR TITLE
Add git-remote for Hokusai

### DIFF
--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,3 +1,4 @@
 ---
 project-name: positron
 pre-deploy: yarn publish-assets
+git-remote: git@github.com:artsy/positron.git


### PR DESCRIPTION
Ensures that we're tracking deploys in artsy/positron's Github releases
for ease of deployment tracking.