### PR TITLE
#migration Add Ingress resource in hokusai/staging.yml and hokusai/production.yml. Switch DNS to Ingress.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -254,3 +254,42 @@ spec:
                         operator: In
                         values:
                           - background
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: positron
+    component: web
+    layer: application
+  name: positron-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: positron
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: positron
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+spec:
+  rules:
+    - host: writer.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: positron-web-internal
+              servicePort: http

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -257,3 +257,42 @@ spec:
                         operator: In
                         values:
                           - background
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: positron
+    component: web
+    layer: application
+  name: positron-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: positron
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: positron
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+spec:
+  rules:
+    - host: stagingwriter.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: positron-web-internal
+              servicePort: http


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2605

See https://www.notion.so/artsy/Nginx-Ingress-Controllers-4b5d937f0acd480f938c34ef1509d3c4 and the section `Migrating an application from an external LoadBalancer-fronted service to an Ingress-fronted service`.

Migration Steps
---
1. Merge this PR and wait for changes to be deployed to Staging.
2. Test the newly created Ingress in Staging by:
    `curl -i -H "host: stagingwriter.artsy.net" -k https://a2b7b9ff4afbf11ea976f123b14b93be-bc5647bbe8f5b617.elb.us-east-1.amazonaws.com`
3. Switch Staging DNS to Ingress by updating on Cloudflare as follows:
    `stagingwriter.artsy.net` -> `a2b7b9ff4afbf11ea976f123b14b93be-bc5647bbe8f5b617.elb.us-east-1.amazonaws.com`
3. Merge the `Deploy` PR that will be automatically generated. Wait for changes to be deployed to Production.
4. Test the newly created Ingress in Production by:
    `curl -i -H "host: writer.artsy.net" -k https://a0e5e98faaf2311eaa26a0a55b7aece7-04d12ab5797eaa99.elb.us-east-1.amazonaws.com`
5. Switch Production DNS to Ingress by updating on Cloudflare as follows:
    `writer.artsy.net` -> `a0e5e98faaf2311eaa26a0a55b7aece7-04d12ab5797eaa99.elb.us-east-1.amazonaws.com`