### PR TITLE
Codecov updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,6 +245,12 @@
     ],
     "roots": [
       "<rootDir>/src"
+    ],
+    "coverageDirectory": "./.nyc_output/",
+    "collectCoverage": true,
+    "coverageReporters": [
+      "text",
+      "json"
     ]
   },
   "lint-staged": {

--- a/scripts/jest.sh
+++ b/scripts/jest.sh
@@ -6,5 +6,4 @@ trap "exit" INT
 
 jest \
   $@ \
-  --maxWorkers=2 --detectOpenHandles --forceExit \
-  --coverage --coverageDirectory .nyc_output --coverageReporters json
+  --maxWorkers=2 --detectOpenHandles --forceExit

--- a/scripts/mocha.sh
+++ b/scripts/mocha.sh
@@ -4,7 +4,7 @@ set -e -x
 
 trap "exit" INT
 
-nyc mocha \
+nyc --extension .coffee mocha \
   --require test.config.js \
   --timeout 10000 \
    $@ \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,8 +2,7 @@
 
 set -e -x
 
-yarn mocha $(find src/api -name '*.test.coffee')
-yarn mocha $(find src/api -name '*.spec.js')
-yarn mocha $(find src/client -name '*.test.coffee')
+yarn mocha $(find src -name '*.test.coffee')
+yarn mocha $(find src -name '*.spec.js')
 yarn jest
 yarn publish-coverage

--- a/src/client/apps/edit/components/content/article_layouts/test/article.test.tsx
+++ b/src/client/apps/edit/components/content/article_layouts/test/article.test.tsx
@@ -1,4 +1,5 @@
 import { FeatureArticle } from "@artsy/reaction/dist/Components/Publishing/Fixtures/Articles"
+import { FullScreenProvider } from "@artsy/reaction/dist/Components/Publishing/Sections/FullscreenViewer/FullScreenProvider"
 import { mount } from "enzyme"
 import React from "react"
 import { Provider } from "react-redux"
@@ -25,7 +26,9 @@ describe("EditArticle", () => {
 
     return mount(
       <Provider store={store}>
-        <EditArticle {...passedProps} />
+        <FullScreenProvider>
+          <EditArticle {...passedProps} />
+        </FullScreenProvider>
       </Provider>
     )
   }

--- a/src/client/apps/edit/components/content/section_list/test/index.test.tsx
+++ b/src/client/apps/edit/components/content/section_list/test/index.test.tsx
@@ -1,4 +1,5 @@
 import { StandardArticle } from "@artsy/reaction/dist/Components/Publishing/Fixtures/Articles"
+import { FullScreenProvider } from "@artsy/reaction/dist/Components/Publishing/Sections/FullscreenViewer/FullScreenProvider"
 import { SectionType } from "@artsy/reaction/dist/Components/Publishing/Typings"
 import { mount } from "enzyme"
 import { clone } from "lodash"
@@ -33,7 +34,9 @@ describe("SectionList", () => {
 
     return mount(
       <Provider store={store}>
-        <SectionList {...passedProps} />
+        <FullScreenProvider>
+          <SectionList {...passedProps} />
+        </FullScreenProvider>
       </Provider>
     )
   }

--- a/src/client/apps/edit/components/content/sections/images/components/test/image_set.test.tsx
+++ b/src/client/apps/edit/components/content/sections/images/components/test/image_set.test.tsx
@@ -1,4 +1,5 @@
 import { ImageSetFull } from "@artsy/reaction/dist/Components/Publishing/Fixtures/Components"
+import { FullScreenProvider } from "@artsy/reaction/dist/Components/Publishing/Sections/FullscreenViewer/FullScreenProvider"
 import { ImageSetPreview } from "@artsy/reaction/dist/Components/Publishing/Sections/ImageSetPreview"
 import { ImageSetPreviewClassic } from "@artsy/reaction/dist/Components/Publishing/Sections/ImageSetPreview/ImageSetPreviewClassic"
 import { mount } from "enzyme"
@@ -12,7 +13,11 @@ describe("ImageSet", () => {
   }
 
   const getWrapper = (passedProps = props) => {
-    return mount(<ImageSet {...passedProps} />)
+    return mount(
+      <FullScreenProvider>
+        <ImageSet {...passedProps} />
+      </FullScreenProvider>
+    )
   }
 
   it("renders an image set for standard/feature articles", () => {

--- a/src/client/apps/edit/components/content/test/index.test.tsx
+++ b/src/client/apps/edit/components/content/test/index.test.tsx
@@ -2,6 +2,7 @@ import {
   StandardArticle,
   VideoArticle,
 } from "@artsy/reaction/dist/Components/Publishing/Fixtures/Articles"
+import { FullScreenProvider } from "@artsy/reaction/dist/Components/Publishing/Sections/FullscreenViewer/FullScreenProvider"
 import { mount } from "enzyme"
 import { cloneDeep } from "lodash"
 import React from "react"
@@ -28,7 +29,9 @@ describe("EditContent", () => {
     })
     return mount(
       <Provider store={store}>
-        <EditContent {...passedProps} />
+        <FullScreenProvider>
+          <EditContent {...passedProps} />
+        </FullScreenProvider>
       </Provider>
     )
   }


### PR DESCRIPTION
- Adds extension flag for `nyc` to read coffee mocha tests
- Condenses mocha rules to search entire `/src` directory
- Moves coverage settings for jest to `package.json` jest rules
- Adds `FullScreenProvider` to tests where it was causing a large error when missing