### PR TITLE
Use circle context hokusai

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ workflows:
   build-deploy:
     jobs:
       - build-and-test:
+          context: hokusai
           filters:
             branches:
               ignore:


### PR DESCRIPTION
Updates circle config to use context: hokusai. 

Follow up step: remove aws keys for Positron's circle env settings.