### PR TITLE
Tune resource consumption.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -44,10 +44,10 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 500m
-              memory: 768Mi
+              cpu: 200m
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               port: positron-http

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -37,6 +37,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/positron:production
           imagePullPolicy: Always
           ports:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -37,6 +37,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/positron:staging
           imagePullPolicy: Always
           ports:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -44,10 +44,10 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 500m
-              memory: 768Mi
+              cpu: 100m
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               port: positron-http

--- a/scripts/production.sh
+++ b/scripts/production.sh
@@ -11,4 +11,4 @@ fi
 export COMMIT_HASH=`cat COMMIT_HASH.txt`
 export ASSET_MANIFEST=$(curl --silent $CDN_URL/manifest-$COMMIT_HASH.json)
 
-node --max_old_space_size=1024 ./src --colors
+node ./src --colors


### PR DESCRIPTION
- Tune resource consumption.
- Use NODE_OPTIONS to specify max_old_space_size in staging/production.yml. Remove the setting from production.sh.

---
https://artsyproduct.atlassian.net/browse/PLATFORM-2654
https://www.notion.so/artsy/Guidelines-on-tuning-an-app-s-CPU-and-memory-consumption-in-a-Kubernetes-cluster-797977be895643af84015a7d4b60a5dc
https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-cpumemory-usage-by-deployment