### PR TITLE
Increase memory for assets compilation

### DIFF
--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -6,7 +6,7 @@ set -e -x
 
 yarn clean
 
-NODE_ENV=production node_modules/.bin/webpack --config ./webpack
+NODE_ENV=production node --max_old_space_size=4096 node_modules/.bin/webpack --config ./webpack
 stylus \
   $(find src/client/assets -name '*.styl') \
   --compress \


### PR DESCRIPTION
`yarn assets` fails due to OOM error: https://circleci.com/gh/artsy/positron/5121

Related conversation: https://artsy.slack.com/archives/CC56D129X/p1569874284001200