### PR TITLE
chore: Show Admin Tab (on Article Edit) based on team role, not admin role.

### DIFF
--- a/src/client/apps/edit/components/header/index.tsx
+++ b/src/client/apps/edit/components/header/index.tsx
@@ -20,7 +20,7 @@ interface Props {
   deleteArticleAction: () => void
   edit: Edit
   forceURL: string
-  isAdmin: boolean
+  hasTeamRole: boolean
   publishArticleAction: () => void
   saveArticleAction: () => void
 }
@@ -168,7 +168,7 @@ export class EditHeader extends Component<Props> {
       channel,
       edit,
       forceURL,
-      isAdmin,
+      hasTeamRole,
     } = this.props
 
     const { isDeleting } = edit
@@ -186,7 +186,7 @@ export class EditHeader extends Component<Props> {
           >
             <Tab name="Content" />
             <Tab name="Display" />
-            {isAdmin && (<Tab name="Admin" /> as any)}
+            {hasTeamRole && (<Tab name="Admin" /> as any)}
           </Tabs>
         </TabContainer>
 
@@ -264,7 +264,7 @@ const mapStateToProps = state => ({
   channel: state.app.channel,
   edit: state.edit,
   forceURL: state.app.forceURL,
-  isAdmin: state.app.isAdmin,
+  hasTeamRole: state.app.hasTeamRole
 })
 
 const mapDispatchToProps = {

--- a/src/client/apps/edit/components/header/test/index.test.tsx
+++ b/src/client/apps/edit/components/header/test/index.test.tsx
@@ -38,7 +38,7 @@ describe("Edit Header Controls", () => {
         isSaving: false,
         isPublishing: false,
       },
-      isAdmin: false,
+      hasTeamRole: false,
       publishArticleAction: jest.fn(),
       saveArticleAction: jest.fn(),
     }
@@ -50,8 +50,8 @@ describe("Edit Header Controls", () => {
     expect(component.find("button").length).toBe(4)
   })
 
-  it("renders admin button for admin users", () => {
-    props.isAdmin = true
+  it("renders admin button for team users", () => {
+    props.hasTeamRole = true
     const component = getWrapper()
 
     expect(component.find("TabButton").length).toBe(2)

--- a/src/client/lib/setup/auth.coffee
+++ b/src/client/lib/setup/auth.coffee
@@ -9,6 +9,7 @@ passport = require 'passport'
 OAuth2Strategy = require 'passport-oauth2'
 User = require '../../models/user'
 Channel = require '../../models/channel'
+jwtDecode = require 'jwt-decode'
 
 setupPassport = ->
   passport.use 'artsy', new OAuth2Strategy
@@ -22,6 +23,7 @@ setupPassport = ->
       headers: 'X-Access-Token': accessToken
       error: (m, err) -> done err
       success: (user) ->
+        user.set 'roles', jwtDecode(accessToken).roles
         id = user.get('channel_ids').concat(user.get('partner_ids'))[0]
         id = process.env.DEFAULT_PARTNER_ID if not id and user.get('type') is 'Admin'
         new Channel(id: id).fetchChannelOrPartner

--- a/src/client/reducers/appReducer.ts
+++ b/src/client/reducers/appReducer.ts
@@ -24,6 +24,7 @@ export interface AppState {
   channel: ChannelState
   forceURL: string
   isAdmin: boolean
+  hasTeamRole: boolean
   isEditorial: boolean
   isPartnerChannel: boolean
   metaphysicsURL: string
@@ -43,6 +44,7 @@ export const getInitialState = () =>
     channel: sd.CURRENT_CHANNEL,
     forceURL: sd.FORCE_URL,
     isAdmin: sd.USER && sd.USER.type === "Admin",
+    hasTeamRole: sd.USER && sd.USER.roles && sd.USER.roles.includes("team"),
     isEditorial: sd.CURRENT_CHANNEL && sd.CURRENT_CHANNEL.type === "editorial",
     isPartnerChannel:
       sd.CURRENT_CHANNEL && sd.CURRENT_CHANNEL.type === "partner",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-2320.

Parse user's roles out of JWT per this [discussion](https://artsy.slack.com/archives/CP9P4KR35/p1607710756442900).

The [admin](https://github.com/artsy/positron/tree/master/src/client/apps/edit/components/admin) component [references](https://github.com/artsy/positron/blob/9446e57cbe657308baa11bd47e3b366e82c896a0/src/client/apps/edit/components/admin/components/article/article_authors.tsx#L91) bunch of app api routes. Those routes are open to non-admins for GET's, but many [require](https://github.com/artsy/positron/blob/9446e57cbe657308baa11bd47e3b366e82c896a0/src/api/apps/tags/index.coffee#L9) admin for `put/post/delete`. Those actions don't seem to be performed by the component, so I think no changes are required.

The component also [queries](https://github.com/artsy/positron/blob/9446e57cbe657308baa11bd47e3b366e82c896a0/src/client/apps/edit/components/admin/components/featuring/index.tsx#L11) Gravity/Metaphysics. I wonder if any changes are required there.

[settings](https://github.com/artsy/positron/tree/master/src/client/apps/settings) app is also restricted to `admin` role. The actions performed in it seem too sensitive for `team` role so I am leaving it alone. (But I wonder if [partner_access](https://github.com/artsy/gravity/blob/af499450c88ec8816936ee2178b5a0cf2e2c15d4/config/initializers/_user_roles.rb#L11) role is more appropriate here.)