### PR TITLE
Adds missing fields to RelatedArticles

### DIFF
--- a/src/client/queries/related_articles.js
+++ b/src/client/queries/related_articles.js
@@ -13,11 +13,13 @@ export function RelatedArticleQuery(ids) {
         }
         description
         id
+        layout
         media {
           duration
           published
           release_date
         }
+        published_at
         thumbnail_title
         thumbnail_image
         title


### PR DESCRIPTION
- Related articles were missing the `layout` and the `published_at` fields which were required for Reaction's `ArticleCard` component