### PR TITLE
Add type-checking to PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@0.7.2
   codecov: codecov/codecov@1.0.5
+  hokusai: artsy/hokusai@0.7.2
+  yarn: artsy/yarn@2.1.1
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -26,6 +27,9 @@ only_release: &only_release
 workflows:
   build-deploy:
     jobs:
+      - yarn/type-check:
+          <<: *not_staging_or_release
+
       - hokusai/test:
           name: test
           <<: *not_staging_or_release


### PR DESCRIPTION
Type-checking should be applied to all PRs. We currently run the `type-check` command as part of a git hook, so engineers can't push work that contains type errors, but dependabot can create PRs with broken types (because it doesn't use the git hook). 

Example: When [dependabot updated the styled-component types](https://github.com/artsy/positron/pull/2485), it introduced a handful of type errors. We saw these locally but not as part of the CI build.