### PR TITLE
Use Metaphysics v2

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -21,7 +21,7 @@ ARTSY_ID=REPLACE
 ARTSY_SECRET=REPLACE
 
 # Needed to link Reaction: `yarn link @artsy/reaction`
-GRAPHQL_ENDPOINT=https://metaphysics-staging.artsy.net
+GRAPHQL_ENDPOINT=https://metaphysics-staging.artsy.net/v2
 
 # Token used to authenticate with the code coverage tracking tool Codecov.
 # Token not needed when running tests during dev, intended to only be set

--- a/src/client/components/autocomplete2/list_metaphysics.tsx
+++ b/src/client/components/autocomplete2/list_metaphysics.tsx
@@ -98,9 +98,13 @@ export class AutocompleteListMetaphysics extends Component<
     const query: any = this.getQuery()
     const idsToFetch = this.idsToFetch(fetchedItems)
     const mpv2 = `${metaphysicsURL}/v2`
-    const isv2Query = ["partners", "sales", "partner_shows", "fairs"].includes(
-      model
-    )
+    const isv2Query = [
+      "artists",
+      "partners",
+      "sales",
+      "partner_shows",
+      "fairs",
+    ].includes(model)
     const mpUrl = isv2Query ? mpv2 : metaphysicsURL
     const rootField = this.getMpRootField()
     // TODO: Metaphysics only returns shows with "displayable: true"
@@ -142,9 +146,13 @@ export class AutocompleteListMetaphysics extends Component<
     const query: any = this.getQuery()
     const idToFetch = article[field]
     const mpv2 = `${metaphysicsURL}/v2`
-    const isv2Query = ["partners", "sales", "partner_shows", "fairs"].includes(
-      model
-    )
+    const isv2Query = [
+      "artists",
+      "partners",
+      "sales",
+      "partner_shows",
+      "fairs",
+    ].includes(model)
     const mpUrl = isv2Query ? mpv2 : metaphysicsURL
     const rootField = this.getMpRootField()
 

--- a/src/client/components/autocomplete2/list_metaphysics.tsx
+++ b/src/client/components/autocomplete2/list_metaphysics.tsx
@@ -80,6 +80,11 @@ export class AutocompleteListMetaphysics extends Component<
     }
   }
 
+  fieldIsMpConnection = () => {
+    const { model } = this.props
+    return this.getMpRootField().includes("Connection") || model === "artworks"
+  }
+
   idsToFetch = fetchedItems => {
     const { article, field, model } = this.props
     let alreadyFetched = uniq(pluck(fetchedItems, "_id"))
@@ -98,13 +103,7 @@ export class AutocompleteListMetaphysics extends Component<
     const query: any = this.getQuery()
     const idsToFetch = this.idsToFetch(fetchedItems)
     const mpv2 = `${metaphysicsURL}/v2`
-    const isv2Query = [
-      "artists",
-      "partners",
-      "sales",
-      "partner_shows",
-      "fairs",
-    ].includes(model)
+    const isv2Query = model !== "users"
     const mpUrl = isv2Query ? mpv2 : metaphysicsURL
     const rootField = this.getMpRootField()
     // TODO: Metaphysics only returns shows with "displayable: true"
@@ -123,7 +122,7 @@ export class AutocompleteListMetaphysics extends Component<
             throw new Error(err)
           }
           if (isv2Query) {
-            if (rootField.includes("Connection")) {
+            if (this.fieldIsMpConnection()) {
               newItems.push(getItemsFromEdges(res.body.data[rootField].edges))
             } else {
               res.body.data[rootField].forEach(item => {
@@ -146,13 +145,7 @@ export class AutocompleteListMetaphysics extends Component<
     const query: any = this.getQuery()
     const idToFetch = article[field]
     const mpv2 = `${metaphysicsURL}/v2`
-    const isv2Query = [
-      "artists",
-      "partners",
-      "sales",
-      "partner_shows",
-      "fairs",
-    ].includes(model)
+    const isv2Query = model !== "users"
     const mpUrl = isv2Query ? mpv2 : metaphysicsURL
     const rootField = this.getMpRootField()
 
@@ -169,7 +162,7 @@ export class AutocompleteListMetaphysics extends Component<
             new Error(err)
           }
           if (isv2Query) {
-            if (rootField.includes("Connection")) {
+            if (this.fieldIsMpConnection()) {
               cb(getItemsFromEdges(res.body.data[rootField].edges))
             } else {
               res.body.data[rootField].forEach(item => {

--- a/src/client/components/autocomplete2/list_metaphysics.tsx
+++ b/src/client/components/autocomplete2/list_metaphysics.tsx
@@ -50,10 +50,10 @@ export class AutocompleteListMetaphysics extends Component<
         return Queries.PartnersConnectionQuery
       }
       case "partner_shows": {
-        return Queries.ShowsQuery
+        return Queries.ShowsConnectionQuery
       }
       case "sales": {
-        return Queries.AuctionsQuery
+        return Queries.SalesConnectionQuery
       }
       case "users": {
         return Queries.UsersQuery
@@ -65,8 +65,13 @@ export class AutocompleteListMetaphysics extends Component<
     const { model } = this.props
 
     switch (model) {
-      case "partners": {
-        return "partnersConnection"
+      case "partners":
+      case "sales": {
+        return `${model}Connection`
+        break
+      }
+      case "partner_shows": {
+        return "showsConnection"
         break
       }
       default: {
@@ -93,7 +98,7 @@ export class AutocompleteListMetaphysics extends Component<
     const query: any = this.getQuery()
     const idsToFetch = this.idsToFetch(fetchedItems)
     const mpv2 = `${metaphysicsURL}/v2`
-    const isv2Query = model === "partners"
+    const isv2Query = ["partners", "sales", "partner_shows"].includes(model)
     const mpUrl = isv2Query ? mpv2 : metaphysicsURL
     const rootField = this.getMpRootField()
     // TODO: Metaphysics only returns shows with "displayable: true"
@@ -109,7 +114,7 @@ export class AutocompleteListMetaphysics extends Component<
         .query({ query: query(idsToFetch) })
         .end((err, res) => {
           if (err) {
-            new Error(err)
+            throw new Error(err)
           }
           if (isv2Query) {
             newItems.push(getItemFromEdges(res.body.data[rootField].edges))
@@ -129,7 +134,7 @@ export class AutocompleteListMetaphysics extends Component<
     const query: any = this.getQuery()
     const idToFetch = article[field]
     const mpv2 = `${metaphysicsURL}/v2`
-    const isv2Query = model === "partners"
+    const isv2Query = ["partners", "sales", "partner_shows"].includes(model)
     const mpUrl = isv2Query ? mpv2 : metaphysicsURL
     const rootField = this.getMpRootField()
 
@@ -208,11 +213,9 @@ export class AutocompleteListMetaphysics extends Component<
       article,
       artsyURL,
       field,
-      isDraggable,
       label,
       model,
       onChangeArticleAction,
-      onDragEnd,
       placeholder,
       type,
     } = this.props
@@ -221,7 +224,6 @@ export class AutocompleteListMetaphysics extends Component<
       case "single": {
         return (
           <AutocompleteSingle
-            article={article}
             fetchItem={(item, cb) => {
               this.fetchItem(item, cb)
             }}
@@ -234,7 +236,7 @@ export class AutocompleteListMetaphysics extends Component<
             onSelect={result => onChangeArticleAction(field, result)}
             placeholder={placeholder || `Search ${model} by name...`}
             url={`${artsyURL}/api/v1/match/${model}?term=%QUERY`}
-            model={model}
+            {...this.props}
           />
         )
       }
@@ -245,14 +247,13 @@ export class AutocompleteListMetaphysics extends Component<
             formatSelected={
               model === "users" ? this.formatSelectedUser : undefined
             }
-            isDraggable={isDraggable}
-            onDragEnd={onDragEnd}
             items={article[field] || []}
             filter={this.getFilter()}
             label={capitalize(label || model)}
             onSelect={results => onChangeArticleAction(field, results)}
             placeholder={placeholder || `Search ${model} by name...`}
             url={`${artsyURL}/api/v1/match/${model}?term=%QUERY`}
+            {...this.props}
           />
         )
       }

--- a/src/client/components/autocomplete2/test/list_metaphysics.test.tsx
+++ b/src/client/components/autocomplete2/test/list_metaphysics.test.tsx
@@ -93,7 +93,7 @@ describe("AutocompleteListMetaphysics", () => {
       ).instance() as AutocompleteListMetaphysics
       const query = component.getQuery()
 
-      expect(query).toBe(Queries.PartnersQuery)
+      expect(query).toBe(Queries.PartnersConnectionQuery)
     })
 
     it("Returns the correct query for shows", () => {
@@ -103,7 +103,7 @@ describe("AutocompleteListMetaphysics", () => {
       ).instance() as AutocompleteListMetaphysics
       const query = component.getQuery()
 
-      expect(query).toBe(Queries.ShowsQuery)
+      expect(query).toBe(Queries.ShowsConnectionQuery)
     })
 
     it("Returns the correct query for auctions", () => {
@@ -113,7 +113,7 @@ describe("AutocompleteListMetaphysics", () => {
       ).instance() as AutocompleteListMetaphysics
       const query = component.getQuery()
 
-      expect(query).toBe(Queries.AuctionsQuery)
+      expect(query).toBe(Queries.SalesConnectionQuery)
     })
 
     it("Returns the correct query for artists", () => {

--- a/src/client/queries/metaphysics.js
+++ b/src/client/queries/metaphysics.js
@@ -1,33 +1,15 @@
 import { stringifyJSONForWeb } from "client/lib/utils/json"
 
-export function ArtworkQuery(id) {
-  return `
-    {
-      artwork(id: ${stringifyJSONForWeb(id)}) {
-        _id
-        title
-      }
-    }
-  `
-}
-
 export function ArtworksQuery(ids) {
   return `
     {
       artworks(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
-        title
-      }
-    }
-  `
-}
-
-export function ArtistQuery(id) {
-  return `
-    {
-      artist(id: ${stringifyJSONForWeb(id)}) {
-        _id
-        name
+        edges {
+          node {
+            internalID
+            title
+          }
+        }
       }
     }
   `
@@ -38,17 +20,6 @@ export function ArtistsQuery(ids) {
     {
       artists(ids: ${stringifyJSONForWeb(ids)}) {
         internalID
-        name
-      }
-    }
-  `
-}
-
-export function AuctionsQuery(ids) {
-  return `
-    {
-      sales(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
         name
       }
     }
@@ -81,17 +52,6 @@ export function FairsQuery(ids) {
   `
 }
 
-export function PartnersQuery(ids) {
-  return `
-    {
-      partners(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
-        name
-      }
-    }
-  `
-}
-
 export function PartnersConnectionQuery(ids) {
   return `
     {
@@ -102,17 +62,6 @@ export function PartnersConnectionQuery(ids) {
             name
           }
         }
-      }
-    }
-  `
-}
-
-export function ShowsQuery(ids) {
-  return `
-    {
-      partner_shows(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
-        name
       }
     }
   `

--- a/src/client/queries/metaphysics.js
+++ b/src/client/queries/metaphysics.js
@@ -74,7 +74,7 @@ export function FairsQuery(ids) {
   return `
     {
       fairs(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
+        internalID
         name
       }
     }

--- a/src/client/queries/metaphysics.js
+++ b/src/client/queries/metaphysics.js
@@ -85,9 +85,13 @@ export function ShowsConnectionQuery(ids) {
 export function UsersQuery(ids) {
   return `
     {
-      users(ids: ${stringifyJSONForWeb(ids)}) {
-        id
-        name
+      usersConnection(ids: ${stringifyJSONForWeb(ids)}) {
+        edges {
+          node {
+            internalID
+            name
+          }
+        }
       }
     }
   `

--- a/src/client/queries/metaphysics.js
+++ b/src/client/queries/metaphysics.js
@@ -55,6 +55,21 @@ export function AuctionsQuery(ids) {
   `
 }
 
+export function SalesConnectionQuery(ids) {
+  return `
+    {
+      salesConnection(ids: ${stringifyJSONForWeb(ids)}) {
+        edges {
+          node {
+            internalID
+            name
+          }
+        }
+      }
+    }
+  `
+}
+
 export function FairsQuery(ids) {
   return `
     {
@@ -98,6 +113,21 @@ export function ShowsQuery(ids) {
       partner_shows(ids: ${stringifyJSONForWeb(ids)}) {
         _id
         name
+      }
+    }
+  `
+}
+
+export function ShowsConnectionQuery(ids) {
+  return `
+    {
+      showsConnection(ids: ${stringifyJSONForWeb(ids)}) {
+        edges {
+          node {
+            internalID
+            name
+          }
+        }
       }
     }
   `

--- a/src/client/queries/metaphysics.js
+++ b/src/client/queries/metaphysics.js
@@ -77,6 +77,21 @@ export function PartnersQuery(ids) {
   `
 }
 
+export function PartnersConnectionQuery(ids) {
+  return `
+    {
+      partnersConnection(ids: ${stringifyJSONForWeb(ids)}) {
+        edges {
+          node {
+            internalID
+            name
+          }
+        }
+      }
+    }
+  `
+}
+
 export function ShowsQuery(ids) {
   return `
     {

--- a/src/client/queries/metaphysics.js
+++ b/src/client/queries/metaphysics.js
@@ -37,7 +37,7 @@ export function ArtistsQuery(ids) {
   return `
     {
       artists(ids: ${stringifyJSONForWeb(ids)}) {
-        _id
+        internalID
         name
       }
     }


### PR DESCRIPTION
Updates `AutocompleteListMetaphysics` to use only MPv2 queries, and distinguish between connections and other data shapes. 

**#migration**
- [ ] `hokusai staging env set GRAPHQL_ENDPOINT=https://metaphysics-staging.artsy.net/v2 && hokusai staging refresh`