### PR TITLE
Update yarn version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN touch /var/run/nginx.pid && \
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-RUN npm install -g yarn@1.9.4
+RUN npm install -g yarn@1.15.2
 
 # Switch to deploy user
 USER deploy


### PR DESCRIPTION
This updates yarn to the latest version. 

I believe this'll help resolve an issue that's causing renovate builds to fail with the new deduplicate dependencies process. 