### PR TITLE
Fix tests affected by palette button changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@artsy/bucket-assets": "1.0.3",
     "@artsy/express-reloadable": "1.4.6",
     "@artsy/gemup": "0.0.3",
-    "@artsy/palette": "4.14.27",
+    "@artsy/palette": "4.14.30",
     "@artsy/reaction": "16.18.23",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.0.0",

--- a/src/client/apps/articles_list/components/test/articles_list_empty.test.tsx
+++ b/src/client/apps/articles_list/components/test/articles_list_empty.test.tsx
@@ -15,7 +15,7 @@ describe("ArticlesListEmpty", () => {
 
   it("renders expected content", () => {
     const component = mount(<ArticlesListEmpty {...props} />)
-    expect(component.text()).toBe(
+    expect(component.text()).toMatch(
       "You haven’t written any articles yet.Artsy Writer is a tool for writing stories about art on Artsy.Get started by writing an article or reaching out to your liaison for help.Write An Article"
     )
   })

--- a/src/client/apps/edit/components/admin/components/article/test/index.test.tsx
+++ b/src/client/apps/edit/components/admin/components/article/test/index.test.tsx
@@ -84,13 +84,13 @@ describe("AdminArticle", () => {
           .find(Button)
           .at(0)
           .text()
-      ).toBe("Tier 1")
+      ).toMatch("Tier 1")
       expect(
         component
           .find("button")
           .at(1)
           .text()
-      ).toBe("Tier 2")
+      ).toMatch("Tier 2")
     })
 
     it("if news layout, does not render tier buttons", () => {
@@ -110,13 +110,13 @@ describe("AdminArticle", () => {
           .find("button")
           .at(2)
           .text()
-      ).toBe("Yes")
+      ).toMatch("Yes")
       expect(
         component
           .find("button")
           .at(3)
           .text()
-      ).toBe("No")
+      ).toMatch("No")
     })
 
     it("if news layout, does not render featured/magazine buttons", () => {
@@ -136,13 +136,13 @@ describe("AdminArticle", () => {
           .find("button")
           .at(4)
           .text()
-      ).toBe("Standard")
+      ).toMatch("Standard")
       expect(
         component
           .find("button")
           .at(5)
           .text()
-      ).toBe("Feature")
+      ).toMatch("Feature")
     })
 
     it("if news layout, does not render layout buttons", () => {

--- a/src/client/apps/edit/components/admin/components/test/verticals_tags.test.tsx
+++ b/src/client/apps/edit/components/admin/components/test/verticals_tags.test.tsx
@@ -142,7 +142,7 @@ describe("AdminVerticalsTags", () => {
       const component = getWrapper()
       component
         .find(IconRemove)
-        .at(1)
+        .at(2)
         .simulate("click")
 
       expect(props.onChangeArticleAction.mock.calls[0][0]).toBe("tracking_tags")

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/gemup/-/gemup-0.0.3.tgz#0397a472bb69432dab3d2d66ca30556815aa96e7"
   integrity sha512-W///stXDTz3jSQw8UtT0BClVk4DLOsVp7a8v12efsEZvrZNT+85YBqPWq2DP1EX3ILZR1hGZhbKr/Gl5uti56Q==
 
-"@artsy/palette@4.14.27":
-  version "4.14.27"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.14.27.tgz#f8ab35e08c0f8a7063aa3d178403dcb789cc402b"
-  integrity sha512-guTfBf7rQuhWkJ07MSh7XkuG6K3dc2oU7J7ns2bS9I3tmcbrhllOXQ42ade5SRdMQe5zAXDoDKvomOnkLzhgqA==
+"@artsy/palette@4.14.30":
+  version "4.14.30"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.14.30.tgz#fab1b8e5b92d885f2ea813e6b2cc051431e07dc7"
+  integrity sha512-cYNo8N4O2Z7YtSJzrt63PtzEtkVjqw8Bi5KyHwvwrIaTU/RBH+NgRj+nfcba5XJ/q/8sJHtv7/WAnZDrGzgiZw==
   dependencies:
     babel-plugin-styled-components "^1.10.0"
     d3-interpolate "^1.3.2"


### PR DESCRIPTION
Now palette seems to print any button text twice, so we needed to change our text matching from `toBe` to `toMatch`