### PR TITLE
Bump @artsy libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@artsy/express-reloadable": "1.4.0",
     "@artsy/palette": "4.1.2",
-    "@artsy/reaction": "15.0.0",
+    "@artsy/reaction": "15.5.4",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.0.0",
     "@babel/node": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "1.4.0",
-    "@artsy/palette": "4.0.3",
+    "@artsy/palette": "4.1.2",
     "@artsy/reaction": "15.0.0",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,10 +37,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.5.tgz#d61e1a9f215d38d90ec2bb97dc1ff7409d0346fa"
   integrity sha512-XRYA77v/j3mVInwy5EYb8NtmMkkAD1/XDxDi45BO0oduv4hsljJfjtjK7jN0ziJ6JUm2QTx/t6QwuaT9E7vTuA==
 
-"@artsy/reaction@15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-15.0.0.tgz#493178ab80ecd49b47a828fea656cd5b22786c4e"
-  integrity sha512-F0VzFb0hq6xXo0rMSgTZy+btuGX0PQZw43oIzq6nr4MbQfQRXjjMm5c0WWwM2Kqn8NJ/yp4/97IVfDbYVl/fFA==
+"@artsy/reaction@15.5.4":
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-15.5.4.tgz#3cde8ca54899fb73f3e8662c6ff1241958456809"
+  integrity sha512-e2cHoGy6ZvcNEIyY9g3E4iej57Sa8SVPn0z+M2V98uimvNEfOLiczL9E0OW2eM+QflJ5fHU5SC2eevPjVNZSUQ==
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.1"
     "@artsy/react-responsive-media" "^2.0.0-beta.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,16 +16,15 @@
     chokidar "^1.7.0"
     decache "^4.4.0"
 
-"@artsy/palette@4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.0.3.tgz#6b8f463fbe3a20f3496a79c1d2439103f52e2879"
-  integrity sha512-pGBCN+pV2GWLT7Ay1IS3tiENNXpABHS9IcCCSEmjP8z/dNCNYHI53RRCRe1BDEz8DkTFrgp4/qnCnaVkSWM8WA==
+"@artsy/palette@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.1.2.tgz#d6f3b957b3895e492723c8ec1d9c7d0cdbca7fcf"
+  integrity sha512-o3XjXCP6fZ+or/sQ59skSZ2lIvvDkktqd4lTGUnoYEGp/nPvrmFXrtMndgBv/nXKla0NFIG7kB+Rrqp1/27FkA==
   dependencies:
     babel-plugin-styled-components "^1.10.0"
     moment "^2.23.0"
     moment-timezone "^0.5.23"
     rc-slider "^8.6.2"
-    react "^16.8.2"
     react-live "^1.12.0"
     react-powerplug "^1.0.0"
     react-spring "^5.7.2"


### PR DESCRIPTION
Renovate PRs have been failing this week due to error writing to yarn lock. Investigating this further, but for now manually updating these libs. 