### PR TITLE
Fix series sub-article edit positioning

### DIFF
--- a/src/client/apps/edit/components/content/sections/related_articles/components/edit_article_card.tsx
+++ b/src/client/apps/edit/components/content/sections/related_articles/components/edit_article_card.tsx
@@ -17,7 +17,7 @@ export class EditArticleCard extends Component<EditArticleCardProps> {
     const { article, color, series, onRemoveArticle } = this.props
 
     return (
-      <Box pb={6}>
+      <Box pb={6} position="relative">
         <Sans size="3" weight="medium">
           <EditLink
             className="EditArticleCard__edit"


### PR DESCRIPTION
Minor but noticed while doing QA on staging, buttons to edit and remove articles from a series were incorrectly positioned.

Before:
<img width="927" alt="Screen Shot 2020-01-06 at 4 07 15 PM" src="https://user-images.githubusercontent.com/1497424/71848915-c7023c80-309e-11ea-848b-0b69723982fd.png">

After:
<img width="929" alt="Screen Shot 2020-01-06 at 4 04 26 PM" src="https://user-images.githubusercontent.com/1497424/71848930-ce294a80-309e-11ea-9da2-c233fc3f71eb.png">
