### PR TITLE
Articles can return channel data via graphql

### DIFF
--- a/src/api/apps/graphql/index.js
+++ b/src/api/apps/graphql/index.js
@@ -14,6 +14,15 @@ import { setUser } from "api/apps/users/routes.coffee"
 const app = (module.exports = express())
 
 const metaFields = {
+  authors: array()
+    .items(object(Author.schema))
+    .meta({
+      resolve: resolvers.relatedAuthors,
+    }),
+  channel: object(Channel.schema).meta({
+    name: "Channel",
+    resolve: resolvers.articleChannel,
+  }),
   is_super_sub_article: boolean().meta({
     resolve: async root => (await getSuperArticleCount(root.id)) > 0,
   }),
@@ -89,11 +98,6 @@ const metaFields = {
     .meta({
       name: "RelatedArticles",
       resolve: resolvers.relatedArticles,
-    }),
-  authors: array()
-    .items(object(Author.schema))
-    .meta({
-      resolve: resolvers.relatedAuthors,
     }),
   seriesArticle: object(Article.inputSchema).meta({
     name: "SeriesArticle",

--- a/src/api/apps/graphql/resolvers.js
+++ b/src/api/apps/graphql/resolvers.js
@@ -120,6 +120,20 @@ export const channels = (root, args, req, ast) => {
   })
 }
 
+export const articleChannel = root => {
+  const args = {
+    id: root.channel_id,
+  }
+  return new Promise((resolve, reject) => {
+    Channel.find(args.id, (err, results) => {
+      if (err) {
+        reject(new Error(err))
+      }
+      resolve(results)
+    })
+  })
+}
+
 export const relatedArticles = (root, args, req) => {
   const { related_article_ids } = root
   const relatedArticleArgs = {

--- a/src/api/apps/graphql/test/resolvers.spec.js
+++ b/src/api/apps/graphql/test/resolvers.spec.js
@@ -50,6 +50,7 @@ describe("resolvers", () => {
     })
     resolvers.__set__("Channel", {
       mongoFetch: sinon.stub().yields(null, channels),
+      find: sinon.stub().yields(null, channels.results[0]),
     })
     resolvers.__set__("Curation", {
       mongoFetch: sinon.stub().yields(null, curations),
@@ -168,10 +169,18 @@ describe("resolvers", () => {
 
   describe("channels", () => {
     it("can find channels", async () => {
-      const results = await resolvers.channels({}, {}, req, {})
+      const results = await resolvers.channels(article, {}, req, {})
       results.length.should.equal(1)
       results[0].name.should.equal("Editorial")
       results[0].type.should.equal("editorial")
+    })
+  })
+
+  describe("articleChannel", () => {
+    it("can return article channel", async () => {
+      const results = await resolvers.articleChannel(article, {}, req, {})
+      results.name.should.equal("Editorial")
+      results.type.should.equal("editorial")
     })
   })
 


### PR DESCRIPTION
Adds `channel` to article meta returned by graphql. This unblocks using React to display internal channel's articles, like job postings, in Force. (Currently these use to-be-deprecated Backbone templates, which we haven't updated in 2 years, although we already built their layout in Reaction).

<img width="948" alt="Screen Shot 2020-02-05 at 3 53 59 PM" src="https://user-images.githubusercontent.com/1497424/73888462-ae22ad80-483b-11ea-9be9-8bab61310455.png">
