### PR TITLE
add support for uploading video files

### DIFF
--- a/src/client/apps/edit/components/content/article_layouts/series.tsx
+++ b/src/client/apps/edit/components/content/article_layouts/series.tsx
@@ -101,6 +101,7 @@ export class EditSeries extends Component<EditSeriesProps> {
             onUpload={src => this.onChangeHero(src)}
             prompt={`+ ${url ? "Change" : "Add"} Background`}
             onProgress={progress => this.setState({ uploadProgress: progress })}
+            video
           />
         </BackgroundInput>
 

--- a/src/client/apps/edit/components/content/article_layouts/test/series.test.tsx
+++ b/src/client/apps/edit/components/content/article_layouts/test/series.test.tsx
@@ -107,13 +107,31 @@ describe("EditSeries", () => {
     expect(props.onChangeArticleAction.mock.calls[0][1].type).toBe("series")
   })
 
-  it("Renders a background image if url", () => {
-    props.article.hero_section = { url: "http://image.jpg" }
-    const component = getWrapper()
-    expect(component.find(FixedBackground).length).toBe(1)
-    expect(component.find(FixedBackground).props().backgroundUrl).toBe(
-      "http://image.jpg"
-    )
-    expect(component.text()).toMatch("+ Change Background")
+  describe("Image and Video Backgrounds", () => {
+    const videoUrl = "http://video.mp4"
+    const imageUrl = "http://image.jpg"
+
+    const render = url => {
+      props.article.hero_section = { url }
+      return getWrapper()
+    }
+
+    it("Passes a background URL to reaction if it contains an image", () => {
+      const component = render(imageUrl)
+      const bg = component.find(FixedBackground)
+      const url = bg.props().backgroundUrl
+      expect(bg.length).toBe(1)
+      expect(url).toBe("http://image.jpg")
+      expect(component.text()).toMatch("+ Change Background")
+    })
+
+    it("Passes a background URL to reaction if it contains a video", () => {
+      const component = render(videoUrl)
+      const bg = component.find(FixedBackground)
+      const url = bg.props().backgroundUrl
+      expect(bg.length).toBe(1)
+      expect(url).toBe(videoUrl)
+      expect(component.text()).toMatch("+ Change Background")
+    })
   })
 })


### PR DESCRIPTION
This allows the user to upload an mp4 as a series background. This PR has been a bit weird, it got into a bad state - you can see a previous attempt [here](https://github.com/artsy/positron/pull/2198). I think I must have somehow pushed this to upstream master without having the PR merged, which made the PR a no-op. I reverted that PR, and am now re-submitting. @eessex knows what's up!

Diff Analysis: 
```
{
  "total_files_changed": 2,
  "test_files_changed": 1,
  "by_type": {
    "tsx": 2
  }
}
```