### PR TITLE
reverts series and series.test to before GROW-1444 accidental master …

### DIFF
--- a/src/client/apps/edit/components/content/article_layouts/series.tsx
+++ b/src/client/apps/edit/components/content/article_layouts/series.tsx
@@ -101,7 +101,6 @@ export class EditSeries extends Component<EditSeriesProps> {
             onUpload={src => this.onChangeHero(src)}
             prompt={`+ ${url ? "Change" : "Add"} Background`}
             onProgress={progress => this.setState({ uploadProgress: progress })}
-            video
           />
         </BackgroundInput>
 

--- a/src/client/apps/edit/components/content/article_layouts/test/series.test.tsx
+++ b/src/client/apps/edit/components/content/article_layouts/test/series.test.tsx
@@ -107,31 +107,13 @@ describe("EditSeries", () => {
     expect(props.onChangeArticleAction.mock.calls[0][1].type).toBe("series")
   })
 
-  describe("Image and Video Backgrounds", () => {
-    const videoUrl = "http://video.mp4"
-    const imageUrl = "http://image.jpg"
-
-    const render = url => {
-      props.article.hero_section = { url }
-      return getWrapper()
-    }
-
-    it("Passes a background URL to reaction if it contains an image", () => {
-      const component = render(imageUrl)
-      const bg = component.find(FixedBackground)
-      const url = bg.props().backgroundUrl
-      expect(bg.length).toBe(1)
-      expect(url).toBe("http://image.jpg")
-      expect(component.text()).toMatch("+ Change Background")
-    })
-
-    it("Passes a background URL to reaction if it contains a video", () => {
-      const component = render(videoUrl)
-      const bg = component.find(FixedBackground)
-      const url = bg.props().backgroundUrl
-      expect(bg.length).toBe(1)
-      expect(url).toBe(videoUrl)
-      expect(component.text()).toMatch("+ Change Background")
-    })
+  it("Renders a background image if url", () => {
+    props.article.hero_section = { url: "http://image.jpg" }
+    const component = getWrapper()
+    expect(component.find(FixedBackground).length).toBe(1)
+    expect(component.find(FixedBackground).props().backgroundUrl).toBe(
+      "http://image.jpg"
+    )
+    expect(component.text()).toMatch("+ Change Background")
   })
 })


### PR DESCRIPTION
Something weird happened with [this PR](https://github.com/artsy/positron/pull/2194) - I think I must have accidentally pushed those changes to upstream master somehow, prior to opening the PR? It doesn't fully make sense to me, but this PR resets the state of the two files I touched to the state they had immediately prior to my changes.

Going to link a correct PR to make the changes, shortly.

Diff Analysis: 
```
{
  "total_files_changed": 2,
  "test_files_changed": 1,
  "by_type": {
    "tsx": 2
  }
}
```