### PR TITLE
Update admin authorization to check team role vs Admin type

### DIFF
--- a/src/api/apps/articles/routes.coffee
+++ b/src/api/apps/articles/routes.coffee
@@ -59,7 +59,9 @@ User = require '../users/model.coffee'
 
 # Don't let non-admins feature
 @restrictFeature = (req, res, next) ->
-  if req.user?.type isnt 'Admin' and req.body.featured
+  roles = req.user?.get('roles') or []
+
+  if 'team' not in roles and req.body.featured
     res.err 401, 'You must be an admin to feature an article.'
   else
     next()

--- a/src/api/apps/articles/test/integration.test.coffee
+++ b/src/api/apps/articles/test/integration.test.coffee
@@ -36,9 +36,9 @@ describe 'articles endpoints', ->
   describe 'as a non-admin', ->
 
     beforeEach (done) ->
-      @normieToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInR5cGUiOiJVc2VyIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwidHlwZSI6IlVzZXIiLCJwYXJ0bmVyX2lkcyI6W10sImlhdCI6MTUxNjIzOTAyMn0.1ONei7j20cbeusjWiUvTt-CTDCdpewnj3mbmIA_-Hbs'
+      @normieToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInR5cGUiOiJVc2VyIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwidHlwZSI6IlVzZXIiLCJyb2xlcyI6IiIsInBhcnRuZXJfaWRzIjpbXSwiaWF0IjoxNTE2MjM5MDIyfQ.uMBdEvBEVprixHImgNn2wed4WMi_G2E1aZ2Rj4xfSG0'
       fabricate 'users', {
-        type: 'User'
+        roles: [],
         name: 'Normie'
         access_token: @normieToken
         has_partner_access: false

--- a/src/api/apps/articles/test/routes.test.coffee
+++ b/src/api/apps/articles/test/routes.test.coffee
@@ -73,7 +73,6 @@ describe 'routes', ->
 
     it 'throws a 404 for articles from non channel members', ->
       @User.hasChannelAccess = sinon.stub().returns false
-      @req.user.type = 'User'
       @req.article = _.extend {}, fixtures().articles,
         published: false
         channel_id: ObjectId('4d8cd73191a5c50ce210002a')
@@ -137,7 +136,8 @@ describe 'routes', ->
       @req.article.title.should.equal 'Andy Foobar and The Gang'
 
     it 'shows unpublished articles to admins', ->
-      @req.user.type = 'Admin'
+      @req.user.roles = ['team']
+
       routes.find @req, @res, @next
       @Article.find.args[0][1] null, _.extend(fixtures().articles,
         author_id: ObjectId('4d8cd73191a5c50ce210002a')

--- a/src/api/apps/users/routes.coffee
+++ b/src/api/apps/users/routes.coffee
@@ -13,7 +13,8 @@
 
 # Require an admin middleware
 @adminOnly = (req, res, next) ->
-  return res.err 401, 'Must be an admin' unless req.user?.type is 'Admin'
+  roles = req.user?.get('roles') or []
+  return res.err 401, 'Must be an admin' unless 'team' in roles
   next()
 
 # Set the user from an access token and alias the `me` param

--- a/src/api/apps/users/test/model.test.coffee
+++ b/src/api/apps/users/test/model.test.coffee
@@ -10,7 +10,7 @@ express = require 'express'
 
 app = express()
 app.get '/__gravity/api/v1/user/563d08e6275b247014000026', (req, res, next) ->
-  user = gravityFabricate 'user', type: 'User', id: '563d08e6275b247014000026'
+  user = gravityFabricate 'user', roles: [], id: '563d08e6275b247014000026'
   res.send user
 app.use '/__gravity', gravity
 
@@ -136,12 +136,12 @@ describe 'User', ->
       done()
 
     it 'returns true for a non-partner or non-channel member but admin when no channel_id', (done) ->
-      user = _.extend fixtures().users, { channel_ids: [], partner_ids: [], type: 'Admin' }
+      user = _.extend fixtures().users, { channel_ids: [], partner_ids: [], roles: ['team'] }
       User.hasChannelAccess(user).should.be.true()
       done()
 
     it 'returns false for a non-partner or non-channel member', (done) ->
-      user = _.extend fixtures().users, { channel_ids: [], partner_ids: [], type: 'User' }
+      user = _.extend fixtures().users, { channel_ids: [], partner_ids: [], roles: [] }
       User.hasChannelAccess(user, '5086df098523e60002000012').should.be.false()
       done()
 

--- a/src/client/apps/switch_channel/test/index.test.coffee
+++ b/src/client/apps/switch_channel/test/index.test.coffee
@@ -13,7 +13,7 @@ describe 'authorized switch_channel (channel)', ->
     user = new User fixtures().users
     user.set channel_ids: ['1234']
     user.set partner_ids: []
-    user.set type: 'Admin'
+    user.set roles: ['team']
     @channel = new Channel(
       name: 'Artsy Editorial'
       id: '1234'
@@ -41,7 +41,7 @@ describe 'authorized switch_channel (partner)', ->
     user = new User fixtures().users
     user.set channel_ids: []
     user.set partner_ids: ['123']
-    user.set type: 'User'
+    user.set roles: []
     @partner = new Channel
       id: '123'
       name: 'Gagosian'
@@ -66,7 +66,7 @@ describe 'non authorized switch_channel', ->
     user = new User fixtures().users
     user.set channel_ids: []
     user.set partner_ids: []
-    user.set type: 'User'
+    user.set roles: []
     @req = user: user, login: sinon.stub(), params: id: 'foo'
     @res = redirect: sinon.stub()
     @next = sinon.stub()

--- a/src/client/components/autocomplete_channels/test/index.test.coffee
+++ b/src/client/components/autocomplete_channels/test/index.test.coffee
@@ -22,7 +22,7 @@ describe 'AutocompleteChannels', ->
       sinon.stub Backbone, 'sync'
       @AutocompleteChannels = benv.require resolve __dirname, '../index'
       @AutocompleteChannels.__set__ 'Modal', sinon.stub().returns {m: ''}
-      @AutocompleteChannels.__set__ 'sd', { USER: { type: 'Admin', id: '123', name: 'Kana'} }
+      @AutocompleteChannels.__set__ 'sd', { USER: { roles: ['team'], id: '123', name: 'Kana'} }
       sinon.stub @AutocompleteChannels.prototype, 'setupTypeahead'
       sinon.stub(User.prototype, 'fetchPartners').yields [fabricate 'partner']
       done()
@@ -49,7 +49,7 @@ describe 'AutocompleteChannels', ->
       view.adminPartners.remote.url.should.containEql '/api/v1/match/partners?term=%QUERY'
 
     xit 'sets Bloodhound args for partner source as a partner', ->
-      @AutocompleteChannels.__set__ 'sd', { USER: { type: 'User', id: '123', name: 'Kana'} }
+      @AutocompleteChannels.__set__ 'sd', { USER: { roles: [], id: '123', name: 'Kana'} }
       view = new @AutocompleteChannels
       view.partners.local.length.should.equal 1
       view.partners.local[0].value.should.equal 'Gagosian Gallery'

--- a/src/client/components/layout/templates/sidebar.jade
+++ b/src/client/components/layout/templates/sidebar.jade
@@ -34,7 +34,7 @@
         include ../public/icons/layout_queue.svg
         br
         | Queue
-    if user.get('type') == 'Admin'
+    if user.isAdmin()
       a#layout-sidebar-settings( href='/settings'
          class=(sd.URL.match('/settings') ? 'is-active' : '') )
         include ../public/icons/layout_settings.svg

--- a/src/client/lib/middleware.coffee
+++ b/src/client/lib/middleware.coffee
@@ -44,7 +44,9 @@ useragent = require 'useragent'
   next()
 
 @adminOnly = (req, res, next) ->
-  if req.user?.get('type') isnt 'Admin'
+  roles = req.user?.get('roles') or []
+
+  if 'team' not in roles
     err = new Error 'You must be logged in as an admin'
     err.status = 403
     next err

--- a/src/client/lib/setup/auth.coffee
+++ b/src/client/lib/setup/auth.coffee
@@ -23,7 +23,7 @@ setupPassport = ->
       error: (m, err) -> done err
       success: (user) ->
         id = user.get('channel_ids').concat(user.get('partner_ids'))[0]
-        id = process.env.DEFAULT_PARTNER_ID if not id and user.get('type') is 'Admin'
+        id = process.env.DEFAULT_PARTNER_ID if not id and 'team' in user.get('roles')
         new Channel(id: id).fetchChannelOrPartner
           headers: 'X-Access-Token': accessToken
           error: (m, err) ->
@@ -38,7 +38,7 @@ setupPassport = ->
     done null, new User(user)
 
 logoutOldSchema = (req, res, next) ->
-  if req.user and not req.user.get('type')
+  if req.user and not req.user.get('roles')
     res.redirect '/logout'
   else
     next()

--- a/src/client/models/user.coffee
+++ b/src/client/models/user.coffee
@@ -10,7 +10,9 @@ module.exports = class User extends Backbone.Model
   urlRoot: "#{sd.API_URL}/users/me"
 
   isAdmin: ->
-    @get('type') is 'Admin'
+    roles = @get('roles') or []
+
+    'team' in roles
 
   refresh: (cb) ->
     request.get("#{sd.API_URL}/users/me/refresh")

--- a/src/client/reducers/appReducer.ts
+++ b/src/client/reducers/appReducer.ts
@@ -42,7 +42,7 @@ export const getInitialState = () =>
     artsyURL: sd.ARTSY_URL,
     channel: sd.CURRENT_CHANNEL,
     forceURL: sd.FORCE_URL,
-    isAdmin: sd.USER && sd.USER.type === "Admin",
+    isAdmin: sd.USER && sd.USER.roles.includes("team"),
     isEditorial: sd.CURRENT_CHANNEL && sd.CURRENT_CHANNEL.type === "editorial",
     isPartnerChannel:
       sd.CURRENT_CHANNEL && sd.CURRENT_CHANNEL.type === "partner",

--- a/src/client/reducers/test/appReducer.test.ts
+++ b/src/client/reducers/test/appReducer.test.ts
@@ -26,7 +26,7 @@ describe("appReducer", () => {
       name: "User Name",
       email: "user@email.com",
       id: "5678",
-      type: "Admin",
+      roles: ["team"],
       partner_ids: ["12345"],
       channel_ids: [current_channel.id],
       current_channel,
@@ -72,7 +72,7 @@ describe("appReducer", () => {
     })
 
     it("sets initial state for non-admin users", () => {
-      delete sharify.data.USER.type
+      delete sharify.data.USER.roles
       const initialState = appReducer(undefined, { payload: {} })
       expect(initialState.isAdmin).toBe(false)
     })

--- a/src/client/test/lib/middleware.test.coffee
+++ b/src/client/test/lib/middleware.test.coffee
@@ -50,7 +50,7 @@ describe 'middleware', ->
 
     describe 'is an admin', ->
       beforeEach ->
-        @req = user: new Backbone.Model type: 'Admin'
+        @req = user: new Backbone.Model roles: ['team']
 
       it 'passes through without error', ->
         middleware.adminOnly @req, {}, @next

--- a/src/client/test/models/user.test.coffee
+++ b/src/client/test/models/user.test.coffee
@@ -27,7 +27,7 @@ describe "User", ->
       @user.isAdmin().should.be.true()
 
     it 'returns false for a non-Admin user', ->
-      @user = new User _.extend fixtures().users, type: 'User'
+      @user = new User _.extend fixtures().users, roles: []
       @user.isAdmin().should.be.false()
 
   describe '#hasChannel', ->
@@ -51,7 +51,7 @@ describe "User", ->
       @user.hasPartner('1234').should.be.true()
 
     it 'returns false for a user that does not have partner permissions', ->
-      @user = new User _.extend fixtures().users, { type: 'User', partner_ids: [] }
+      @user = new User _.extend fixtures().users, { roles: [], partner_ids: [] }
       @user.hasPartner('1234').should.be.false()
 
   describe '#hasArticleAccess', ->
@@ -76,7 +76,7 @@ describe "User", ->
 
     it 'returns false for a member of a channel on a partner article', ->
       @article = new Article _.extend fixtures().articles, { partner_channel_id: '1234' }
-      @user = new User _.extend fixtures().users, { channel_ids: ['12345'], type: 'User' }
+      @user = new User _.extend fixtures().users, { channel_ids: ['12345'], roles: [] }
       @user.hasArticleAccess(@article).should.be.false()
 
     it 'returns false for a member of a partner on a channel article', ->

--- a/src/test/helpers/fixtures.coffee
+++ b/src/test/helpers/fixtures.coffee
@@ -135,9 +135,9 @@ module.exports = ->
   fixtures.users =
     id: '4d8cd73191a5c50ce200002a'
     name: 'Craig Spaeth'
-    type: 'Admin'
+    roles: ['team']
     profile_icon_url: 'https://d32dm0rphc51dk.cloudfront.net/CJOHhrln8lwVAubiMIIYYA/square140.png'
-    access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsInBhcnRuZXJfaWRzIjpbXX0.-A-T4cwj1PFzuMhiHn9FYk8IBA0lIukzXKUNa43jjlQ'
+    access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwicm9sZXMiOiJ0ZWFtIiwicGFydG5lcl9pZHMiOltdfQ.mBHDr2Hghu4cYkeF6AdsSmaV7R35Qv7rUcbAoKayZdY'
     current_channel:
       name: 'Editorial'
       type: 'editorial'

--- a/test.config.js
+++ b/test.config.js
@@ -48,5 +48,5 @@ try {
 sd.data = {
   ARTICLE: FeatureArticle,
   CHANNEL: {},
-  USER: { id: "57b5fc6acd530e65f8000406" },
+  USER: { id: "57b5fc6acd530e65f8000406", roles: [] },
 }


### PR DESCRIPTION
Whenever we check for admin authorization, check that the currently authenticated user has the `team` role vs the `Admin` user type.

I chose to only change the underlying check logic and not the names of functions or spec descriptions to keep the diff focused. Happy to follow-up with those changes in a subsequent pull request.