### PR TITLE
fix: build.yml was mistakenly removed in pr#2889. adding it back.

### DIFF
--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -1,0 +1,5 @@
+---
+version: "2"
+services:
+  positron:
+{% include 'templates/docker-compose-service.yml.j2' %}


### PR DESCRIPTION
Caused staging build to fail with:
https://app.circleci.com/pipelines/github/artsy/positron/4081/workflows/1cfc8032-b2f2-4cf5-a876-97ef30377e3f/jobs/9090
```
No Yaml or Jinja templates found for build
```