### PR TITLE
Related article can return their parent series

### DIFF
--- a/src/api/apps/graphql/index.js
+++ b/src/api/apps/graphql/index.js
@@ -53,17 +53,32 @@ const metaFields = {
         )
         .concat(
           object({
+            seriesArticle: object(Article.inputSchema).meta({
+              resolve: resolvers.seriesArticle,
+            }),
+          })
+        )
+        .concat(
+          object({
             relatedArticles: array()
               .items(
-                object(Article.inputSchema).concat(
-                  object({
-                    authors: array()
-                      .items(object(Author.schema))
-                      .meta({
-                        resolve: resolvers.relatedAuthors,
+                object(Article.inputSchema)
+                  .concat(
+                    object({
+                      authors: array()
+                        .items(object(Author.schema))
+                        .meta({
+                          resolve: resolvers.relatedAuthors,
+                        }),
+                    })
+                  )
+                  .concat(
+                    object({
+                      seriesArticle: object(Article.inputSchema).meta({
+                        resolve: resolvers.seriesArticle,
                       }),
-                  })
-                )
+                    })
+                  )
               )
               .meta({
                 resolve: resolvers.relatedArticles,

--- a/src/api/apps/graphql/resolvers.js
+++ b/src/api/apps/graphql/resolvers.js
@@ -271,7 +271,6 @@ export const seriesArticle = root => {
   return new Promise(async (resolve, reject) => {
     const seriesArticles = await promisedMongoFetch({
       layout: "series",
-      published: true,
     }).catch(e => reject(e))
 
     seriesArticles.results.map(article => {

--- a/src/api/apps/graphql/test/integration.spec.js
+++ b/src/api/apps/graphql/test/integration.spec.js
@@ -126,6 +126,50 @@ describe("graphql endpoint", () => {
     )
   })
 
+  it("can get seriesArticle in relatedArticles", done => {
+    fabricate(
+      "articles",
+      [
+        {
+          title: "Top Ten Booths",
+          published: true,
+          layout: "feature",
+          _id: ObjectId("5c9d3c1aa4ba105ad8336956"),
+          author_ids: [ObjectId("55356a9deca560a0137bb4ae")],
+          channel_id: ObjectId("5aa99c11da4c00d6bc33a816"),
+        },
+        {
+          published: true,
+          featured: true,
+          vertical: {
+            name: "Culture",
+            id: ObjectId("55356a9deca560a0137bb4a7"),
+          },
+          _id: ObjectId("5ae762608cd4110038b40049"),
+          layout: "series",
+          channel_id: ObjectId("5aa99c11da4c00d6bc33a816"),
+          author_ids: [ObjectId("55356a9deca560a0137bb4ae")],
+          related_article_ids: [ObjectId("5c9d3c1aa4ba105ad8336956")],
+        },
+      ],
+      (err, articles) => {
+        request
+          .post("http://localhost:5000/graphql")
+          .send({ query: RelatedArticlesQuery })
+          .end((err, res) => {
+            res.body.data.articles.length.should.equal(2)
+            res.body.data.articles[0].relatedArticles[0].title.should.equal(
+              "Top Ten Booths"
+            )
+            res.body.data.articles[0].relatedArticles[0].seriesArticle.id.should.equal(
+              "5ae762608cd4110038b40049"
+            )
+            done()
+          })
+      }
+    )
+  })
+
   it("can get authors in relatedArticlesCanvas", done => {
     fabricate(
       "authors",

--- a/src/api/apps/graphql/test/queries.js
+++ b/src/api/apps/graphql/test/queries.js
@@ -115,6 +115,12 @@ export const RelatedArticlesQuery = `
         authors {
           name
         }
+        seriesArticle {
+          id
+        }
+        relatedArticles {
+          title
+        }
       }
     }
   }

--- a/src/api/apps/graphql/test/resolvers.spec.js
+++ b/src/api/apps/graphql/test/resolvers.spec.js
@@ -197,7 +197,7 @@ describe("resolvers", () => {
       results.length.should.equal(1)
     })
 
-    it.only("preserves sort order of related articles", async () => {
+    it("preserves sort order of related articles", async () => {
       const root = {
         ...SeriesArticle,
       }


### PR DESCRIPTION
Updates `relatedArticles` resolver to allow returning the `seriesArticle` that is its parent. Related to routing for Vanguard project.