### PR TITLE
[HOLD] Update assets script

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "cheerio": "0.19.0",
     "coffeescript": "1.11.1",
     "compression": "1.7.2",
+    "connect-timeout": "^1.9.0",
     "cookie-parser": "1.4.3",
     "cookie-session": "1.2.0",
     "cors": "2.8.4",

--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -6,7 +6,7 @@ set -e -x
 
 yarn clean
 
-NODE_ENV=production node_modules/.bin/webpack
+NODE_ENV=production yarn webpack
 stylus \
   $(find src/client/assets -name '*.styl') \
   --compress \

--- a/src/lib/assetMiddleware.js
+++ b/src/lib/assetMiddleware.js
@@ -1,0 +1,37 @@
+import chalk from "chalk"
+import fs from "fs"
+import { isProduction } from "./environment"
+import path from "path"
+
+const { CDN_URL } = process.env
+
+export const assetMiddleware = () => {
+  if (isProduction) {
+    const manifestPath = path.resolve(process.cwd(), "manifest.json")
+
+    let manifest = {}
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, { encoding: "utf8" }))
+    } catch (error) {
+      console.error(chalk.red("\n[Positron] Error parsing manifest:"), error)
+    }
+
+    return (_req, res, next) => {
+      res.locals.asset = filename => {
+        let manifestFile = manifest[filename] || filename
+        if (CDN_URL) {
+          manifestFile = CDN_URL + manifestFile
+        }
+        return manifestFile
+      }
+      next()
+    }
+
+    // Development, return the file being requested and don't look for a manifest
+  } else {
+    return (_req, res, next) => {
+      res.locals.asset = filename => filename
+      next()
+    }
+  }
+}

--- a/webpack/environments/baseConfig.js
+++ b/webpack/environments/baseConfig.js
@@ -21,7 +21,7 @@ const baseConfig = {
   output: {
     filename: "[name].js",
     path: path.resolve(basePath, "public/assets"),
-    publicPath: "/assets",
+    publicPath: "/assets/",
     sourceMapFilename: "[file].map?[contenthash]",
   },
   module: {

--- a/webpack/environments/prodConfig.js
+++ b/webpack/environments/prodConfig.js
@@ -24,8 +24,6 @@ module.exports.prodConfig = {
   optimization: {
     minimizer: [
       new TerserPlugin({
-        cache: false,
-        parallel: false,
         sourceMap: true, // Must be set to true if using source-maps in production
       }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3687,6 +3687,16 @@ concat-stream@~1.4.7:
     readable-stream "~1.1.9"
     typedarray "~0.0.5"
 
+connect-timeout@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/connect-timeout/-/connect-timeout-1.9.0.tgz#bc27326b122103714bebfa0d958bab33f6522e3a"
+  integrity sha1-vCcyaxIhA3FL6/oNlYurM/ZSLjo=
+  dependencies:
+    http-errors "~1.6.1"
+    ms "2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
+
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"


### PR DESCRIPTION
Uses the `yarn webpack` command in assets rather than pointing to node modules, which ensures we pass all expected options (including config) to webpack.