### PR TITLE
chore: Remove cohesion from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
   },
   "devDependencies": {
     "@artsy/antigravity": "0.2.0",
-    "@artsy/cohesion": "1.44.0",
     "@cypress/webpack-preprocessor": "4.1.3",
     "@sentry/browser": "4.6.4",
     "@testing-library/cypress": "5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,11 +35,6 @@
     superagent "^1.2.0"
     underscore "^1.8.3"
 
-"@artsy/cohesion@1.44.0":
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.44.0.tgz#c13ee91ea739af61b817e215a0dba0e8677547dc"
-  integrity sha512-SnKfCojWEIY0YwwP1kREtosH9LsuqkCvx8P6i7qu3LgXLNbuu4okFlIg7rDFRYWMJ3dhU5LmJ3sYX88FMEWg/g==
-
 "@artsy/cohesion@1.45.0":
   version "1.45.0"
   resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.45.0.tgz#f97ff2237033cf9704e452fb35a50b769dd4ef14"


### PR DESCRIPTION
Cohesion is not actually used by this repo, but was necessary to include while it was a `devDependency` in reaction. Following [this PR](https://github.com/artsy/reaction/pull/3658) it is safe to remove from Positron. 