### PR TITLE
Fix admin button active state

### DIFF
--- a/src/client/apps/edit/components/admin/components/article/index.tsx
+++ b/src/client/apps/edit/components/admin/components/article/index.tsx
@@ -125,7 +125,7 @@ export class AdminArticle extends Component<
                         <Button
                           onClick={() => onChangeArticleAction("tier", 1)}
                           variant={
-                            article.tier === 1 ? "primaryBlack" : "noOutline"
+                            article.tier !== 2 ? "primaryBlack" : "noOutline"
                           }
                         >
                           Tier 1

--- a/src/client/apps/edit/components/admin/components/article/index.tsx
+++ b/src/client/apps/edit/components/admin/components/article/index.tsx
@@ -123,16 +123,18 @@ export class AdminArticle extends Component<
                       <FormLabel>Article Tier</FormLabel>
                       <ButtonGroup>
                         <Button
-                          color={article.tier === 1 ? "black100" : "black10"}
                           onClick={() => onChangeArticleAction("tier", 1)}
-                          variant="noOutline"
+                          variant={
+                            article.tier === 1 ? "primaryBlack" : "noOutline"
+                          }
                         >
                           Tier 1
                         </Button>
                         <Button
-                          color={article.tier === 2 ? "black100" : "black10"}
                           onClick={() => onChangeArticleAction("tier", 2)}
-                          variant="noOutline"
+                          variant={
+                            article.tier === 2 ? "primaryBlack" : "noOutline"
+                          }
                         >
                           Tier 2
                         </Button>
@@ -143,20 +145,22 @@ export class AdminArticle extends Component<
                       <FormLabel>Magazine Feed</FormLabel>
                       <ButtonGroup>
                         <Button
-                          color={article.featured ? "black100" : "black10"}
                           onClick={() =>
                             onChangeArticleAction("featured", true)
                           }
-                          variant="noOutline"
+                          variant={
+                            article.featured ? "primaryBlack" : "noOutline"
+                          }
                         >
                           Yes
                         </Button>
                         <Button
-                          color={!article.featured ? "black100" : "black10"}
                           onClick={() =>
                             onChangeArticleAction("featured", false)
                           }
-                          variant="noOutline"
+                          variant={
+                            !article.featured ? "primaryBlack" : "noOutline"
+                          }
                         >
                           No
                         </Button>
@@ -173,27 +177,25 @@ export class AdminArticle extends Component<
                         <FormLabel>Article Layout</FormLabel>
                         <ButtonGroup>
                           <Button
-                            variant="noOutline"
                             onClick={() =>
                               onChangeArticleAction("layout", "standard")
                             }
-                            color={
+                            variant={
                               article.layout === "standard"
-                                ? "black100"
-                                : "black10"
+                                ? "primaryBlack"
+                                : "noOutline"
                             }
                           >
                             Standard
                           </Button>
                           <Button
-                            variant="noOutline"
-                            color={
-                              article.layout === "feature"
-                                ? "black100"
-                                : "black10"
-                            }
                             onClick={() =>
                               onChangeArticleAction("layout", "feature")
+                            }
+                            variant={
+                              article.layout === "feature"
+                                ? "primaryBlack"
+                                : "noOutline"
                             }
                           >
                             Feature

--- a/src/client/apps/edit/components/admin/components/article/test/index.test.tsx
+++ b/src/client/apps/edit/components/admin/components/article/test/index.test.tsx
@@ -75,92 +75,160 @@ describe("AdminArticle", () => {
       expect(component.find(ArticleAuthors).exists()).toBe(true)
     })
 
-    it("Renders tier buttons", () => {
-      const component = getWrapper()
+    describe("Tier buttons", () => {
+      it("Renders tier buttons", () => {
+        const component = getWrapper()
 
-      expect(component.html()).toMatch("Article Tier")
-      expect(
-        component
-          .find(Button)
-          .at(0)
-          .text()
-      ).toMatch("Tier 1")
-      expect(
-        component
-          .find("button")
-          .at(1)
-          .text()
-      ).toMatch("Tier 2")
+        expect(component.html()).toMatch("Article Tier")
+        expect(
+          component
+            .find(Button)
+            .at(0)
+            .text()
+        ).toMatch("Tier 1")
+        expect(
+          component
+            .find("button")
+            .at(1)
+            .text()
+        ).toMatch("Tier 2")
+      })
+
+      it("shows active state for tier buttons", () => {
+        const component = getWrapper()
+        expect(
+          component
+            .find(Button)
+            .at(0)
+            .props().variant
+        ).toBe("primaryBlack")
+        expect(
+          component
+            .find(Button)
+            .at(1)
+            .props().variant
+        ).toBe("noOutline")
+      })
+
+      it("if news layout, does not render tier buttons", () => {
+        props.article.layout = "news"
+        const component = getWrapper(props)
+
+        expect(component.html()).not.toMatch("Article Tier")
+        expect(component.find("button").length).toBe(1)
+      })
     })
 
-    it("if news layout, does not render tier buttons", () => {
-      props.article.layout = "news"
-      const component = getWrapper(props)
+    describe("featured/magazine buttons", () => {
+      it("Renders featured/magazine buttons if editorial", () => {
+        const component = getWrapper()
 
-      expect(component.html()).not.toMatch("Article Tier")
-      expect(component.find("button").length).toBe(1)
+        expect(component.html()).toMatch("Magazine Feed")
+        expect(
+          component
+            .find("button")
+            .at(2)
+            .text()
+        ).toMatch("Yes")
+        expect(
+          component
+            .find("button")
+            .at(3)
+            .text()
+        ).toMatch("No")
+      })
+
+      it("shows active state for featured/magazine buttons", () => {
+        const component = getWrapper()
+        expect(
+          component
+            .find(Button)
+            .at(2)
+            .props().variant
+        ).toBe("noOutline")
+        expect(
+          component
+            .find(Button)
+            .at(3)
+            .props().variant
+        ).toBe("primaryBlack")
+
+        expect(
+          component
+            .find(Button)
+            .at(2)
+            .props().variant
+        ).not.toBe(
+          component
+            .find(Button)
+            .at(3)
+            .props().variant
+        )
+      })
+
+      it("if news layout, does not render featured/magazine buttons", () => {
+        props.article.layout = "news"
+        const component = getWrapper(props)
+
+        expect(component.html()).not.toMatch("Magazine Feed")
+        expect(component.find("button").length).toBe(1)
+      })
     })
 
-    it("Renders featured/magazine buttons if editorial", () => {
-      const component = getWrapper()
+    describe("layout buttons", () => {
+      it("Renders layout buttons if editorial", () => {
+        const component = getWrapper()
 
-      expect(component.html()).toMatch("Magazine Feed")
-      expect(
-        component
-          .find("button")
-          .at(2)
-          .text()
-      ).toMatch("Yes")
-      expect(
-        component
-          .find("button")
-          .at(3)
-          .text()
-      ).toMatch("No")
-    })
+        expect(component.html()).toMatch("Article Layout")
+        expect(
+          component
+            .find("button")
+            .at(4)
+            .text()
+        ).toMatch("Standard")
+        expect(
+          component
+            .find("button")
+            .at(5)
+            .text()
+        ).toMatch("Feature")
+      })
 
-    it("if news layout, does not render featured/magazine buttons", () => {
-      props.article.layout = "news"
-      const component = getWrapper(props)
+      it("shows active state for layout buttons", () => {
+        const component = getWrapper()
 
-      expect(component.html()).not.toMatch("Magazine Feed")
-      expect(component.find("button").length).toBe(1)
-    })
+        expect(component.html()).toMatch("Article Layout")
+        expect(
+          component
+            .find(Button)
+            .at(4)
+            .props().variant
+        ).toMatch("primaryBlack")
+        expect(
+          component
+            .find(Button)
+            .at(5)
+            .props().variant
+        ).toMatch("noOutline")
+      })
 
-    it("Renders layout buttons if editorial", () => {
-      const component = getWrapper()
+      it("if news layout, does not render layout buttons", () => {
+        props.article.layout = "news"
+        const component = getWrapper(props)
 
-      expect(component.html()).toMatch("Article Layout")
-      expect(
-        component
-          .find("button")
-          .at(4)
-          .text()
-      ).toMatch("Standard")
-      expect(
-        component
-          .find("button")
-          .at(5)
-          .text()
-      ).toMatch("Feature")
-    })
+        expect(component.html()).not.toMatch("Article Layout")
+        expect(component.html()).not.toMatch("Standard")
+        expect(component.html()).not.toMatch("Feature")
+      })
 
-    it("if news layout, does not render layout buttons", () => {
-      props.article.layout = "news"
-      const component = getWrapper(props)
+      it("If not editorial, does not render layout buttons", () => {
+        props.isEditorial = false
+        const component = getWrapper(props)
 
-      expect(component.html()).not.toMatch("Article Layout")
-      expect(component.html()).not.toMatch("Standard")
-      expect(component.html()).not.toMatch("Feature")
-    })
-
-    it("If not editorial, does not render layout buttons", () => {
-      props.isEditorial = false
-      const component = getWrapper(props)
-
-      expect(component.html()).not.toMatch("Article Layout")
-      expect(component.html()).not.toMatch("Standard")
-      expect(component.html()).not.toMatch("Feature")
+        expect(component.html()).not.toMatch("Article Layout")
+        expect(component.html()).not.toMatch("Standard")
+        expect(component.html()).not.toMatch("Feature")
+      })
     })
 
     it("Renders indexable checkbox for editorial", () => {


### PR DESCRIPTION
Noticed while working on Vanguard, changes in palette's `Button` caused the active-state color to stop working. Switched to variant so these buttons are functional again.

**AFTER:**
<img width="544" alt="Screen Shot 2019-09-24 at 4 19 47 PM" src="https://user-images.githubusercontent.com/1497424/65548588-ba8c1680-dee9-11e9-9dc9-6fe5122fa493.png">

**BEFORE:**
<img width="511" alt="Screen Shot 2019-09-24 at 4 20 08 PM" src="https://user-images.githubusercontent.com/1497424/65548604-c1b32480-dee9-11e9-9757-f35fe6866d8d.png">
