### PR TITLE
[WIP] AutocompleteV2 uses metaphysics v2

### DIFF
--- a/src/client/components/autocomplete2/index.tsx
+++ b/src/client/components/autocomplete2/index.tsx
@@ -7,6 +7,7 @@ import { data as sd } from "sharify"
 import styled from "styled-components"
 
 export interface Item {
+  displayName?: string // partners only
   name?: string
   title?: string
 }

--- a/src/client/components/autocomplete2/list.tsx
+++ b/src/client/components/autocomplete2/list.tsx
@@ -72,7 +72,7 @@ export class AutocompleteList extends Component<
     const { items } = this.state
 
     return items.map((item, i) => {
-      const title = item ? item.title || item.name : ""
+      const title = item ? item.title || item.name || item.displayName : ""
       return (
         <ListItem key={i} isDraggable={isDraggable}>
           {formatListItem ? (

--- a/src/client/components/autocomplete2/test/list_metaphysics.test.tsx
+++ b/src/client/components/autocomplete2/test/list_metaphysics.test.tsx
@@ -194,7 +194,9 @@ describe("AutocompleteListMetaphysics", () => {
       ).instance() as AutocompleteListMetaphysics
       component.fetchItem("123", jest.fn())
 
-      expect(request.get.mock.calls[0][0]).toBe(props.metaphysicsURL)
+      expect(request.get.mock.calls[0][0]).toBe(
+        "https://metaphysics-staging.artsy.net/v2"
+      )
       expect(request.query().end).toBeCalled()
     })
 
@@ -265,7 +267,9 @@ describe("AutocompleteListMetaphysics", () => {
       ).instance() as AutocompleteListMetaphysics
       component.fetchItems(["123"], jest.fn())
 
-      expect(request.get.mock.calls[0][0]).toBe(props.metaphysicsURL)
+      expect(request.get.mock.calls[0][0]).toBe(
+        "https://metaphysics-staging.artsy.net/v2"
+      )
       expect(request.query().end).toBeCalled()
     })
 

--- a/src/client/queries/metaphysics.js
+++ b/src/client/queries/metaphysics.js
@@ -4,7 +4,7 @@ export function ArtworkQuery(id) {
   return `
     {
       artwork(id: ${stringifyJSONForWeb(id)}) {
-        _id
+        id
         title
       }
     }
@@ -15,8 +15,12 @@ export function ArtworksQuery(ids) {
   return `
     {
       artworks(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
-        title
+        edges {
+          node {
+            id
+            title
+          }
+        }
       }
     }
   `
@@ -26,7 +30,7 @@ export function ArtistQuery(id) {
   return `
     {
       artist(id: ${stringifyJSONForWeb(id)}) {
-        _id
+        id
         name
       }
     }
@@ -37,7 +41,7 @@ export function ArtistsQuery(ids) {
   return `
     {
       artists(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
+        id
         name
       }
     }
@@ -47,9 +51,13 @@ export function ArtistsQuery(ids) {
 export function AuctionsQuery(ids) {
   return `
     {
-      sales(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
-        name
+      salesConnection(ids: ${stringifyJSONForWeb(ids)}) {
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
     }
   `
@@ -59,7 +67,7 @@ export function FairsQuery(ids) {
   return `
     {
       fairs(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
+        id
         name
       }
     }
@@ -67,17 +75,19 @@ export function FairsQuery(ids) {
 }
 
 export function PartnersQuery(ids) {
+  // FIXME: should be deprecated
   return `
     {
-      partners(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
-        name
+      _unused_gravity_partners(ids: ${stringifyJSONForWeb(ids)}) {
+        id
+        displayName
       }
     }
   `
 }
 
 export function ShowsQuery(ids) {
+  // FIXME: doesn't exist in v2
   return `
     {
       partner_shows(ids: ${stringifyJSONForWeb(ids)}) {


### PR DESCRIPTION
Updates metaphysics autocomplete components to target MP v2. Shows are still fetching from v1.

I ran into an issue where we do not have endpoints to fetch a list of items by `id` for all models. An equivalent to `partner_shows` from v1 does not seem to exist. Partners exist, but labelled as `_unused_gravity_partners`. I've used this for the moment, but hopefully there is a better option. 