### PR TITLE
chore: remove recursive chown from Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM node:12.18-alpine
 ARG COMMIT_HASH
 ENV PORT 3005
 EXPOSE 3005
-WORKDIR /app
 
 # Install system dependencies
 RUN apk add --no-cache --quiet \
@@ -14,18 +13,17 @@ RUN apk add --no-cache --quiet \
   # Add deploy user
   adduser -D -g '' deploy
 
-# Install the packages
-COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile && yarn cache clean
+# let everything here-on be done as deploy user who owns workdir.
+WORKDIR /app
+RUN chown deploy:deploy $(pwd)
+USER deploy
 
-# Update file/directory permissions
-RUN chown -R deploy:deploy ./
+# Install the packages
+COPY --chown=deploy:deploy package.json yarn.lock ./
+RUN yarn install --frozen-lockfile && yarn cache clean
 
 # Copy application code
 COPY --chown=deploy:deploy . ./
-
-# Switch to less-privileged user
-USER deploy
 
 # Ensure COMMIT_HASH is present
 # Run this step as late as possible b/c it busts docker cache.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:12.18-alpine
 
-ARG COMMIT_HASH
 ENV PORT 3005
 EXPOSE 3005
 
@@ -27,6 +26,7 @@ COPY --chown=deploy:deploy . ./
 
 # Ensure COMMIT_HASH is present
 # Run this step as late as possible b/c it busts docker cache.
+ARG COMMIT_HASH
 RUN test -n "$COMMIT_HASH" && \
   echo $COMMIT_HASH > COMMIT_HASH.txt
 


### PR DESCRIPTION
`chown -R` takes 10-20 minutes on my machine, together with COMMIT_HASH ARG busting docker cache upon every git commit, makes my local hokusai dev very time-consuming.

Following this [example](https://github.com/artsy/force/pull/5801/files), remove chown -R.

Move ARG to farther down the file so it busts less cache.