### PR TITLE
Fix position bug for removing users from channels

### DIFF
--- a/src/client/components/layout/stylesheets/form_elements.styl
+++ b/src/client/components/layout/stylesheets/form_elements.styl
@@ -90,6 +90,7 @@ input-placeholder()
   transition color 0.3s
 
 .bordered-input, .simple-modal-content input, .autocomplete-select-selected
+  position relative
   margin 0
   padding 5px 12px
   border 2px solid gray-lighter-color


### PR DESCRIPTION
Minor change to make legacy autocomplete components contain their remove button, so we can remove former employees from editorial channel.

After:
<img width="969" alt="Screen Shot 2020-02-10 at 11 09 32 AM" src="https://user-images.githubusercontent.com/1497424/74167320-1683dd00-4bf6-11ea-8348-c1ec2354434d.png">

Before:
<img width="991" alt="Screen Shot 2020-02-10 at 11 09 44 AM" src="https://user-images.githubusercontent.com/1497424/74167293-0c61de80-4bf6-11ea-940c-e28f9853cf67.png">
