### PR TITLE
Remove push-production-image step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,10 +54,5 @@ workflows:
             - push-staging-image
 
       # Release
-      - hokusai/push:
-          name: push-production-image
-          <<: *only_release
       - hokusai/deploy-production:
           <<: *only_release
-          requires:
-            - push-production-image


### PR DESCRIPTION
Removes redundant push-production-image step from CI workflow. Related to https://artsyproduct.atlassian.net/browse/PLATFORM-1596