### PR TITLE
chore: Show Admin Tab (on Article Edit) based on team role, not admin role.

### DIFF
--- a/src/client/apps/edit/components/header/index.tsx
+++ b/src/client/apps/edit/components/header/index.tsx
@@ -20,7 +20,7 @@ interface Props {
   deleteArticleAction: () => void
   edit: Edit
   forceURL: string
-  isAdmin: boolean
+  hasTeamRole: boolean
   publishArticleAction: () => void
   saveArticleAction: () => void
 }
@@ -168,7 +168,7 @@ export class EditHeader extends Component<Props> {
       channel,
       edit,
       forceURL,
-      isAdmin,
+      hasTeamRole,
     } = this.props
 
     const { isDeleting } = edit
@@ -186,7 +186,7 @@ export class EditHeader extends Component<Props> {
           >
             <Tab name="Content" />
             <Tab name="Display" />
-            {isAdmin && (<Tab name="Admin" /> as any)}
+            {hasTeamRole && (<Tab name="Admin" /> as any)}
           </Tabs>
         </TabContainer>
 
@@ -264,7 +264,7 @@ const mapStateToProps = state => ({
   channel: state.app.channel,
   edit: state.edit,
   forceURL: state.app.forceURL,
-  isAdmin: state.app.isAdmin,
+  hasTeamRole: state.app.hasTeamRole
 })
 
 const mapDispatchToProps = {

--- a/src/client/apps/edit/components/header/test/index.test.tsx
+++ b/src/client/apps/edit/components/header/test/index.test.tsx
@@ -38,7 +38,7 @@ describe("Edit Header Controls", () => {
         isSaving: false,
         isPublishing: false,
       },
-      isAdmin: false,
+      hasTeamRole: false,
       publishArticleAction: jest.fn(),
       saveArticleAction: jest.fn(),
     }
@@ -50,8 +50,8 @@ describe("Edit Header Controls", () => {
     expect(component.find("button").length).toBe(4)
   })
 
-  it("renders admin button for admin users", () => {
-    props.isAdmin = true
+  it("renders admin button for team users", () => {
+    props.hasTeamRole = true
     const component = getWrapper()
 
     expect(component.find("TabButton").length).toBe(2)

--- a/src/client/lib/setup/auth.coffee
+++ b/src/client/lib/setup/auth.coffee
@@ -9,6 +9,7 @@ passport = require 'passport'
 OAuth2Strategy = require 'passport-oauth2'
 User = require '../../models/user'
 Channel = require '../../models/channel'
+jwtDecode = require 'jwt-decode'
 
 setupPassport = ->
   passport.use 'artsy', new OAuth2Strategy
@@ -22,6 +23,7 @@ setupPassport = ->
       headers: 'X-Access-Token': accessToken
       error: (m, err) -> done err
       success: (user) ->
+        user.set 'roles', jwtDecode(accessToken).roles
         id = user.get('channel_ids').concat(user.get('partner_ids'))[0]
         id = process.env.DEFAULT_PARTNER_ID if not id and user.get('type') is 'Admin'
         new Channel(id: id).fetchChannelOrPartner

--- a/src/client/reducers/appReducer.ts
+++ b/src/client/reducers/appReducer.ts
@@ -24,6 +24,7 @@ export interface AppState {
   channel: ChannelState
   forceURL: string
   isAdmin: boolean
+  hasTeamRole: boolean
   isEditorial: boolean
   isPartnerChannel: boolean
   metaphysicsURL: string
@@ -43,6 +44,7 @@ export const getInitialState = () =>
     channel: sd.CURRENT_CHANNEL,
     forceURL: sd.FORCE_URL,
     isAdmin: sd.USER && sd.USER.type === "Admin",
+    hasTeamRole: sd.USER && sd.USER.roles && sd.USER.roles.includes("team"),
     isEditorial: sd.CURRENT_CHANNEL && sd.CURRENT_CHANNEL.type === "editorial",
     isPartnerChannel:
       sd.CURRENT_CHANNEL && sd.CURRENT_CHANNEL.type === "partner",


### PR DESCRIPTION
The changes here were PR'd under https://github.com/artsy/positron/pull/2893 and deployed.

However, due to [report](https://artsy.slack.com/archives/C01ADJNCS5D/p1608154275456600) of the article-edit `admin` tab vanishing, I reverted the changes, under https://github.com/artsy/positron/pull/2901.

I am able to re-produce this behavior locally, that for an existing browser session (of my user who has both `team` and `admin` roles, when the changes are made effective by an app restart, the tab does dis-appear. However, upon logging out/in, the tab re-appears.

Therefore, it seems we can confidently attempt this change again. We should roll it out to staging, test there. When we go prod, we should let users know in advance that they will have to log out/in.

