### PR TITLE
Fix tests broken by Reaction's Input

### DIFF
--- a/src/client/apps/edit/components/admin/components/article/test/article_authors.test.tsx
+++ b/src/client/apps/edit/components/admin/components/article/test/article_authors.test.tsx
@@ -111,7 +111,7 @@ describe("ArticleAuthors", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {

--- a/src/client/apps/edit/components/admin/components/test/sponsor.test.tsx
+++ b/src/client/apps/edit/components/admin/components/test/sponsor.test.tsx
@@ -111,7 +111,7 @@ describe("EditAdmin", () => {
       const input = component
         .find(Input)
         .at(0)
-        .instance() as Input
+        .props()
 
       const event = ({
         currentTarget: {
@@ -155,7 +155,7 @@ describe("EditAdmin", () => {
       const input = component
         .find(Input)
         .at(1)
-        .instance() as Input
+        .props()
 
       const event = ({
         currentTarget: {

--- a/src/client/apps/edit/components/admin/components/test/super_article.test.tsx
+++ b/src/client/apps/edit/components/admin/components/test/super_article.test.tsx
@@ -108,7 +108,7 @@ describe("AdminSuperArticle", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {

--- a/src/client/apps/edit/components/admin/components/test/tags.test.tsx
+++ b/src/client/apps/edit/components/admin/components/test/tags.test.tsx
@@ -41,7 +41,7 @@ describe("AdminTags", () => {
       const input = component
         .find(Input)
         .at(0)
-        .instance() as Input
+        .props()
 
       const event = ({
         currentTarget: {
@@ -81,7 +81,7 @@ describe("AdminTags", () => {
       const input = component
         .find(Input)
         .at(1)
-        .instance() as Input
+        .props()
 
       const event = ({
         currentTarget: {

--- a/src/client/apps/edit/components/content/sections/embed/test/controls.test.tsx
+++ b/src/client/apps/edit/components/content/sections/embed/test/controls.test.tsx
@@ -71,7 +71,7 @@ describe("EmbedControls", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: "new value",
@@ -88,7 +88,7 @@ describe("EmbedControls", () => {
     const input = component
       .find(Input)
       .at(1)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: "500",
@@ -105,7 +105,7 @@ describe("EmbedControls", () => {
     const input = component
       .find(Input)
       .at(2)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: "200",

--- a/src/client/apps/edit/components/content/sections/images/components/test/controls.test.tsx
+++ b/src/client/apps/edit/components/content/sections/images/components/test/controls.test.tsx
@@ -338,7 +338,7 @@ describe("ImagesControls", () => {
       const input = component
         .find(Input)
         .at(2)
-        .instance() as Input
+        .props()
       const event = ({
         currentTarget: {
           value: "A title for the Image Set",

--- a/src/client/apps/edit/components/content/sections/images/components/test/input_artwork_url.test.tsx
+++ b/src/client/apps/edit/components/content/sections/images/components/test/input_artwork_url.test.tsx
@@ -41,7 +41,7 @@ describe("InputArtworkUrl", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: artworkUrl,

--- a/src/client/apps/edit/components/content/sections/social_embed/test/controls.test.tsx
+++ b/src/client/apps/edit/components/content/sections/social_embed/test/controls.test.tsx
@@ -73,7 +73,7 @@ describe("SocialEmbedControls", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: "New value",

--- a/src/client/apps/edit/components/display/components/test/email.test.tsx
+++ b/src/client/apps/edit/components/display/components/test/email.test.tsx
@@ -137,7 +137,7 @@ describe("DisplayEmail", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {

--- a/src/client/apps/settings/client/curations/display/components/canvas/test/canvas_text.test.tsx
+++ b/src/client/apps/settings/client/curations/display/components/canvas/test/canvas_text.test.tsx
@@ -26,7 +26,7 @@ describe("Canvas Text", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -59,7 +59,7 @@ describe("Canvas Text", () => {
     const input = component
       .find(Input)
       .at(1)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -78,7 +78,7 @@ describe("Canvas Text", () => {
     const input = component
       .find(Input)
       .at(2)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -97,7 +97,7 @@ describe("Canvas Text", () => {
     const input = component
       .find(Input)
       .at(3)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {

--- a/src/client/apps/settings/client/curations/display/components/panel/test/index.test.tsx
+++ b/src/client/apps/settings/client/curations/display/components/panel/test/index.test.tsx
@@ -76,7 +76,7 @@ describe("Panel", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -95,7 +95,7 @@ describe("Panel", () => {
     const input = component
       .find(Input)
       .at(1)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: "http://new-link.com",
@@ -113,7 +113,7 @@ describe("Panel", () => {
     const input = component
       .find(Input)
       .at(2)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: "new tracking code",

--- a/src/client/apps/settings/client/curations/display/components/test/campaign.test.tsx
+++ b/src/client/apps/settings/client/curations/display/components/test/campaign.test.tsx
@@ -74,7 +74,7 @@ describe("Campaign Admin", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: "Campaign Sample",
@@ -95,7 +95,7 @@ describe("Campaign Admin", () => {
     const input = component
       .find(Input)
       .at(1)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: newDate,
@@ -116,7 +116,7 @@ describe("Campaign Admin", () => {
     const input = component
       .find(Input)
       .at(2)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: newDate,

--- a/src/client/apps/settings/client/curations/gucci/test/metadata.test.tsx
+++ b/src/client/apps/settings/client/curations/gucci/test/metadata.test.tsx
@@ -94,7 +94,7 @@ describe("Metadata", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -112,7 +112,7 @@ describe("Metadata", () => {
     const input = component
       .find(Input)
       .at(1)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -130,7 +130,7 @@ describe("Metadata", () => {
     const input = component
       .find(Input)
       .at(2)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -148,7 +148,7 @@ describe("Metadata", () => {
     const input = component
       .find(Input)
       .at(3)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -166,7 +166,7 @@ describe("Metadata", () => {
     const input = component
       .find(Input)
       .at(4)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {

--- a/src/client/apps/settings/client/curations/gucci/test/section.test.tsx
+++ b/src/client/apps/settings/client/curations/gucci/test/section.test.tsx
@@ -84,7 +84,7 @@ describe("Section Admin", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -116,7 +116,7 @@ describe("Section Admin", () => {
     const input = component
       .find(Input)
       .at(1)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {
@@ -134,7 +134,7 @@ describe("Section Admin", () => {
     const input = component
       .find(Input)
       .at(2)
-      .instance() as Input
+      .props()
 
     const event = ({
       currentTarget: {

--- a/src/client/apps/settings/client/curations/gucci/test/series.test.tsx
+++ b/src/client/apps/settings/client/curations/gucci/test/series.test.tsx
@@ -84,7 +84,7 @@ describe("Series Admin", () => {
     const input = component
       .find(Input)
       .at(0)
-      .instance() as Input
+      .props()
     const event = ({
       currentTarget: {
         value: "http://link.com",

--- a/src/client/components/character_limit/test/index.test.tsx
+++ b/src/client/components/character_limit/test/index.test.tsx
@@ -57,7 +57,7 @@ describe("Character Limit", () => {
       const input = component
         .find(Input)
         .at(0)
-        .instance() as Input
+        .props()
 
       const event = ({
         currentTarget: {


### PR DESCRIPTION
Not sure how circle turned the renovate PR green, but the latest version of Reaction has left our tests broken on master.  This updates any tests searching for `Input` as a class to look for `props().onChange` rather than `instance().onChange`.