### PR TITLE
Un-revert #2801

### DIFF
--- a/src/api/apps/articles/model/sanitize.js
+++ b/src/api/apps/articles/model/sanitize.js
@@ -1,0 +1,24 @@
+// @ts-check
+import { URL } from "url"
+
+// FIXME: cannot use typescript in yarn task commands
+export const sanitizeLink = urlString => {
+  let url
+  if (!urlString) {
+    return
+  }
+  try {
+    url = new URL(urlString)
+  } catch (_e) {
+    url = new URL(`https://${urlString}`)
+  }
+
+  if (url.hostname === "artsy.net") {
+    url.hostname = "www.artsy.net"
+  }
+  if (url.hostname.includes(".artsy.net")) {
+    url.protocol = "https:"
+  }
+
+  return url.href
+}

--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -180,7 +180,7 @@ sanitize = (article) ->
     lead_paragraph: sanitizeHtml article.lead_paragraph
     postscript: sanitizeHtml article.postscript
     sections: sections
-  if article.news_source
+  if article.news_source?.url
     sanitized.news_source.url = sanitizeLink article.news_source.url
   if article.hero_section?.caption
     sanitized.hero_section.caption = sanitizeHtml article.hero_section.caption

--- a/src/api/apps/articles/test/model/index/persistence.spec.ts
+++ b/src/api/apps/articles/test/model/index/persistence.spec.ts
@@ -431,7 +431,7 @@ describe("Article Persistence", () => {
 
     it("escapes xss", done => {
       const body =
-        '<h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com">Aloha</a></p>'
+        '<h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com/">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com/">Aloha</a></p>'
       const badBody =
         '<script>alert(foo)</script><h2>Hi</h2><h3>Hello</h3><p><b>Hola</b></p><p><i>Guten Tag</i></p><ol><li>Bonjour<br></li><li><a href="http://www.foo.com">Bonjour2</a></li></ol><ul><li>Aloha</li><li>Aloha Again</li></ul><h2><b><i>Good bye</i></b></h2><p><b><i>Adios</i></b></p><h3>Alfiederzen</h3><p><a href="http://foo.com">Aloha</a></p>'
       Article.save(
@@ -504,10 +504,10 @@ describe("Article Persistence", () => {
           article.sections[3].items[0].caption.should.equal(
             '<p>abcd abcd</p>&lt;svg onload="alert(1)"/&gt;'
           )
-          article.sections[4].url.should.equal("http://maps.google.com")
+          article.sections[4].url.should.equal("https://maps.google.com/")
           article.sections[4].height.should.equal("400")
           article.sections[4].mobile_height.should.equal("300")
-          article.sections[5].url.should.equal("http://some-link.com")
+          article.sections[5].url.should.equal("https://some-link.com/")
           done()
         }
       )
@@ -554,10 +554,10 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.sections[0].body.should.equal(
-            '<a href="http://foo.com">Foo</a>'
+            '<a href="https://foo.com/">Foo</a>'
           )
           article.sections[1].body.should.equal(
-            '<a href="http://www.bar.com">Foo</a>'
+            '<a href="https://www.bar.com/">Foo</a>'
           )
           done()
         }
@@ -594,10 +594,10 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.sections[0].body.should.equal(
-            '<a href="http://foo.com">Foo</a>'
+            '<a href="https://foo.com/">Foo</a>'
           )
           article.sections[1].images[0].url.should.equal("http://foo.com")
-          article.sections[2].url.should.equal("http://foo.com/watch")
+          article.sections[2].url.should.equal("https://foo.com/watch")
           done()
         }
       ))
@@ -1513,7 +1513,7 @@ describe("Article Persistence", () => {
             done(err)
           }
           article.news_source.title.should.equal("The New York Times")
-          article.news_source.url.should.equal("https://nytimes.com")
+          article.news_source.url.should.equal("https://nytimes.com/")
           done()
         }
       ))

--- a/src/api/apps/articles/test/model/sanitize.test.ts
+++ b/src/api/apps/articles/test/model/sanitize.test.ts
@@ -1,0 +1,42 @@
+import { sanitizeLink } from "../../model/sanitize"
+
+describe("#sanitizeLink", () => {
+  it("skips sanitizing links that do not have an href", () => {
+    expect(sanitizeLink("")).toBeUndefined()
+  })
+
+  it("inserts protocol for non artsy links", () => {
+    expect(sanitizeLink("insecure-website.com")).toBe(
+      "https://insecure-website.com/"
+    )
+  })
+
+  it("does not change existing protocol for external links", () => {
+    expect(sanitizeLink("http://insecure-website.com")).toBe(
+      "http://insecure-website.com/"
+    )
+  })
+
+  it("inserts protocol for artsy links", () => {
+    expect(sanitizeLink("folio.artsy.net")).toBe("https://folio.artsy.net/")
+    expect(sanitizeLink("artsy.net")).toBe("https://www.artsy.net/")
+  })
+
+  it("replaces http with https for www.artsy.net links", () => {
+    expect(sanitizeLink("http://artsy.net/artist/andy-warhol")).toBe(
+      "https://www.artsy.net/artist/andy-warhol"
+    )
+  })
+
+  it("replaces http with https for *.artsy.net links", () => {
+    expect(sanitizeLink("http://folio.artsy.net")).toBe(
+      "https://folio.artsy.net/"
+    )
+  })
+
+  it("adds www to artsy links", () => {
+    expect(sanitizeLink("http://artsy.net/artist/andy-warhol")).toBe(
+      "https://www.artsy.net/artist/andy-warhol"
+    )
+  })
+})

--- a/src/api/apps/articles/test/model/save.spec.ts
+++ b/src/api/apps/articles/test/model/save.spec.ts
@@ -447,6 +447,122 @@ describe("Save", () => {
         ],
       }))
 
+    it("sanitizes non artsy links", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.sections[0].body.should.containEql(
+            '<a href="http://insecure-website.com/">link</a><a href="https://insecure-website.com/">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        sections: [
+          {
+            type: "text",
+            body:
+              "<a href='http://insecure-website.com'>link</a><a href='insecure-website.com'>link</a>",
+          },
+        ],
+      }))
+
+    it("sanitizes www.artsy.net links", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.sections[0].body.should.containEql(
+            '<a href="https://www.artsy.net/artist/andy-warhol">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        sections: [
+          {
+            type: "text",
+            body: "<a href='http://artsy.net/artist/andy-warhol'>link</a>",
+          },
+        ],
+      }))
+
+    it("sanitizes *.artsy.net links", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.sections[0].body.should.containEql(
+            '<a href="https://folio.artsy.net/">link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        sections: [
+          {
+            type: "text",
+            body: "<a href='http://folio.artsy.net'>link</a>",
+          },
+        ],
+      }))
+
+    it("sanitizes lead_paragraph", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.lead_paragraph.should.containEql(
+            '<a href="https://insecure-website.com/">link</a><a href="https://www.artsy.net/artist/andy-warhol">artsy link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        lead_paragraph:
+          '<a href="insecure-website.com">link</a><a href="http://artsy.net/artist/andy-warhol">artsy link</a>',
+      }))
+
+    it("sanitizes postscript", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.postscript.should.containEql(
+            '<a href="https://insecure-website.com/">link</a><a href="https://www.artsy.net/artist/andy-warhol">artsy link</a>'
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        postscript:
+          '<a href="insecure-website.com">link</a><a href="http://artsy.net/artist/andy-warhol">artsy link</a>',
+      }))
+
+    it("sanitizes news_source", done =>
+      Save.sanitizeAndSave(() =>
+        Article.find("5086df098523e60002000011", (err, article) => {
+          if (err) {
+            done(err)
+          }
+          article.news_source.url.should.containEql(
+            "https://www.artsy.net/artist/andy-warhol"
+          )
+          done()
+        })
+      )(null, {
+        _id: ObjectId("5086df098523e60002000011"),
+        news_source: {
+          url: "http://artsy.net/artist/andy-warhol",
+        },
+      }))
+
     it("can save follow artist links (whitelist data-id)", done =>
       Save.sanitizeAndSave(() =>
         Article.find("5086df098523e60002000011", (err, article) => {


### PR DESCRIPTION
Puts back changes from #2801 

The `sanitize` file has been converted to es6 JS, typescript files were breaking the tasks because babel was not compiling correctly. I'm punting on the typescript issue and changing the extension to `.js`,  because we have proven examples of these tasks working with es6 as noted in docs: https://github.com/artsy/positron#running-tasks

The `yarn task` command runs successfully locally (was also broken in typescript).

Also adds a minor fix to the treatment of `news_source.url`, in `sanitizeOnSave`, which lead to Joi errors when saving articles.
