### PR TITLE
Swap ua-parser for useragent lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,11 +136,11 @@
     "ts-loader": "4.1.0",
     "typescript": "3.0.1",
     "typescript-styled-plugin": "0.1.2",
-    "ua-parser": "0.3.5",
     "uglifyify": "3.0.4",
     "underscore": "1.8.3",
     "underscore.string": "3.3.4",
     "updeep": "1.0.0",
+    "useragent": "^2.3.0",
     "valid-url": "1.0.9",
     "xss": "0.2.18",
     "yoastseo": "artsy/YoastSEO.js#develop"

--- a/src/client/lib/middleware.coffee
+++ b/src/client/lib/middleware.coffee
@@ -4,9 +4,9 @@
 #
 
 viewHelpers = require './view_helpers'
-uaParser = require 'ua-parser'
 crypto = require 'crypto'
 Channel = require '../models/channel'
+useragent = require 'useragent'
 
 @helpers = (req, res, next) ->
   res.backboneError = (model, err) -> next err
@@ -21,15 +21,15 @@ Channel = require '../models/channel'
   next()
 
 @ua = (req, res, next) ->
-  r = uaParser.parse(req.get('user-agent'))
+  r = useragent.parse(req.get('user-agent'))
   res.locals.sd.USER_AGENT = req.get('user-agent')
   res.locals.sd.IS_MOBILE = true if r.os.family in ['iOS', 'Android']
-  allowed = switch r.ua.family
-    when 'Chrome' then r.ua.major >= 38
-    when 'Firefox' then r.ua.major >= 34
-    when 'Safari' then r.ua.major >= 7
-    when 'Mobile Safari' then r.ua.major >= 5
-    when 'IE' then r.ua.major >= 10
+  allowed = switch r.family
+    when 'Chrome' then r.major >= 38
+    when 'Firefox' then r.major >= 34
+    when 'Safari' then r.major >= 7
+    when 'Mobile Safari' then r.major >= 5
+    when 'IE' then r.major >= 10
     when 'Android' then true
     when 'Android 2' then true
     else false

--- a/yarn.lock
+++ b/yarn.lock
@@ -8799,6 +8799,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   dependencies:
     js-tokens "^3.0.0"
 
+lru-cache@4.1.x:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
@@ -10015,7 +10023,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -13654,6 +13662,13 @@ tiny-invariant@^1.0.0:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.0.tgz#03f96fef4d3ba911f97ed467e1b88bca3d4d9d9f"
   integrity sha512-bCLTQ14OaNO7tSXKy3mXMd/odOvisOAhF/TFzhbH4SdtHPMSS64KvBhWawAHwYTy7dtEKbXo9QGw8LBO/suOIw==
 
+tmp@0.0.x:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -13938,13 +13953,6 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
   integrity sha1-BMgamb3V3FImPqKdJMa/jUgYpLs=
-
-ua-parser@0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/ua-parser/-/ua-parser-0.3.5.tgz#2ff4f9c9e6e2d64d711461f17beb2c9c697f2f1a"
-  integrity sha1-L/T5yebi1k1xFGHxe+ssnGl/Lxo=
-  dependencies:
-    yamlparser ">=0.0.2"
 
 uglify-es@^3.3.4:
   version "3.3.9"
@@ -14239,6 +14247,14 @@ user-home@^2.0.0:
   integrity sha1-nHC/2Babwdy/SGBODwS4tJzenp8=
   dependencies:
     os-homedir "^1.0.0"
+
+useragent@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
+  integrity sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==
+  dependencies:
+    lru-cache "4.1.x"
+    tmp "0.0.x"
 
 util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -14836,11 +14852,6 @@ yaml@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-0.2.3.tgz#b5450e92e76ef36b5dd24e3660091ebaeef3e5c7"
   integrity sha1-tUUOkudu82td0k42YAkeuu7z5cc=
-
-yamlparser@>=0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/yamlparser/-/yamlparser-0.0.2.tgz#32393e6afc70c8ca066b6650ac6738b481678ebc"
-  integrity sha1-Mjk+avxwyMoGa2ZQrGc4tIFnjrw=
 
 yargs-parser@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Swaps out `ua-parser`, which has a high severity security warning, for the recommended replacement `useragent`.