### PR TITLE
@eessex => [Elasticsearch] Bump ES image to latest, in prep for v5 upgrade #no-op

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,5 +1,4 @@
----
-version: '2'
+version: "2"
 services:
   positron:
     command: ["yarn", "dev"]
@@ -16,7 +15,12 @@ services:
       - positron-mongodb
       - positron-elasticsearch
   positron-elasticsearch:
-    image: artsy/elasticsearch:2.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ports:
       - "9200:9200"
   positron-mongodb:

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -13,7 +13,12 @@ services:
       - positron-mongodb
       - positron-elasticsearch
   positron-elasticsearch:
-    image: artsy/elasticsearch:2.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ports:
       - "9200:9200"
   positron-mongodb:


### PR DESCRIPTION
cc @izakp 

Turns out Positron actually had some integration specs that were spinning up ES, indexing articles, and searching for them!

This is great b/c it gives us even more confidence that everything should work fine with a new ES.

I think this is safe to merge anytime/prior to the upgrade.