### PR TITLE
Use newer styled-components syntax for typing attrs

### DIFF
--- a/src/client/apps/edit/components/admin/components/article/article_publish_date.tsx
+++ b/src/client/apps/edit/components/admin/components/article/article_publish_date.tsx
@@ -172,7 +172,7 @@ export class ArticlePublishDate extends Component<ArticlePublishDateProps> {
   }
 }
 
-export const InputGroup = styled(Flex).attrs<{ hasFocus?: boolean }>({})`
+export const InputGroup = styled(Flex)<{ hasFocus?: boolean }>`
   min-width: 70%;
   border: 1px solid
     ${props => (props.hasFocus ? color("purple100") : color("black10"))};

--- a/src/client/apps/edit/components/admin/components/article/index.tsx
+++ b/src/client/apps/edit/components/admin/components/article/index.tsx
@@ -341,9 +341,9 @@ export default connect(
   mapDispatchToProps
 )(AdminArticle)
 
-export const Button = styled(SystemButton).attrs<{
+export const Button = styled(SystemButton)<{
   color?: string
-}>({})`
+}>`
   color: ${props => props.color};
 `
 

--- a/src/client/apps/edit/components/content/sections/footer/index.tsx
+++ b/src/client/apps/edit/components/content/sections/footer/index.tsx
@@ -52,7 +52,7 @@ export default connect(
   mapDispatchToProps
 )(SectionFooter)
 
-const FooterContainer = styled.div.attrs<{ layout?: string }>({})`
+const FooterContainer = styled.div<{ layout?: string }>`
   ${props =>
     props.layout === "standard" &&
     `
@@ -60,7 +60,7 @@ const FooterContainer = styled.div.attrs<{ layout?: string }>({})`
   `};
 `
 
-const SectionFooterPostscript = styled.div.attrs<{ width?: string }>({})`
+const SectionFooterPostscript = styled.div<{ width?: string }>`
   width: 100%;
   max-width: ${props => props.width || "100%"};
   margin: auto;

--- a/src/client/apps/edit/components/content/sections/images/components/controls.tsx
+++ b/src/client/apps/edit/components/content/sections/images/components/controls.tsx
@@ -272,7 +272,7 @@ export const ArtworkInputs = styled(Flex)`
 `
 
 // TODO: Use palette radios
-export const RadioInput = styled.div.attrs<{ isActive: boolean }>({})`
+export const RadioInput = styled.div<{ isActive: boolean }>`
   border: 2px solid white;
   width: 16px;
   height: 16px;

--- a/src/client/apps/edit/components/content/sections/images/components/edit_image.tsx
+++ b/src/client/apps/edit/components/content/sections/images/components/edit_image.tsx
@@ -132,7 +132,7 @@ export default connect(
   mapDispatchToProps
 )(EditImage)
 
-export const EditImageContainer = styled.div.attrs<{ width?: any }>({})`
+export const EditImageContainer = styled.div<{ width?: any }>`
   width: ${props => props.width || "100%"};
   position: relative;
   max-width: 100%;

--- a/src/client/apps/edit/components/content/sections/images/index.tsx
+++ b/src/client/apps/edit/components/content/sections/images/index.tsx
@@ -204,10 +204,10 @@ export default connect(
   mapDispatchToProps
 )(SectionImages)
 
-const SectionImagesContainer = styled.section.attrs<{
+const SectionImagesContainer = styled.section<{
   sectionLayout: SectionLayout
   isWrapping?: boolean
-}>({})`
+}>`
   .RemoveButton {
     position: absolute;
     top: -12px;
@@ -236,9 +236,9 @@ const SectionImagesContainer = styled.section.attrs<{
   `};
 `
 
-const SectionImagesList = styled(Flex).attrs<{
+const SectionImagesList = styled(Flex)<{
   isWrapping?: boolean
-}>({})`
+}>`
   position: relative;
 
   ${DragContainer} {

--- a/src/client/apps/edit/components/content/sections/text/index2.tsx
+++ b/src/client/apps/edit/components/content/sections/text/index2.tsx
@@ -263,10 +263,10 @@ export default connect(
   mapDispatchToProps
 )(SectionText2)
 
-const SectionTextContainer = styled.div.attrs<{
+const SectionTextContainer = styled.div<{
   isEditing?: boolean
   layout: string
-}>({})`
+}>`
   position: relative;
   z-index: ${props => (props.isEditing ? 2 : -1)};
 

--- a/src/client/apps/edit/components/display/components/magazine.tsx
+++ b/src/client/apps/edit/components/display/components/magazine.tsx
@@ -86,6 +86,6 @@ export default connect(
   mapDispatchToProps
 )(DisplayMagazine)
 
-export const FillTitlePrompt = styled(Serif).attrs<{ onClick: () => void }>({})`
+export const FillTitlePrompt = styled(Serif)<{ onClick: () => void }>`
   cursor: pointer;
 `

--- a/src/client/apps/edit/components/header/index.tsx
+++ b/src/client/apps/edit/components/header/index.tsx
@@ -244,7 +244,7 @@ export interface HeaderButtonProps {
   borderLeft?: string
   borderBottom?: string
 }
-export const HeaderButton = styled(Button).attrs<HeaderButtonProps>({})``
+export const HeaderButton = styled(Button)<HeaderButtonProps>``
 
 const CheckIcon = styled(Icon)`
   margin-right: 0;

--- a/src/client/apps/edit/components/yoast/index.tsx
+++ b/src/client/apps/edit/components/yoast/index.tsx
@@ -222,7 +222,7 @@ const Drawer = styled(Flex)`
   border-bottom: 1px solid ${color("black10")};
 `
 
-const CloseIcon = styled(Icon).attrs<{ rotation: number }>({})`
+const CloseIcon = styled(Icon)<{ rotation: number }>`
   transform: rotate(${props => props.rotation}deg);
   transition: all 0.25s;
   position: absolute;

--- a/src/client/apps/settings/client/curations/display/index.tsx
+++ b/src/client/apps/settings/client/curations/display/index.tsx
@@ -149,6 +149,6 @@ export default class DisplayAdmin extends React.Component<
   }
 }
 
-const Button = styled(SystemButton).attrs<{ color?: string }>({})`
+const Button = styled(SystemButton)<{ color?: string }>`
   ${props => props.color && `color: ${props.color}`};
 `

--- a/src/client/components/autocomplete2/index.tsx
+++ b/src/client/components/autocomplete2/index.tsx
@@ -251,10 +251,10 @@ const AutocompleteResultsBackground = styled.div`
   z-index: -1;
 `
 
-export const AutocompleteResult = styled(Flex).attrs<{
+export const AutocompleteResult = styled(Flex)<{
   isEmpty?: boolean
   children: any
-}>({})`
+}>`
   padding: 10px;
   background: white;
   color: ${color("black100")};

--- a/src/client/components/autocomplete2/list.tsx
+++ b/src/client/components/autocomplete2/list.tsx
@@ -120,7 +120,7 @@ export class AutocompleteList extends Component<
   }
 }
 
-export const ListItem = styled(Flex).attrs<{ isDraggable?: boolean }>({})`
+export const ListItem = styled(Flex)<{ isDraggable?: boolean }>`
   border: 1px solid ${color("black10")};
   position: relative;
   padding: 10px 10px 10px;

--- a/src/client/components/character_limit/index.tsx
+++ b/src/client/components/character_limit/index.tsx
@@ -113,7 +113,7 @@ export class CharacterLimit extends React.Component<
   }
 }
 
-const CharacterLimitContainer = styled.div.attrs<{ type?: string }>({})`
+const CharacterLimitContainer = styled.div<{ type?: string }>`
   ${props =>
     props.type === "textarea" &&
     `
@@ -127,6 +127,6 @@ const CharacterLimitContainer = styled.div.attrs<{ type?: string }>({})`
   }
 `
 
-export const RemainingChars = styled.div.attrs<{ isOverLimit: boolean }>({})`
+export const RemainingChars = styled.div<{ isOverLimit: boolean }>`
   color: ${props => (props.isOverLimit ? color("red100") : color("black30"))};
 `

--- a/src/client/components/draft/components/text_input_url.tsx
+++ b/src/client/components/draft/components/text_input_url.tsx
@@ -135,9 +135,7 @@ export class TextInputUrl extends Component<Props, State> {
   }
 }
 
-const TextInputUrlContainer = styled.div.attrs<{ top: number; left: number }>(
-  {}
-)`
+const TextInputUrlContainer = styled.div<{ top: number; left: number }>`
   top: ${props => `${props.top + 5}px` || 0};
   left: ${props => `${props.left}px` || 0};
   position: absolute;

--- a/src/client/components/draft/components/text_nav.tsx
+++ b/src/client/components/draft/components/text_nav.tsx
@@ -229,11 +229,11 @@ export class TextNav extends Component<Props, State> {
   }
 }
 
-export const TextNavContainer = styled.div.attrs<{
+export const TextNavContainer = styled.div<{
   top: number
   left: number
   width: number
-}>({})`
+}>`
   max-width: ${props => props.width}px;
   background: ${color("black100")};
   border-radius: 5px;
@@ -258,7 +258,7 @@ export const TextNavContainer = styled.div.attrs<{
   }
 `
 
-export const Button = styled.div.attrs<{ styleType: string }>({})`
+export const Button = styled.div<{ styleType: string }>`
   color: ${color("black30")};
   height: ${BUTTON_HEIGHT}px;
   width: ${BUTTON_WIDTH}px;

--- a/src/client/components/drag_drop2/drag_source.tsx
+++ b/src/client/components/drag_drop2/drag_source.tsx
@@ -45,9 +45,9 @@ export class DragSource extends React.Component<DragSourceProps> {
   }
 }
 
-export const DragSourceContainer = styled.div.attrs<{
+export const DragSourceContainer = styled.div<{
   isActiveSource?: boolean
-}>({})`
+}>`
   z-index: 1;
   position: relative;
   background: white;

--- a/src/client/components/drag_drop2/drag_target.tsx
+++ b/src/client/components/drag_drop2/drag_target.tsx
@@ -74,10 +74,10 @@ export class DragTarget extends React.Component<DragTargetProps> {
   }
 }
 
-export const DragPlaceholder = styled.div.attrs<{
+export const DragPlaceholder = styled.div<{
   height?: number
   isVertical?: boolean
-}>({})`
+}>`
   border: 2px dashed ${color("black10")};
   height: ${props => (props.height ? `${props.height}px` : "auto")};
   min-height: 1em;
@@ -96,11 +96,11 @@ export const DragPlaceholder = styled.div.attrs<{
   `};
 `
 
-export const DragTargetContainer = styled.div.attrs<{
+export const DragTargetContainer = styled.div<{
   isActiveSource: boolean
   isActiveTarget: boolean
   width?: number
-}>({})`
+}>`
   position: relative;
   width: ${props => (props.width ? props.width : "100%")};
 


### PR DESCRIPTION
Was pretty certain this syntax wasn't working in a few weeks back, but at this moment it looks like we no longer need to use `attrs` when declaring styled component props.  This does a quick remove of the old syntax.