### PR TITLE
@eessex => [XAPP] Make sure to re-require tokens when needed

### DIFF
--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -12,7 +12,7 @@ request = require 'superagent'
 Article = require './index'
 { distributeArticle, deleteArticleFromSailthru, getArticleUrl, indexForSearch } = require './distribute'
 { ARTSY_URL, GEMINI_CLOUDFRONT_URL } = process.env
-artsyXapp = require('artsy-xapp').token or ''
+artsyXapp = require('artsy-xapp')
 
 @onPublish = (article, cb) =>
   unless article.published_at or article.scheduled_publish_at
@@ -102,13 +102,14 @@ removeStopWords = (title) ->
     return cb null, article
   keywords = []
   callbacks = []
+  token = artsyXapp.token or ''
   if input.primary_featured_artist_ids
     for artistId in input.primary_featured_artist_ids
       do (artistId) ->
         callbacks.push (callback) ->
           request
             .get("#{ARTSY_URL}/api/v1/artist/#{artistId}")
-            .set('X-Xapp-Token': artsyXapp)
+            .set('X-Xapp-Token': token)
             .end callback
   if input.featured_artist_ids
     for artistId in input.featured_artist_ids
@@ -116,7 +117,7 @@ removeStopWords = (title) ->
         callbacks.push (callback) ->
           request
             .get("#{ARTSY_URL}/api/v1/artist/#{artistId}")
-            .set('X-Xapp-Token': artsyXapp)
+            .set('X-Xapp-Token': token)
             .end callback
   if input.fair_ids
     for fairId in input.fair_ids
@@ -124,7 +125,7 @@ removeStopWords = (title) ->
         callbacks.push (callback) ->
           request
             .get("#{ARTSY_URL}/api/v1/fair/#{fairId}")
-            .set('X-Xapp-Token': artsyXapp)
+            .set('X-Xapp-Token': token)
             .end callback
   if input.partner_ids
     for partnerId in input.partner_ids
@@ -132,7 +133,7 @@ removeStopWords = (title) ->
         callbacks.push (callback) ->
           request
             .get("#{ARTSY_URL}/api/v1/partner/#{partnerId}")
-            .set('X-Xapp-Token': artsyXapp)
+            .set('X-Xapp-Token': token)
             .end callback
   async.parallel callbacks, (err, results) =>
     return cb(err) if err

--- a/src/api/apps/articles/test/model/save.test.coffee
+++ b/src/api/apps/articles/test/model/save.test.coffee
@@ -28,7 +28,6 @@ describe 'Save', ->
 
   beforeEach (done) ->
     @removeStopWords = Save.__get__ 'removeStopWords'
-    Save.__set__ 'artsyXapp', { token: 'foo' }
     Save.__set__ 'request', post: (@post = sinon.stub()).returns
       send: (@send = sinon.stub()).returns
         end: sinon.stub().yields()

--- a/src/client/models/channel.coffee
+++ b/src/client/models/channel.coffee
@@ -3,7 +3,7 @@ Backbone = require 'backbone'
 sd = require('sharify').data
 async = require 'async'
 request = require 'superagent'
-artsyXapp = require('artsy-xapp').token or ''
+artsyXapp = require('artsy-xapp')
 
 module.exports = class Channel extends Backbone.Model
 
@@ -102,7 +102,7 @@ module.exports = class Channel extends Backbone.Model
     async.parallel [
       (cb) =>
         request.get("#{sd.API_URL}/channels/#{@get('id')}")
-          .set('X-Xapp-Token': artsyXapp)
+          .set('X-Xapp-Token': artsyXapp.token)
           .end (err, res) ->
             if err
               cb null, {}
@@ -110,7 +110,7 @@ module.exports = class Channel extends Backbone.Model
               cb null, res
       (cb) =>
         request.get("#{sd.ARTSY_URL}/api/v1/partner/#{@get('id')}")
-          .set('X-Xapp-Token': artsyXapp)
+          .set('X-Xapp-Token': artsyXapp.token)
           .end (err, res) ->
             if err
               cb null, {}


### PR DESCRIPTION
This was a tricky one!

Turns out, we were only ever reading this value once, and then using it. Switching to re-require the xapp token object lets the relevant code have access to the updated value.

To repro-
  - run positron locally vs local gravity, with 1 minute client app expiry
  - hit 'save' on an article that has an artist id attached (triggers a gravity request with xapp token)
  - hit 'save' on that article a minute later (and note 2xx vs 401, updated token vs not).

Now that I looked at this again, I think it's quite likely that Force suffers from the same problem. Will investigate.