### PR TITLE
add VPN and Google DNS resolvers to development.yml

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -15,6 +15,9 @@ services:
     depends_on:
       - positron-mongodb
       - positron-elasticsearch
+    dns:
+      - 10.0.0.2
+      - 8.8.8.8
   positron-elasticsearch:
     image: artsy/elasticsearch:2.1
     ports:


### PR DESCRIPTION
Adding the VPC DNS server `10.0.0.2` as well as a fallback to Google's DNS servers `8.8.8.8` allows Positron development docker container to use VPN connections, if enabled.