### PR TITLE
Sanitized links use https

### DIFF
--- a/src/api/apps/articles/model/sanitize.ts
+++ b/src/api/apps/articles/model/sanitize.ts
@@ -1,0 +1,22 @@
+import { URL } from "url"
+
+export const sanitizeLink = (urlString?: string) => {
+  let url
+  if (!urlString) {
+    return
+  }
+  try {
+    url = new URL(urlString)
+  } catch (_e) {
+    url = new URL(`https://${urlString}`)
+  }
+
+  if (url.hostname === "artsy.net") {
+    url.hostname = "www.artsy.net"
+  }
+  if (url.hostname.includes(".artsy.net")) {
+    url.protocol = "https:"
+  }
+
+  return url.href
+}

--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -192,11 +192,10 @@ sanitize = (article) ->
 sanitizeLink = (urlString) ->
   return unless urlString
   u = url.parse urlString
+  return urlString if u.protocol is "https:"
+
   if u.protocol
-    if u.protocol is "http:"
-      urlString.replace("http:", "https:")
-    else
-      urlString
+    urlString.replace("http:", "https:") if u.hostname is "artsy.net"
   else
     'https://' + u.href
 

--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -20,11 +20,11 @@ artsyXapp = require('artsy-xapp')
   @generateSlugs article, cb
 
 @onUnpublish = (article, cb) =>
-  @generateSlugs article, (err, article) =>
-    deleteArticleFromSailthru getArticleUrl(article), =>
+  @generateSlugs article, (err, article) ->
+    deleteArticleFromSailthru getArticleUrl(article), ->
       cb null, article
 
-setOnPublishFields = (article) =>
+setOnPublishFields = (article) ->
   article.email_metadata = article.email_metadata or {}
   article.email_metadata.image_url = article.thumbnail_image unless article.email_metadata?.image_url
   if article.contributing_authors?.length > 0
@@ -64,7 +64,7 @@ removeStopWords = (title) ->
   # Moves the slug to the end of the slugs array if it already exists in the array
   if article.slugs && article.slugs.includes(slug)
     article.slugs.push(article.slugs.splice(article.slugs.indexOf(slug), 1)[0])
-    return cb null, article  
+    return cb null, article
 
   # # Appends published_at to slug if that slug already exists
   db.articles.count { slugs: slug }, (err, count) ->
@@ -85,7 +85,7 @@ removeStopWords = (title) ->
       # If the slug with the appended date already exists in the array it moves it to the end
       if article.slugs && article.slugs.includes(slug)
         article.slugs.push(article.slugs.splice(article.slugs.indexOf(slug), 1)[0])
-        return cb null, article 
+        return cb null, article
 
     article.slugs = (article.slugs or []).concat slug
     cb(null, article)
@@ -135,7 +135,7 @@ removeStopWords = (title) ->
             .get("#{ARTSY_URL}/api/v1/partner/#{partnerId}")
             .set('X-Xapp-Token': token)
             .end callback
-  async.parallel callbacks, (err, results) =>
+  async.parallel callbacks, (err, results) ->
     return cb(err) if err
     keywords = article.tags or []
     keywords = keywords.concat (res.body.name for res in results)
@@ -145,13 +145,13 @@ removeStopWords = (title) ->
     article.keywords = keywords[0..9]
     cb(null, article)
 
-@sanitizeAndSave = (callback) => (err, article) =>
+@sanitizeAndSave = (callback) -> (err, article) ->
   return callback err if err
   # Send new content call to Sailthru on any published article save
   if article.published or article.scheduled_publish_at
     article = setOnPublishFields article
     indexForSearch(article, ->) if article.indexable
-    distributeArticle article, =>
+    distributeArticle article, ->
       db.articles.save sanitize(article), callback
   else
     indexForSearch(article, ->) if article.indexable
@@ -177,7 +177,10 @@ sanitize = (article) ->
     title: sanitizeHtml article.title?.replace /\n/g, ''
     thumbnail_title: sanitizeHtml article.thumbnail_title
     lead_paragraph: sanitizeHtml article.lead_paragraph
+    postscript: sanitizeHtml article.postscript
     sections: sections
+  if article.news_source
+    sanitized.news_source.url = sanitizeLink article.news_source.url
   if article.hero_section?.caption
     sanitized.hero_section.caption = sanitizeHtml article.hero_section.caption
   if article.media
@@ -187,8 +190,15 @@ sanitize = (article) ->
   sanitized
 
 sanitizeLink = (urlString) ->
+  return unless urlString
   u = url.parse urlString
-  if u.protocol then urlString else 'http://' + u.href
+  if u.protocol
+    if u.protocol is "http:"
+      urlString.replace("http:", "https:")
+    else
+      urlString
+  else
+    'https://' + u.href
 
 sanitizeHtml = (html) ->
   return xss html unless try $ = cheerio.load html, decodeEntities: false

--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -192,12 +192,17 @@ sanitize = (article) ->
 sanitizeLink = (urlString) ->
   return unless urlString
   u = url.parse urlString
-  return urlString if u.protocol is "https:"
+
+  if u.hostname is "www.artsy.net"
+    urlString = urlString.replace("www.", "")
+
+  if urlString.includes("artsy.net")
+    urlString = urlString.replace("http:", "https:")
 
   if u.protocol
-    urlString.replace("http:", "https:") if u.hostname is "artsy.net"
+    return urlString
   else
-    'https://' + u.href
+    return 'https://' + u.href
 
 sanitizeHtml = (html) ->
   return xss html unless try $ = cheerio.load html, decodeEntities: false

--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -13,6 +13,8 @@ Article = require './index'
 { distributeArticle, deleteArticleFromSailthru, getArticleUrl, indexForSearch } = require './distribute'
 { ARTSY_URL, GEMINI_CLOUDFRONT_URL } = process.env
 artsyXapp = require('artsy-xapp')
+{ sanitizeLink } = require "./sanitize.ts"
+
 
 @onPublish = (article, cb) =>
   unless article.published_at or article.scheduled_publish_at
@@ -188,21 +190,6 @@ sanitize = (article) ->
     sanitized.media.description = sanitizeHtml media.description if media.description
     sanitized.media.credits = sanitizeHtml media.credits if media.credits
   sanitized
-
-sanitizeLink = (urlString) ->
-  return unless urlString
-  u = url.parse urlString
-
-  if u.hostname is "www.artsy.net"
-    urlString = urlString.replace("www.", "")
-
-  if urlString.includes("artsy.net")
-    urlString = urlString.replace("http:", "https:")
-
-  if u.protocol
-    return urlString
-  else
-    return 'https://' + u.href
 
 sanitizeHtml = (html) ->
   return xss html unless try $ = cheerio.load html, decodeEntities: false

--- a/src/api/apps/articles/test/model/index/persistence.spec.ts
+++ b/src/api/apps/articles/test/model/index/persistence.spec.ts
@@ -431,9 +431,9 @@ describe("Article Persistence", () => {
 
     it("escapes xss", done => {
       const body =
-        '<h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com">Aloha</a></p>'
+        '<h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="https://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="https://foo.com">Aloha</a></p>'
       const badBody =
-        '<script>alert(foo)</script><h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com">Aloha</a></p>'
+        '<script>alert(foo)</script><h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="https://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="https://foo.com">Aloha</a></p>'
       Article.save(
         {
           id: "5086df098523e60002000018",
@@ -504,10 +504,10 @@ describe("Article Persistence", () => {
           article.sections[3].items[0].caption.should.equal(
             '<p>abcd abcd</p>&lt;svg onload="alert(1)"/&gt;'
           )
-          article.sections[4].url.should.equal("http://maps.google.com")
+          article.sections[4].url.should.equal("https://maps.google.com")
           article.sections[4].height.should.equal("400")
           article.sections[4].mobile_height.should.equal("300")
-          article.sections[5].url.should.equal("http://some-link.com")
+          article.sections[5].url.should.equal("https://some-link.com")
           done()
         }
       )
@@ -554,10 +554,10 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.sections[0].body.should.equal(
-            '<a href="http://foo.com">Foo</a>'
+            '<a href="https://foo.com">Foo</a>'
           )
           article.sections[1].body.should.equal(
-            '<a href="http://www.bar.com">Foo</a>'
+            '<a href="https://www.bar.com">Foo</a>'
           )
           done()
         }
@@ -577,7 +577,7 @@ describe("Article Persistence", () => {
               images: [
                 {
                   type: "image",
-                  url: "http://foo.com",
+                  url: "https://foo.com",
                 },
               ],
             },
@@ -594,10 +594,10 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.sections[0].body.should.equal(
-            '<a href="http://foo.com">Foo</a>'
+            '<a href="https://foo.com">Foo</a>'
           )
-          article.sections[1].images[0].url.should.equal("http://foo.com")
-          article.sections[2].url.should.equal("http://foo.com/watch")
+          article.sections[1].images[0].url.should.equal("https://foo.com")
+          article.sections[2].url.should.equal("https://foo.com/watch")
           done()
         }
       ))
@@ -714,15 +714,15 @@ describe("Article Persistence", () => {
           author_id: "5086df098523e60002000018",
           is_super_article: true,
           super_article: {
-            partner_link: "http://partnerlink.com",
-            partner_logo: "http://partnerlink.com/logo.jpg",
+            partner_link: "https://partnerlink.com",
+            partner_logo: "https://partnerlink.com/logo.jpg",
             partner_fullscreen_header_logo:
-              "http://partnerlink.com/blacklogo.jpg",
+              "https://partnerlink.com/blacklogo.jpg",
             partner_link_title: "Download The App",
-            partner_logo_link: "http://itunes",
-            secondary_partner_logo: "http://secondarypartner.com/logo.png",
+            partner_logo_link: "https://itunes",
+            secondary_partner_logo: "https://secondarypartner.com/logo.png",
             secondary_logo_text: "In Partnership With",
-            secondary_logo_link: "http://secondary",
+            secondary_logo_link: "https://secondary",
             footer_blurb: "This is a Footer Blurb",
             related_articles: ["5530e72f7261696238050000"],
             footer_title: "Footer Title",
@@ -736,26 +736,26 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.super_article.partner_link.should.equal(
-            "http://partnerlink.com"
+            "https://partnerlink.com"
           )
           article.super_article.partner_logo.should.equal(
-            "http://partnerlink.com/logo.jpg"
+            "https://partnerlink.com/logo.jpg"
           )
           article.super_article.partner_link_title.should.equal(
             "Download The App"
           )
-          article.super_article.partner_logo_link.should.equal("http://itunes")
+          article.super_article.partner_logo_link.should.equal("https://itunes")
           article.super_article.partner_fullscreen_header_logo.should.equal(
-            "http://partnerlink.com/blacklogo.jpg"
+            "https://partnerlink.com/blacklogo.jpg"
           )
           article.super_article.secondary_partner_logo.should.equal(
-            "http://secondarypartner.com/logo.png"
+            "https://secondarypartner.com/logo.png"
           )
           article.super_article.secondary_logo_text.should.equal(
             "In Partnership With"
           )
           article.super_article.secondary_logo_link.should.equal(
-            "http://secondary"
+            "https://secondary"
           )
           article.super_article.footer_blurb.should.equal(
             "This is a Footer Blurb"
@@ -803,7 +803,7 @@ describe("Article Persistence", () => {
               type: "callout",
               text: "The Title Goes Here",
               article: "",
-              thumbnail_url: "http://image.jpg",
+              thumbnail_url: "https://image.jpg",
               hide_image: false,
             },
             {
@@ -831,7 +831,7 @@ describe("Article Persistence", () => {
           }
           article.sections[0].type.should.equal("callout")
           article.sections[0].text.should.equal("The Title Goes Here")
-          article.sections[0].thumbnail_url.should.equal("http://image.jpg")
+          article.sections[0].thumbnail_url.should.equal("https://image.jpg")
           article.sections[1].type.should.equal("text")
           article.sections[3].type.should.equal("text")
           article.sections[2].article.should.equal("53da550a726169083c0a0700")
@@ -902,7 +902,7 @@ describe("Article Persistence", () => {
                   slug: "andy-warhol",
                   title: "The Piece",
                   date: "2015-04-01",
-                  image: "http://image.png",
+                  image: "https://image.png",
                   credit: "Credit Line",
                 },
               ],
@@ -936,7 +936,7 @@ describe("Article Persistence", () => {
             {
               type: "social_embed",
               layout: "column_width",
-              url: "http://instagram.com/foo",
+              url: "https://instagram.com/foo",
             },
           ],
         },
@@ -947,7 +947,7 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.sections[0].layout.should.equal("column_width")
-          article.sections[0].url.should.equal("http://instagram.com/foo")
+          article.sections[0].url.should.equal("https://instagram.com/foo")
           article.sections[0].type.should.equal("social_embed")
           done()
         }
@@ -1291,7 +1291,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "http://youtube.com",
+            url: "https://youtube.com",
             type: "video",
             caption: "This year was incredible.",
           },
@@ -1302,7 +1302,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("http://youtube.com")
+          article.hero_section.url.should.equal("https://youtube.com")
           article.hero_section.type.should.equal("video")
           article.hero_section.caption.should.equal("This year was incredible.")
           done()
@@ -1313,7 +1313,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "http://image.com",
+            url: "https://image.com",
             type: "fullscreen",
             deck: "This year was incredible.",
           },
@@ -1324,7 +1324,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("http://image.com")
+          article.hero_section.url.should.equal("https://image.com")
           article.hero_section.type.should.equal("fullscreen")
           article.hero_section.deck.should.equal("This year was incredible.")
           done()
@@ -1335,7 +1335,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "http://image.com",
+            url: "https://image.com",
             type: "text",
             deck: "This year was incredible.",
           },
@@ -1346,7 +1346,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("http://image.com")
+          article.hero_section.url.should.equal("https://image.com")
           article.hero_section.type.should.equal("text")
           article.hero_section.deck.should.equal("This year was incredible.")
           done()
@@ -1357,7 +1357,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "http://image.com",
+            url: "https://image.com",
             type: "split",
             deck: "This year was incredible.",
           },
@@ -1368,7 +1368,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("http://image.com")
+          article.hero_section.url.should.equal("https://image.com")
           article.hero_section.type.should.equal("split")
           article.hero_section.deck.should.equal("This year was incredible.")
           done()
@@ -1379,10 +1379,10 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "http://image.com",
+            url: "https://image.com",
             type: "basic",
             deck: "This year was incredible.",
-            cover_image_url: "http://some-cover-image.png",
+            cover_image_url: "https://some-cover-image.png",
           },
         },
         "foo",
@@ -1391,10 +1391,10 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("http://image.com")
+          article.hero_section.url.should.equal("https://image.com")
           article.hero_section.type.should.equal("basic")
           article.hero_section.cover_image_url.should.equal(
-            "http://some-cover-image.png"
+            "https://some-cover-image.png"
           )
           done()
         }
@@ -1404,7 +1404,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "http://image.com",
+            url: "https://image.com",
             type: "series",
           },
         },
@@ -1414,7 +1414,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("http://image.com")
+          article.hero_section.url.should.equal("https://image.com")
           article.hero_section.type.should.equal("series")
           done()
         }

--- a/src/api/apps/articles/test/model/index/persistence.spec.ts
+++ b/src/api/apps/articles/test/model/index/persistence.spec.ts
@@ -431,9 +431,9 @@ describe("Article Persistence", () => {
 
     it("escapes xss", done => {
       const body =
-        '<h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="https://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="https://foo.com">Aloha</a></p>'
+        '<h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com/">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com/">Aloha</a></p>'
       const badBody =
-        '<script>alert(foo)</script><h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="https://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="https://foo.com">Aloha</a></p>'
+        '<script>alert(foo)</script><h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com">Aloha</a></p>'
       Article.save(
         {
           id: "5086df098523e60002000018",
@@ -504,10 +504,10 @@ describe("Article Persistence", () => {
           article.sections[3].items[0].caption.should.equal(
             '<p>abcd abcd</p>&lt;svg onload="alert(1)"/&gt;'
           )
-          article.sections[4].url.should.equal("https://maps.google.com")
+          article.sections[4].url.should.equal("https://maps.google.com/")
           article.sections[4].height.should.equal("400")
           article.sections[4].mobile_height.should.equal("300")
-          article.sections[5].url.should.equal("https://some-link.com")
+          article.sections[5].url.should.equal("https://some-link.com/")
           done()
         }
       )
@@ -554,10 +554,10 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.sections[0].body.should.equal(
-            '<a href="https://foo.com">Foo</a>'
+            '<a href="https://foo.com/">Foo</a>'
           )
           article.sections[1].body.should.equal(
-            '<a href="https://www.bar.com">Foo</a>'
+            '<a href="https://www.bar.com/">Foo</a>'
           )
           done()
         }
@@ -577,7 +577,7 @@ describe("Article Persistence", () => {
               images: [
                 {
                   type: "image",
-                  url: "https://foo.com",
+                  url: "http://foo.com",
                 },
               ],
             },
@@ -594,9 +594,9 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.sections[0].body.should.equal(
-            '<a href="https://foo.com">Foo</a>'
+            '<a href="https://foo.com/">Foo</a>'
           )
-          article.sections[1].images[0].url.should.equal("https://foo.com")
+          article.sections[1].images[0].url.should.equal("http://foo.com")
           article.sections[2].url.should.equal("https://foo.com/watch")
           done()
         }
@@ -714,15 +714,15 @@ describe("Article Persistence", () => {
           author_id: "5086df098523e60002000018",
           is_super_article: true,
           super_article: {
-            partner_link: "https://partnerlink.com",
-            partner_logo: "https://partnerlink.com/logo.jpg",
+            partner_link: "http://partnerlink.com",
+            partner_logo: "http://partnerlink.com/logo.jpg",
             partner_fullscreen_header_logo:
-              "https://partnerlink.com/blacklogo.jpg",
+              "http://partnerlink.com/blacklogo.jpg",
             partner_link_title: "Download The App",
-            partner_logo_link: "https://itunes",
-            secondary_partner_logo: "https://secondarypartner.com/logo.png",
+            partner_logo_link: "http://itunes",
+            secondary_partner_logo: "http://secondarypartner.com/logo.png",
             secondary_logo_text: "In Partnership With",
-            secondary_logo_link: "https://secondary",
+            secondary_logo_link: "http://secondary",
             footer_blurb: "This is a Footer Blurb",
             related_articles: ["5530e72f7261696238050000"],
             footer_title: "Footer Title",
@@ -736,26 +736,26 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.super_article.partner_link.should.equal(
-            "https://partnerlink.com"
+            "http://partnerlink.com"
           )
           article.super_article.partner_logo.should.equal(
-            "https://partnerlink.com/logo.jpg"
+            "http://partnerlink.com/logo.jpg"
           )
           article.super_article.partner_link_title.should.equal(
             "Download The App"
           )
-          article.super_article.partner_logo_link.should.equal("https://itunes")
+          article.super_article.partner_logo_link.should.equal("http://itunes")
           article.super_article.partner_fullscreen_header_logo.should.equal(
-            "https://partnerlink.com/blacklogo.jpg"
+            "http://partnerlink.com/blacklogo.jpg"
           )
           article.super_article.secondary_partner_logo.should.equal(
-            "https://secondarypartner.com/logo.png"
+            "http://secondarypartner.com/logo.png"
           )
           article.super_article.secondary_logo_text.should.equal(
             "In Partnership With"
           )
           article.super_article.secondary_logo_link.should.equal(
-            "https://secondary"
+            "http://secondary"
           )
           article.super_article.footer_blurb.should.equal(
             "This is a Footer Blurb"
@@ -803,7 +803,7 @@ describe("Article Persistence", () => {
               type: "callout",
               text: "The Title Goes Here",
               article: "",
-              thumbnail_url: "https://image.jpg",
+              thumbnail_url: "http://image.jpg",
               hide_image: false,
             },
             {
@@ -831,7 +831,7 @@ describe("Article Persistence", () => {
           }
           article.sections[0].type.should.equal("callout")
           article.sections[0].text.should.equal("The Title Goes Here")
-          article.sections[0].thumbnail_url.should.equal("https://image.jpg")
+          article.sections[0].thumbnail_url.should.equal("http://image.jpg")
           article.sections[1].type.should.equal("text")
           article.sections[3].type.should.equal("text")
           article.sections[2].article.should.equal("53da550a726169083c0a0700")
@@ -902,7 +902,7 @@ describe("Article Persistence", () => {
                   slug: "andy-warhol",
                   title: "The Piece",
                   date: "2015-04-01",
-                  image: "https://image.png",
+                  image: "http://image.png",
                   credit: "Credit Line",
                 },
               ],
@@ -936,7 +936,7 @@ describe("Article Persistence", () => {
             {
               type: "social_embed",
               layout: "column_width",
-              url: "https://instagram.com/foo",
+              url: "http://instagram.com/foo",
             },
           ],
         },
@@ -947,7 +947,7 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.sections[0].layout.should.equal("column_width")
-          article.sections[0].url.should.equal("https://instagram.com/foo")
+          article.sections[0].url.should.equal("http://instagram.com/foo")
           article.sections[0].type.should.equal("social_embed")
           done()
         }
@@ -1291,7 +1291,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "https://youtube.com",
+            url: "http://youtube.com",
             type: "video",
             caption: "This year was incredible.",
           },
@@ -1302,7 +1302,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("https://youtube.com")
+          article.hero_section.url.should.equal("http://youtube.com")
           article.hero_section.type.should.equal("video")
           article.hero_section.caption.should.equal("This year was incredible.")
           done()
@@ -1313,7 +1313,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "https://image.com",
+            url: "http://image.com",
             type: "fullscreen",
             deck: "This year was incredible.",
           },
@@ -1324,7 +1324,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("https://image.com")
+          article.hero_section.url.should.equal("http://image.com")
           article.hero_section.type.should.equal("fullscreen")
           article.hero_section.deck.should.equal("This year was incredible.")
           done()
@@ -1335,7 +1335,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "https://image.com",
+            url: "http://image.com",
             type: "text",
             deck: "This year was incredible.",
           },
@@ -1346,7 +1346,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("https://image.com")
+          article.hero_section.url.should.equal("http://image.com")
           article.hero_section.type.should.equal("text")
           article.hero_section.deck.should.equal("This year was incredible.")
           done()
@@ -1357,7 +1357,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "https://image.com",
+            url: "http://image.com",
             type: "split",
             deck: "This year was incredible.",
           },
@@ -1368,7 +1368,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("https://image.com")
+          article.hero_section.url.should.equal("http://image.com")
           article.hero_section.type.should.equal("split")
           article.hero_section.deck.should.equal("This year was incredible.")
           done()
@@ -1379,10 +1379,10 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "https://image.com",
+            url: "http://image.com",
             type: "basic",
             deck: "This year was incredible.",
-            cover_image_url: "https://some-cover-image.png",
+            cover_image_url: "http://some-cover-image.png",
           },
         },
         "foo",
@@ -1391,10 +1391,10 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("https://image.com")
+          article.hero_section.url.should.equal("http://image.com")
           article.hero_section.type.should.equal("basic")
           article.hero_section.cover_image_url.should.equal(
-            "https://some-cover-image.png"
+            "http://some-cover-image.png"
           )
           done()
         }
@@ -1404,7 +1404,7 @@ describe("Article Persistence", () => {
       Article.save(
         {
           hero_section: {
-            url: "https://image.com",
+            url: "http://image.com",
             type: "series",
           },
         },
@@ -1414,7 +1414,7 @@ describe("Article Persistence", () => {
           if (err) {
             done(err)
           }
-          article.hero_section.url.should.equal("https://image.com")
+          article.hero_section.url.should.equal("http://image.com")
           article.hero_section.type.should.equal("series")
           done()
         }
@@ -1513,7 +1513,7 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.news_source.title.should.equal("The New York Times")
-          article.news_source.url.should.equal("https://nytimes.com")
+          article.news_source.url.should.equal("https://nytimes.com/")
           done()
         }
       ))

--- a/src/api/apps/articles/test/model/save.spec.ts
+++ b/src/api/apps/articles/test/model/save.spec.ts
@@ -468,7 +468,7 @@ describe("Save", () => {
         ],
       }))
 
-    it("repalaces http protocol with https for artsy links", done =>
+    it("replaces http with https for artsy links", done =>
       Save.sanitizeAndSave(() =>
         Article.find("5086df098523e60002000011", (err, article) => {
           if (err) {
@@ -485,6 +485,27 @@ describe("Save", () => {
           {
             type: "text",
             body: "<a href='http://artsy.net/artist/andy-warhol'>link</a>",
+          },
+        ],
+      }))
+
+    it("removes www from artsy links", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.sections[0].body.should.containEql(
+            '<a href="https://artsy.net/artist/andy-warhol">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        sections: [
+          {
+            type: "text",
+            body: "<a href='http://www.artsy.net/artist/andy-warhol'>link</a>",
           },
         ],
       }))

--- a/src/api/apps/articles/test/model/save.spec.ts
+++ b/src/api/apps/articles/test/model/save.spec.ts
@@ -447,14 +447,14 @@ describe("Save", () => {
         ],
       }))
 
-    it("inserts protocol for non artsy links", done =>
+    it("sanitizes non artsy links", done =>
       Save.sanitizeAndSave(() =>
         Article.find("5086df098523e60002000011", (err, article) => {
           if (err) {
             done(err)
           }
           article.sections[0].body.should.containEql(
-            '<a href="https://insecure-website.com">link</a>'
+            '<a href="http://insecure-website.com/">link</a><a href="https://insecure-website.com/">link</a>'
           )
           done()
         })
@@ -463,19 +463,20 @@ describe("Save", () => {
         sections: [
           {
             type: "text",
-            body: "<a href='insecure-website.com'>link</a>",
+            body:
+              "<a href='http://insecure-website.com'>link</a><a href='insecure-website.com'>link</a>",
           },
         ],
       }))
 
-    it("replaces http with https for artsy links", done =>
+    it("sanitizes www.artsy.net links", done =>
       Save.sanitizeAndSave(() =>
         Article.find("5086df098523e60002000011", (err, article) => {
           if (err) {
             done(err)
           }
           article.sections[0].body.should.containEql(
-            '<a href="https://artsy.net/artist/andy-warhol">link</a>'
+            '<a href="https://www.artsy.net/artist/andy-warhol">link</a>'
           )
           done()
         })
@@ -489,14 +490,14 @@ describe("Save", () => {
         ],
       }))
 
-    it("removes www from artsy links", done =>
+    it("sanitizes *.artsy.net links", done =>
       Save.sanitizeAndSave(() =>
         Article.find("5086df098523e60002000011", (err, article) => {
           if (err) {
             done(err)
           }
           article.sections[0].body.should.containEql(
-            '<a href="https://artsy.net/artist/andy-warhol">link</a>'
+            '<a href="https://folio.artsy.net/">link</a>'
           )
           done()
         })
@@ -505,28 +506,7 @@ describe("Save", () => {
         sections: [
           {
             type: "text",
-            body: "<a href='http://www.artsy.net/artist/andy-warhol'>link</a>",
-          },
-        ],
-      }))
-
-    it("does not change http protocol for non artsy links", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.sections[0].body.should.containEql(
-            '<a href="http://insecure-website.com">link</a>'
-          )
-          done()
-        })
-      )(null, {
-        _id: ObjectId("5086df098523e60002000011"),
-        sections: [
-          {
-            type: "text",
-            body: "<a href='http://insecure-website.com'>link</a>",
+            body: "<a href='http://folio.artsy.net'>link</a>",
           },
         ],
       }))
@@ -538,7 +518,7 @@ describe("Save", () => {
             done(err)
           }
           article.lead_paragraph.should.containEql(
-            '<a href="https://insecure-website.com">link</a><a href="https://artsy.net/artist/andy-warhol">artsy link</a>'
+            '<a href="https://insecure-website.com/">link</a><a href="https://www.artsy.net/artist/andy-warhol">artsy link</a>'
           )
           done()
         })
@@ -555,7 +535,7 @@ describe("Save", () => {
             done(err)
           }
           article.postscript.should.containEql(
-            '<a href="https://insecure-website.com">link</a><a href="https://artsy.net/artist/andy-warhol">artsy link</a>'
+            '<a href="https://insecure-website.com/">link</a><a href="https://www.artsy.net/artist/andy-warhol">artsy link</a>'
           )
           done()
         })
@@ -572,7 +552,7 @@ describe("Save", () => {
             done(err)
           }
           article.news_source.url.should.containEql(
-            "https://artsy.net/artist/andy-warhol"
+            "https://www.artsy.net/artist/andy-warhol"
           )
           done()
         })

--- a/src/api/apps/articles/test/model/save.spec.ts
+++ b/src/api/apps/articles/test/model/save.spec.ts
@@ -447,6 +447,77 @@ describe("Save", () => {
         ],
       }))
 
+    it("repalaces http with https in sanitized links", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.sections[0].body.should.containEql(
+            '<a href="https://insecure-website.com">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        sections: [
+          {
+            type: "text",
+            body: "<a href='http://insecure-website.com'>link</a>",
+          },
+        ],
+      }))
+
+    it("sanitizes lead_paragraph", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.lead_paragraph.should.containEql(
+            '<a href="https://insecure-website.com">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        lead_paragraph: "<a href='http://insecure-website.com'>link</a>",
+      }))
+
+    it("sanitizes postscript", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.postscript.should.containEql(
+            '<a href="https://insecure-website.com">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        postscript: "<a href='http://insecure-website.com'>link</a>",
+      }))
+
+    it("sanitizes news_source", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.news_source.url.should.containEql(
+            "https://insecure-website.com"
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        news_source: {
+          url: "http://insecure-website.com",
+        },
+      }))
+
     it("can save follow artist links (whitelist data-id)", done =>
       Save.sanitizeAndSave(() =>
         Article.find("5086df098523e60002000011", (err, article) => {

--- a/src/api/apps/articles/test/model/save.spec.ts
+++ b/src/api/apps/articles/test/model/save.spec.ts
@@ -447,7 +447,7 @@ describe("Save", () => {
         ],
       }))
 
-    it("repalaces http with https in sanitized links", done =>
+    it("inserts protocol for non artsy links", done =>
       Save.sanitizeAndSave(() =>
         Article.find("5086df098523e60002000011", (err, article) => {
           if (err) {
@@ -455,6 +455,48 @@ describe("Save", () => {
           }
           article.sections[0].body.should.containEql(
             '<a href="https://insecure-website.com">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        sections: [
+          {
+            type: "text",
+            body: "<a href='insecure-website.com'>link</a>",
+          },
+        ],
+      }))
+
+    it("repalaces http protocol with https for artsy links", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.sections[0].body.should.containEql(
+            '<a href="https://artsy.net/artist/andy-warhol">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        sections: [
+          {
+            type: "text",
+            body: "<a href='http://artsy.net/artist/andy-warhol'>link</a>",
+          },
+        ],
+      }))
+
+    it("does not change http protocol for non artsy links", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.sections[0].body.should.containEql(
+            '<a href="http://insecure-website.com">link</a>'
           )
           done()
         })
@@ -475,13 +517,14 @@ describe("Save", () => {
             done(err)
           }
           article.lead_paragraph.should.containEql(
-            '<a href="https://insecure-website.com">link</a>'
+            '<a href="https://insecure-website.com">link</a><a href="https://artsy.net/artist/andy-warhol">artsy link</a>'
           )
           done()
         })
       )(null, {
         _id: ObjectId("5086df098523e60002000011"),
-        lead_paragraph: "<a href='http://insecure-website.com'>link</a>",
+        lead_paragraph:
+          '<a href="insecure-website.com">link</a><a href="http://artsy.net/artist/andy-warhol">artsy link</a>',
       }))
 
     it("sanitizes postscript", done =>
@@ -491,13 +534,14 @@ describe("Save", () => {
             done(err)
           }
           article.postscript.should.containEql(
-            '<a href="https://insecure-website.com">link</a>'
+            '<a href="https://insecure-website.com">link</a><a href="https://artsy.net/artist/andy-warhol">artsy link</a>'
           )
           done()
         })
       )(null, {
         _id: ObjectId("5086df098523e60002000011"),
-        postscript: "<a href='http://insecure-website.com'>link</a>",
+        postscript:
+          '<a href="insecure-website.com">link</a><a href="http://artsy.net/artist/andy-warhol">artsy link</a>',
       }))
 
     it("sanitizes news_source", done =>
@@ -507,14 +551,14 @@ describe("Save", () => {
             done(err)
           }
           article.news_source.url.should.containEql(
-            "https://insecure-website.com"
+            "https://artsy.net/artist/andy-warhol"
           )
           done()
         })
       )(null, {
         _id: ObjectId("5086df098523e60002000011"),
         news_source: {
-          url: "http://insecure-website.com",
+          url: "http://artsy.net/artist/andy-warhol",
         },
       }))
 

--- a/src/api/apps/articles/test/sanitize.test.ts
+++ b/src/api/apps/articles/test/sanitize.test.ts
@@ -1,0 +1,42 @@
+import { sanitizeLink } from "../model/sanitize"
+
+describe("#sanitizeLink", () => {
+  it("skips sanitizing links that do not have an href", () => {
+    expect(sanitizeLink("")).toBeUndefined()
+  })
+
+  it("inserts protocol for non artsy links", () => {
+    expect(sanitizeLink("insecure-website.com")).toBe(
+      "https://insecure-website.com/"
+    )
+  })
+
+  it("does not change existing protocol for external links", () => {
+    expect(sanitizeLink("http://insecure-website.com")).toBe(
+      "http://insecure-website.com/"
+    )
+  })
+
+  it("inserts protocol for artsy links", () => {
+    expect(sanitizeLink("folio.artsy.net")).toBe("https://folio.artsy.net/")
+    expect(sanitizeLink("artsy.net")).toBe("https://www.artsy.net/")
+  })
+
+  it("replaces http with https for www.artsy.net links", () => {
+    expect(sanitizeLink("http://artsy.net/artist/andy-warhol")).toBe(
+      "https://www.artsy.net/artist/andy-warhol"
+    )
+  })
+
+  it("replaces http with https for *.artsy.net links", () => {
+    expect(sanitizeLink("http://folio.artsy.net")).toBe(
+      "https://folio.artsy.net/"
+    )
+  })
+
+  it("adds www to artsy links", () => {
+    expect(sanitizeLink("http://artsy.net/artist/andy-warhol")).toBe(
+      "https://www.artsy.net/artist/andy-warhol"
+    )
+  })
+})


### PR DESCRIPTION
Updates `sanitizeLink` to: 
- add https protocol if no protocol present
- use https for all artsy links
- add `www.` to `artsy.net` links
- use typescript
 
Also adds `news_source.url` and `postscript` to fields sanitized on save.

I've run the updated `sanitizeAndSave` as a backfill against staging to confirmed all works as expected. 

https://artsyproduct.atlassian.net/browse/PLATFORM-2715