### PR TITLE
Graphql can return authors on RelatedArticles

### DIFF
--- a/src/api/apps/graphql/index.js
+++ b/src/api/apps/graphql/index.js
@@ -41,7 +41,17 @@ const metaFields = {
       resolve: resolvers.relatedArticlesPanel,
     }),
   relatedArticles: array()
-    .items(object(Article.inputSchema))
+    .items(
+      object(Article.inputSchema).concat(
+        object({
+          authors: array()
+            .items(object(Author.schema))
+            .meta({
+              resolve: resolvers.relatedAuthors,
+            }),
+        })
+      )
+    )
     .meta({
       name: "RelatedArticles",
       resolve: resolvers.relatedArticles,

--- a/src/api/apps/graphql/test/integration.spec.js
+++ b/src/api/apps/graphql/test/integration.spec.js
@@ -1,6 +1,7 @@
 import request from "superagent"
 import {
   ArticleSectionsQuery,
+  RelatedArticlesQuery,
   RelatedArticlesCanvasQuery,
 } from "api/apps/graphql/test/queries"
 const { ObjectId } = require("mongojs")
@@ -76,6 +77,52 @@ describe("graphql endpoint", () => {
           done()
         })
     })
+  })
+
+  it("can get authors in relatedArticles", done => {
+    fabricate(
+      "authors",
+      [{ _id: ObjectId("55356a9deca560a0137bb4ae"), name: "Kana" }],
+      (err, articles) => {
+        fabricate(
+          "articles",
+          [
+            {
+              title: "Top Ten Booths",
+              published: true,
+              _id: ObjectId("5c9d3c1aa4ba105ad8336956"),
+              author_ids: [ObjectId("55356a9deca560a0137bb4ae")],
+            },
+            {
+              published: true,
+              featured: true,
+              vertical: {
+                name: "Culture",
+                id: ObjectId("55356a9deca560a0137bb4a7"),
+              },
+              channel_id: ObjectId("5aa99c11da4c00d6bc33a816"),
+              author_ids: [ObjectId("55356a9deca560a0137bb4ae")],
+              related_article_ids: [ObjectId("5c9d3c1aa4ba105ad8336956")],
+            },
+          ],
+          (err, articles) => {
+            request
+              .post("http://localhost:5000/graphql")
+              .send({ query: RelatedArticlesQuery })
+              .end((err, res) => {
+                res.body.data.articles.length.should.equal(2)
+                res.body.data.articles[0].relatedArticles[0].title.should.equal(
+                  "Top Ten Booths"
+                )
+                res.body.data.articles[0].relatedArticles[0].authors[0].name.should.equal(
+                  "Kana"
+                )
+                done()
+              })
+          }
+        )
+      }
+    )
   })
 
   it("can get authors in relatedArticlesCanvas", done => {

--- a/src/api/apps/graphql/test/queries.js
+++ b/src/api/apps/graphql/test/queries.js
@@ -99,3 +99,23 @@ export const RelatedArticlesCanvasQuery = `
     }
   }
 `
+
+export const RelatedArticlesQuery = `
+  {
+    articles(published: true) {
+      title
+      id
+      channel_id
+      vertical {
+        id
+        name
+      }
+      relatedArticles {
+        title
+        authors {
+          name
+        }
+      }
+    }
+  }
+`

--- a/src/client/apps/edit/components/content/sections/related_articles/index.jsx
+++ b/src/client/apps/edit/components/content/sections/related_articles/index.jsx
@@ -116,7 +116,7 @@ export class RelatedArticles extends Component {
           editTitle="Title"
           editDescription="Article or video description..."
           editImage={() => <div />}
-          editDate="Publish Date"
+          editDate={!article.published && "Publish Date"}
           article={{}}
           series={article}
           color={color}

--- a/src/client/queries/related_articles.js
+++ b/src/client/queries/related_articles.js
@@ -4,6 +4,10 @@ export function RelatedArticleQuery(ids) {
   return `
     {
       articles(ids: ${stringifyJSONForWeb(ids)}) {
+        authors {
+          name
+          id
+        }
         description
         id
         media {

--- a/src/client/queries/related_articles.js
+++ b/src/client/queries/related_articles.js
@@ -8,6 +8,9 @@ export function RelatedArticleQuery(ids) {
           name
           id
         }
+        author {
+          name
+        }
         description
         id
         media {


### PR DESCRIPTION
- Updates API to support querying `authors` on the `relatedArticles` resolver
- Adds authors query to display authors in series editing `relatedArticles` display