### PR TITLE
Style: Add some missing linebreaks in example data dog agent declaration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,8 @@ MONGOHQ_URL=mongodb://localhost:27017/positron
 #  -v /proc/:/host/proc/:ro \
 #  -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
 #  -e DD_API_KEY=[GET-FROM-DD-UI] \
-#  -e DD_APM_ENABLED=true
-#  -e DD_HOSTNAME="$(whoami)-$(hostname -s)"
+#  -e DD_APM_ENABLED=true \
+#  -e DD_HOSTNAME="$(whoami)-$(hostname -s)" \
 #  datadog/agent:latest
 #```
 ##


### PR DESCRIPTION
Tiny change that I realized when working on some data dog stuff with @bhoggard  