### PR TITLE
Move empty block stripping into rich_text

### DIFF
--- a/src/client/apps/edit/components/content/sections/text/test/index.test.js
+++ b/src/client/apps/edit/components/content/sections/text/test/index.test.js
@@ -5,7 +5,6 @@ import { EditorState } from "draft-js"
 import { StandardArticle } from "@artsy/reaction/dist/Components/Publishing/Fixtures/Articles"
 import { TextNav } from "client/components/rich_text/components/text_nav"
 import { SectionText } from "../index.jsx"
-import { removeEmptyParagraphs } from "client/components/rich_text/utils/text_stripping"
 
 describe("SectionText", () => {
   let props
@@ -339,9 +338,7 @@ describe("SectionText", () => {
 
       expect(handleBackspace).toBe("handled")
       expect(props.removeSectionAction.mock.calls[0][0]).toBe(props.index - 1)
-      expect(component.state().html).toMatch(
-        removeEmptyParagraphs(props.section.body)
-      )
+      expect(component.state().html).toMatch(props.section.body)
       expect(component.state().html).toMatch(
         article.sections[props.index - 1].body
       )

--- a/src/client/components/draft/paragraph/paragraph.tsx
+++ b/src/client/components/draft/paragraph/paragraph.tsx
@@ -23,12 +23,12 @@ import {
 
 interface Props {
   allowedStyles?: AllowedStyles
-  allowEmptyLines?: boolean
+  allowEmptyLines?: boolean // Users can insert br tags
   html?: string
   hasLinks: boolean
   onChange: (html: string) => void
   placeholder?: string
-  stripLinebreaks: boolean
+  stripLinebreaks: boolean // Return a single p block
   isDark?: boolean
   isReadOnly?: boolean
 }
@@ -100,8 +100,13 @@ export class Paragraph extends Component<Props, State> {
   }
 
   editorStateFromHTML = (html: string) => {
-    const { hasLinks } = this.props
-    const contentBlocks = convertHtmlToDraft(html, hasLinks, this.allowedStyles)
+    const { hasLinks, allowEmptyLines } = this.props
+    const contentBlocks = convertHtmlToDraft(
+      html,
+      hasLinks,
+      this.allowedStyles,
+      allowEmptyLines
+    )
 
     return EditorState.createWithContent(contentBlocks, decorators(hasLinks))
   }

--- a/src/client/components/draft/paragraph/test/paragraph.test.tsx
+++ b/src/client/components/draft/paragraph/test/paragraph.test.tsx
@@ -147,7 +147,9 @@ describe("Paragraph", () => {
       const editorState = instance.editorStateFromHTML(component.props().html)
       instance.onChange(editorState)
 
-      expect(component.state().html).toBe("<p>A paragraph</p><p><br /></p>")
+      expect(component.state().html).toBe(
+        "<p>A paragraph</p><p><br /></p><p><br /></p><p><br /></p>"
+      )
     })
 
     it("Removes disallowed styles", () => {

--- a/src/client/components/draft/paragraph/utils/convert.tsx
+++ b/src/client/components/draft/paragraph/utils/convert.tsx
@@ -25,10 +25,14 @@ import {
 export const convertHtmlToDraft = (
   html: string,
   hasLinks: boolean,
-  allowedStyles: StyleMap
+  allowedStyles: StyleMap,
+  allowEmptyLines: boolean = false
 ) => {
   let cleanedHtml = stripGoogleStyles(html)
-  cleanedHtml = removeEmptyParagraphs(cleanedHtml)
+
+  cleanedHtml = allowEmptyLines
+    ? removeBreakingSpaces(cleanedHtml)
+    : removeEmptyParagraphs(cleanedHtml)
 
   return convertFromHTML({
     htmlToBlock,
@@ -210,4 +214,13 @@ export const removeEmptyParagraphs = (html: string) => {
  */
 export const preserveEmptyParagraphs = (html: string) => {
   return html.replace(/<p><\/p>/g, "<p><br /></p>")
+}
+
+/**
+ * Removes br tags during editing
+ * These cause extra spaces to appear in draft content state
+ * br tags are restored when converted back to html
+ */
+export const removeBreakingSpaces = (html: string) => {
+  return html.replace(/<br \/>/g, "").replace(/<br>/g, "")
 }

--- a/src/client/components/draft/rich_text/utils/convert.tsx
+++ b/src/client/components/draft/rich_text/utils/convert.tsx
@@ -30,8 +30,9 @@ export const convertHtmlToDraft = (
   allowedBlocks: any,
   allowedStyles: StyleMap
 ) => {
-  const cleanedHtml = stripGoogleStyles(html)
-  // TODO: REMOVE ILLEGAL LINEBREAKS
+  let cleanedHtml = stripGoogleStyles(html)
+  cleanedHtml = removeEmptyParagraphs(cleanedHtml)
+
   return convertFromHTML({
     htmlToBlock: (nodeName: string, node: HTMLElement) => {
       return htmlToBlock(nodeName, node, allowedBlocks)
@@ -292,4 +293,8 @@ export const blockToHTML = (
     start: "<p>",
     end: "</p>",
   }
+}
+
+export const removeEmptyParagraphs = (html: string) => {
+  return html.replace(/<p><br><\/p>/g, "")
 }

--- a/src/client/components/draft/shared/test_helpers.ts
+++ b/src/client/components/draft/shared/test_helpers.ts
@@ -43,6 +43,22 @@ export const getContentState = (
   return convertHtmlToDraft(html, hasLinks, blockMap, richTextStyleMap)
 }
 
+export const getHtmlViaContentState = (
+  html: string,
+  hasLinks = false,
+  hasFollowButton = false
+) => {
+  // Get unstripped content state
+  const contentState = getContentState(html, hasLinks, richTextBlockRenderMap)
+  // Convert contentState back to html
+  return convertDraftToHtml(
+    contentState,
+    richTextBlockRenderMap,
+    richTextStyleMap,
+    hasFollowButton
+  )
+}
+
 export const getEditorState = (
   html,
   hasLinks = true,

--- a/src/client/components/rich_text/test/utils/text_stripping.test.js
+++ b/src/client/components/rich_text/test/utils/text_stripping.test.js
@@ -95,7 +95,7 @@ describe("Draft Utils: Text Stripping", () => {
 
     it("Can remove unicode spaces", () => {
       const html = stripGoogleStyles("<p>\u2028hello</p>")
-      expect(html).toBe("<p>hello</p>")
+      expect(html).toBe("<p><br></p><p>hello</p>")
     })
 
     it("Replaces italic spans with <em> tags", () => {

--- a/src/client/components/rich_text/utils/text_stripping.js
+++ b/src/client/components/rich_text/utils/text_stripping.js
@@ -185,9 +185,6 @@ export const stripGoogleStyles = html => {
   // 5. Strip non-style guide spaces
   strippedHtml = standardizeSpacing(strippedHtml)
 
-  // 6. Remove empty paragraphs
-  strippedHtml = removeEmptyParagraphs(strippedHtml)
-
   return strippedHtml
 }
 
@@ -220,10 +217,5 @@ export const stripBlockquote = html => {
   let newHtml = html
     .replace("<blockquote>", "<p>")
     .replace("</blockquote>", "</p>")
-  return newHtml
-}
-
-export const removeEmptyParagraphs = html => {
-  let newHtml = html.replace(/<p><br><\/p>/g, "")
   return newHtml
 }


### PR DESCRIPTION
Introduced a bug in https://github.com/artsy/positron/pull/1911

Issue:
Empty text blocks should not be allowed in `RichText`, however we accidentally removed this restriction when introducing optional linebreaks to the `Paragraph` component for this ticket: https://artsyproduct.atlassian.net/browse/GROW-961

This PR moves linebreak stripping out of `stripGoogleStyles` and into `convertToHtml` for `RichText`
