### PR TITLE
#migration update Kubernetes config to use named ports

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -33,9 +33,12 @@ spec:
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/positron:production
           imagePullPolicy: Always
           ports:
-            - containerPort: 3005
-            - containerPort: 8080
-            - containerPort: 8443
+            - name: positron-http
+              containerPort: 3005
+            - name: nginx-http
+              containerPort: 8080
+            - name: nginx-https
+              containerPort: 8443
           resources:
             requests:
               cpu: 500m
@@ -44,7 +47,7 @@ spec:
               memory: 1Gi
           readinessProbe:
             httpGet:
-              port: 3005
+              port: positron-http
               path: /api/health
               httpHeaders:
                 - name: X-FORWARDED-PROTO
@@ -113,11 +116,11 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 8443
+      targetPort: nginx-https
   selector:
     app: positron
     layer: application

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -33,9 +33,12 @@ spec:
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/positron:staging
           imagePullPolicy: Always
           ports:
-            - containerPort: 3005
-            - containerPort: 8080
-            - containerPort: 8443
+            - name: positron-http
+              containerPort: 3005
+            - name: nginx-http
+              containerPort: 8080
+            - name: nginx-https
+              containerPort: 8443
           resources:
             requests:
               cpu: 500m
@@ -44,7 +47,7 @@ spec:
               memory: 1Gi
           readinessProbe:
             httpGet:
-              port: 3005
+              port: positron-http
               path: /api/health
               httpHeaders:
                 - name: X-FORWARDED-PROTO
@@ -113,11 +116,11 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 8443
+      targetPort: nginx-https
   selector:
     app: positron
     layer: application


### PR DESCRIPTION
Using named ports allows us to make port changes to services gracefully.  Named ports allow service selectors to reference those ports by name, and orchestrate smooth rollouts if the port numbers change.  From https://kubernetes.io/docs/concepts/services-networking/service/ ...

> Port definitions in Pods have names, and you can reference these names in the targetPort attribute of a Service. This will work even if there are a mixture of Pods in the Service, with the same network protocol available via different port numbers but a single configured name. This offers a lot of flexibility for deploying and evolving your Services. For example, you can change the port number that pods expose in the next version of your backend software, without breaking clients.

After this is merged we can roll out changes to Nginx / Positron's listening ports by referencing the ports `positron-http` / `nginx-http` / `nginx-https` and the Service will use the port number the Container exposes, no matter where it is mapped.  And we get graceful migrations!

## Migration

```
hokusai staging update
hokusai production update
```
