### PR TITLE
Use reaction 27

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/gemup": "0.1.0",
     "@artsy/palette": "10.1.0",
-    "@artsy/reaction": "26.54.0",
+    "@artsy/reaction": "27.0.0",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.0.0",
     "@babel/node": "7.0.0",

--- a/src/client/apps/edit/components/admin/components/super_article.tsx
+++ b/src/client/apps/edit/components/admin/components/super_article.tsx
@@ -1,10 +1,10 @@
 import { Box, Checkbox, Flex } from "@artsy/palette"
 import { Input } from "@artsy/reaction/dist/Components/Input"
 import { ArticleData } from "@artsy/reaction/dist/Components/Publishing/Typings"
-import TextArea from "@artsy/reaction/dist/Components/TextArea"
 import { onChangeArticle } from "client/actions/edit/articleActions"
 import { AutocompleteList } from "client/components/autocomplete2/list"
 import { FormLabel } from "client/components/form_label"
+import { TextArea } from "client/components/text_area"
 import { SubArticleQuery } from "client/queries/sub_articles"
 import { clone, uniq } from "lodash"
 import React, { Component } from "react"
@@ -173,7 +173,9 @@ export class AdminSuperArticle extends Component<AdminSuperArticleProps> {
                 block
                 defaultValue={footer_blurb || ""}
                 disabled={isDisabled}
-                onChange={e => this.onChange("footer_blurb", e.target.value)}
+                onChange={e =>
+                  this.onChange("footer_blurb", e.currentTarget.value)
+                }
               />
               <div className="supports-markdown" />
             </Box>

--- a/src/client/apps/settings/client/curations/gucci/components/metadata.tsx
+++ b/src/client/apps/settings/client/curations/gucci/components/metadata.tsx
@@ -1,7 +1,7 @@
 import { Box, Col, Row } from "@artsy/palette"
 import { Input } from "@artsy/reaction/dist/Components/Input"
-import TextArea from "@artsy/reaction/dist/Components/TextArea"
 import { FormLabel } from "client/components/form_label"
+import { TextArea } from "client/components/text_area"
 import React from "react"
 import { SectionAdminProps } from "./section"
 const ImageUpload = require("client/apps/edit/components/admin/components/image_upload.coffee")

--- a/src/client/apps/settings/client/curations/gucci/test/metadata.test.tsx
+++ b/src/client/apps/settings/client/curations/gucci/test/metadata.test.tsx
@@ -1,5 +1,5 @@
 import { Input } from "@artsy/reaction/dist/Components/Input"
-import TextArea from "@artsy/reaction/dist/Components/TextArea"
+import { TextArea } from "client/components/text_area"
 import { mount } from "enzyme"
 import React from "react"
 import { Metadata } from "../components/metadata"

--- a/src/client/apps/settings/client/curations/gucci/test/section.test.tsx
+++ b/src/client/apps/settings/client/curations/gucci/test/section.test.tsx
@@ -1,7 +1,7 @@
 import { Checkbox } from "@artsy/palette"
 import { Input } from "@artsy/reaction/dist/Components/Input"
-import TextArea from "@artsy/reaction/dist/Components/TextArea"
 import { Paragraph } from "client/components/draft/paragraph/paragraph"
+import { TextArea } from "client/components/text_area"
 import { mount } from "enzyme"
 import React from "react"
 import { SectionAdmin } from "../components/section"

--- a/src/client/components/text_area.tsx
+++ b/src/client/components/text_area.tsx
@@ -1,0 +1,56 @@
+import { color } from "@artsy/palette"
+import { garamond } from "@artsy/reaction/dist/Assets/Fonts"
+import React from "react"
+import styled from "styled-components"
+
+interface TextAreaProps extends React.HTMLProps<HTMLTextAreaElement> {
+  error?: boolean
+  block?: boolean
+  hasError?: boolean
+}
+
+/**
+ * @deprecated in favor of our Design System TextArea component in @artsy/palette
+ * https://palette.artsy.net/elements/inputs/textarea
+ */
+const StyledTextArea: React.SFC<TextAreaProps> = props => {
+  const newProps = { ...props }
+  delete newProps.block
+  return <textarea {...props} />
+}
+
+export const TextArea = styled(StyledTextArea)`
+  padding: 10px;
+  box-shadow: none;
+  transition: border-color 0.25s;
+  width: 100%;
+  margin: 24px auto;
+  margin-right: 10px;
+  resize: none;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &::placeholder {
+    color: ${color("black60")};
+    text-overflow: ellipsis;
+    line-height: normal;
+  }
+  ${garamond("s17")};
+  border: 1px solid
+    ${({ hasError }) => (hasError ? color("red100") : color("black60"))};
+  transition: border-color 0.25s;
+
+  &:hover,
+  &:focus,
+  &.focused {
+    border-color: ${({ hasError }) =>
+      hasError ? color("red100") : color("purple100")};
+    outline: 0;
+  }
+
+  &:disabled {
+    border: 2px dotted ${color("black60")};
+  }
+`

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,10 +81,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
-"@artsy/reaction@26.54.0":
-  version "26.54.0"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.54.0.tgz#369584721a1e0c59460096019633b83da230f850"
-  integrity sha512-KtDTaFJ2FcQr66JttbjhDYqiHdwVD/fAjkX1IUeRL+EW6AVPKcDCVQkAvwU3yN2bZqHfw9FS5Z1fje5KKT1G/Q==
+"@artsy/reaction@27.0.0":
+  version "27.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-27.0.0.tgz#d1e753dc2744ee5386c70ca66c7b3f2bf499ad58"
+  integrity sha512-LfMcejTijPi5H/89I2RaJVmcoUJrEfixurZfVzf85JxeJI15eOQzmiUGflIOTnRQlFM4J1tWbfvhSaubbHNHGQ==
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"


### PR DESCRIPTION
Updates for major upgrade to Reaction v27. Ports `TextArea` component, which is removed from new Reaction. Will follow up in a separate PR to use Palette's `TextArea`.