### PR TITLE
Add horizon deploy block config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   codecov: codecov/codecov@1.1.1
   hokusai: artsy/hokusai@0.7.4
   yarn: artsy/yarn@5.1.3
+  horizon: artsy/release@0.0.1
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -62,5 +63,12 @@ workflows:
             - push-staging-image
 
       # Release
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: 21
+
       - hokusai/deploy-production:
           <<: *only_release
+          requires:
+            - horizon/block


### PR DESCRIPTION
Deploys are not actually blocked unless we use the orb. Configuring as an opportunity to QA that recent Horizon config changes work as expected.