### PR TITLE
Swap bucket-assets for @artsy/bucket-assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "styled-components": "4.1.3"
   },
   "dependencies": {
+    "@artsy/bucket-assets": "^1.0.3",
     "@artsy/express-reloadable": "1.4.6",
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "4.14.4",
@@ -69,7 +70,6 @@
     "bluebird": "3.5.0",
     "bluebird-q": "1.0.3",
     "body-parser": "1.17.1",
-    "bucket-assets": "1.0.2",
     "cheerio": "0.19.0",
     "coffeescript": "1.11.1",
     "compression": "1.7.2",

--- a/scripts/publish-assets.sh
+++ b/scripts/publish-assets.sh
@@ -10,4 +10,4 @@ fi
 
 export COMMIT_HASH=`cat COMMIT_HASH.txt`
 
-yarn assets && yarn bucket-assets -b $S3_BUCKET
+yarn assets && ./node_modules/.bin/bucket-assets -b $S3_BUCKET

--- a/scripts/publish-assets.sh
+++ b/scripts/publish-assets.sh
@@ -10,4 +10,4 @@ fi
 
 export COMMIT_HASH=`cat COMMIT_HASH.txt`
 
-yarn assets && ./node_modules/.bin/bucket-assets -b $S3_BUCKET
+yarn assets && yarn bucket-assets -b $S3_BUCKET

--- a/src/client/lib/setup/index.coffee
+++ b/src/client/lib/setup/index.coffee
@@ -7,7 +7,7 @@
 # Dependencies
 require './sharify'
 sharify = require 'sharify'
-bucketAssets = require 'bucket-assets'
+bucketAssets = require '@artsy/bucket-assets'
 express = require 'express'
 bodyParser = require 'body-parser'
 cookieParser = require 'cookie-parser'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,19 @@
 # yarn lockfile v1
 
 
+"@artsy/bucket-assets@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@artsy/bucket-assets/-/bucket-assets-1.0.3.tgz#0b3139b736b19845fffb741d86926483a900f653"
+  integrity sha512-fH2waIkV/v/ypMHt+lZTnRFG8tV8DRO5wSkmQhSYqiQgqCqdzfCFia0hCU7x9b2o90eez4hgfPtIuS3jlmqDjg==
+  dependencies:
+    async "^0.9.0"
+    commander "^2.8.1"
+    glob "^5.0.5"
+    knox-s3 "^0.9.5"
+    mime "^1.3.4"
+    superagent "^1.2.0"
+    underscore "^1.8.3"
+
 "@artsy/detect-responsive-traits@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.0.4.tgz#933c66db24e70186c20e83017af39794a920ef0e"
@@ -2753,19 +2766,6 @@ buble@^0.19.3:
     os-homedir "^1.0.1"
     regexpu-core "^4.2.0"
     vlq "^1.0.0"
-
-bucket-assets@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bucket-assets/-/bucket-assets-1.0.2.tgz#e927b5594ff1ae3e40f2ad652aa38d49bb0c5239"
-  integrity sha1-6Se1WU/xrj5A8q1lKqONSbsMUjk=
-  dependencies:
-    async "^0.9.0"
-    commander "^2.8.1"
-    glob "^5.0.5"
-    knox "^0.9.2"
-    mime "^1.3.4"
-    superagent "^1.2.0"
-    underscore "^1.8.3"
 
 buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
@@ -8228,7 +8228,18 @@ kleur@^2.0.1:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"
   integrity sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==
 
-knox@0.9.2, knox@^0.9.2:
+knox-s3@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/knox-s3/-/knox-s3-0.9.5.tgz#48fe99953ccb57697d184f631bc8efe8f1dcb575"
+  integrity sha512-icjGO5ByRRmxpRa9U1CimHsBX3W/NW/jpE0XMqmZTxZ5eOc0haWRbtPJImZltcSGm6bOZ14IlDR9UoFFE/sK2g==
+  dependencies:
+    debug "^2.2.0"
+    mime "^1.4.0"
+    once "^1.3.0"
+    stream-counter "^1.0.0"
+    xml2js "^0.4.4"
+
+knox@0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/knox/-/knox-0.9.2.tgz#3736593669e24f024fdaf723b6a1dc4afd839a71"
   integrity sha1-NzZZNmniTwJP2vcjtqHcSv2DmnE=
@@ -9080,6 +9091,11 @@ mime@^1.2.11, mime@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
+
+mime@^1.4.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
Updates to @artsy-namespaced `bucket-assets` lib, which has been updated (caused deprecation conflicts when updating `superagent` due to `knox` and `mime` versions).