### PR TITLE
Remove deprecated borderRadius prop

### DIFF
--- a/src/client/apps/edit/components/content/sections/images/components/input_artwork_url.tsx
+++ b/src/client/apps/edit/components/content/sections/images/components/input_artwork_url.tsx
@@ -67,7 +67,6 @@ export class InputArtworkUrl extends Component<
         <Button
           variant="secondaryGray"
           loading={isLoading}
-          borderRadius={0}
           onClick={() => this.getIdFromSlug(url)}
         >
           Add


### PR DESCRIPTION
Not sure why this wasn't caught by type-check, but the most recent version of Palette caused a breaking change due to deprecated `borderRadius` prop on `Button`: https://circleci.com/gh/artsy/positron/4104 