### PR TITLE
Delete duplicate and invalid article slugs (GROW-1079)

### DIFF
--- a/src/api/apps/articles/test/backfill.test.js
+++ b/src/api/apps/articles/test/backfill.test.js
@@ -1,0 +1,62 @@
+import {
+  bar,
+  foo
+} from "../model";
+
+describe("Foo", () => {
+
+  let article
+
+  beforeEach(() => {
+    article = {
+      "slugs": [
+        "artsy-editorial-1523284755",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-pub",
+        "artsy-editorial-publish",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-i",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend",
+        "artsy-editorial-1523285220",
+        "artsy-editorial-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220",
+        "artsy-editorial-Invalid date",
+        "artsy-editorial-Invalid date",
+      ]
+    }
+  })
+
+  it("Bar", () => {
+    foo(article)
+    bar(article)
+
+    expect(article.slugs).toHaveLength(7)
+    expect(article.slugs[article.slugs.length - 1]).toBe("artsy-editorial-art-collector-andy-warhols-scene-died-fire-broke-trump-tower-apartment-weekend-1523285220")
+  })
+})


### PR DESCRIPTION
This PR deletes article slugs that are either duplicated or contain "Invalid date". This is necessary to index the slug field in the database and improve performance. This PR does not need to be merged since backfilling is done from a local instance of Positron. 