### PR TITLE
Graceful shutdown of nginx/web containers.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -61,7 +61,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 10"]
         - name: positron-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
@@ -78,7 +78,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
               valueFrom:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -61,7 +61,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 10"]
         - name: positron-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
@@ -78,7 +78,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
               valueFrom:


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-1996

When nginx/web containers are abruptly shut down, as they are when there is a scale-in event, deployment, or update, browser clients might see 502 Bad Gateway errors. Kubernetes can run a command in the container and wait for the command to finish before killing the container. The feature is called "preStop handler". This PR is to apply preStop handlers to the 'web' and 'nginx' containers. When a pod is 'terminating', it likely has outstanding requests from clients. With the handlers, we are trying to keep the containers alive long enough so that those requests still get fulfilled.