### PR TITLE
feat: replace admin role restriction with team for SETTINGS

### DIFF
--- a/src/api/apps/articles/index.coffee
+++ b/src/api/apps/articles/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated } = require '../users/routes'
+{ setUser, authenticated, teamOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/articles', setUser, routes.index
 app.get '/articles/:id', routes.find, routes.show
-app.post '/articles', setUser, authenticated, routes.restrictFeature, routes.create
-app.put '/articles/:id', setUser, authenticated, routes.restrictFeature, routes.update
+app.post '/articles', setUser, authenticated, teamOnly, routes.create
+app.put '/articles/:id', setUser, authenticated, teamOnly, routes.update
 app.delete '/articles/:id', setUser, authenticated, routes.find, routes.delete

--- a/src/api/apps/articles/index.coffee
+++ b/src/api/apps/articles/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, teamOnly } = require '../users/routes'
+{ setUser, authenticated } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/articles', setUser, routes.index
 app.get '/articles/:id', routes.find, routes.show
-app.post '/articles', setUser, authenticated, teamOnly, routes.create
-app.put '/articles/:id', setUser, authenticated, teamOnly, routes.update
+app.post '/articles', setUser, authenticated, routes.restrictFeature, routes.create
+app.put '/articles/:id', setUser, authenticated, routes.restrictFeature, routes.update
 app.delete '/articles/:id', setUser, authenticated, routes.find, routes.delete

--- a/src/api/apps/articles/routes.coffee
+++ b/src/api/apps/articles/routes.coffee
@@ -57,13 +57,6 @@ User = require '../users/model.coffee'
     return next err if err
     res.send present req.article
 
-# Don't let non-admins feature
-@restrictFeature = (req, res, next) ->
-  if req.user?.type isnt 'Admin' and req.body.featured
-    res.err 401, 'You must be an admin to feature an article.'
-  else
-    next()
-
 # Fetch & attach a req.article middleware
 @find = (req, res, next) ->
   Article.find (req.params.id or req.query.article_id), (err, article) ->

--- a/src/api/apps/articles/routes.coffee
+++ b/src/api/apps/articles/routes.coffee
@@ -57,6 +57,12 @@ User = require '../users/model.coffee'
     return next err if err
     res.send present req.article
 
+@restrictFeature = (req, res, next) ->
+  if !req.user?.roles?.includes("team") and req.body.featured
+    res.err 401, 'You must have team role to feature an article.'
+  else
+    next()
+
 # Fetch & attach a req.article middleware
 @find = (req, res, next) ->
   Article.find (req.params.id or req.query.article_id), (err, article) ->

--- a/src/api/apps/articles/test/integration.spec.ts
+++ b/src/api/apps/articles/test/integration.spec.ts
@@ -58,7 +58,7 @@ describe("articles endpoints", () => {
         }
       )))
 
-  describe("as a non-admin", () => {
+  describe("as a non-admin and no team role", () => {
     let normieToken
     beforeEach(done => {
       normieToken =
@@ -88,7 +88,7 @@ describe("articles endpoints", () => {
         .send({ featured: true })
         .end((err, res) => {
           err.status.should.equal(401)
-          res.body.message.should.containEql("must be an admin")
+          res.body.message.should.containEql("must have team role")
           done()
         })
     })

--- a/src/api/apps/authors/index.coffee
+++ b/src/api/apps/authors/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, adminOnly } = require '../users/routes'
+{ setUser, authenticated, teamOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/authors', routes.index
 app.get '/authors/:id', routes.find, routes.show
-app.post '/authors', setUser, authenticated, adminOnly, routes.save
-app.put '/authors/:id', setUser, authenticated, adminOnly, routes.find, routes.save
-app.delete '/authors/:id', setUser, authenticated, adminOnly, routes.find, routes.delete
+app.post '/authors', setUser, authenticated, teamOnly, routes.save
+app.put '/authors/:id', setUser, authenticated, teamOnly, routes.find, routes.save
+app.delete '/authors/:id', setUser, authenticated, teamOnly, routes.find, routes.delete

--- a/src/api/apps/curations/index.coffee
+++ b/src/api/apps/curations/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, adminOnly } = require '../users/routes'
+{ setUser, authenticated, teamOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/curations', routes.index
 app.get '/curations/:id', routes.find, routes.show
-app.post '/curations', setUser, authenticated, adminOnly, routes.save
-app.put '/curations/:id', setUser, authenticated, adminOnly, routes.find, routes.save
-app.delete '/curations/:id', setUser, authenticated, adminOnly, routes.find, routes.delete
+app.post '/curations', setUser, authenticated, teamOnly, routes.save
+app.put '/curations/:id', setUser, authenticated, teamOnly, routes.find, routes.save
+app.delete '/curations/:id', setUser, authenticated, teamOnly, routes.find, routes.delete

--- a/src/api/apps/sections/index.coffee
+++ b/src/api/apps/sections/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, adminOnly } = require '../users/routes'
+{ setUser, authenticated, teamOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/sections', routes.index
 app.get '/sections/:id', routes.find, routes.show
-app.post '/sections', setUser, authenticated, adminOnly, routes.save
-app.put '/sections/:id', setUser, authenticated, adminOnly, routes.find, routes.save
-app.delete '/sections/:id', setUser, authenticated, adminOnly, routes.find, routes.delete
+app.post '/sections', setUser, authenticated, teamOnly, routes.save
+app.put '/sections/:id', setUser, authenticated, teamOnly, routes.find, routes.save
+app.delete '/sections/:id', setUser, authenticated, teamOnly, routes.find, routes.delete

--- a/src/api/apps/tags/index.coffee
+++ b/src/api/apps/tags/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, adminOnly } = require '../users/routes'
+{ setUser, authenticated, teamOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/tags', routes.index
 app.get '/tags/:id', routes.find, routes.show
-app.post '/tags', setUser, authenticated, adminOnly, routes.save
-app.put '/tags/:id', setUser, authenticated, adminOnly, routes.find, routes.update
-app.delete '/tags/:id', setUser, authenticated, adminOnly, routes.find, routes.delete
+app.post '/tags', setUser, authenticated, teamOnly, routes.save
+app.put '/tags/:id', setUser, authenticated, teamOnly, routes.find, routes.update
+app.delete '/tags/:id', setUser, authenticated, teamOnly, routes.find, routes.delete

--- a/src/api/apps/users/routes.coffee
+++ b/src/api/apps/users/routes.coffee
@@ -32,7 +32,7 @@ jwtDecode = require 'jwt-decode'
     res.err 404, 'Could not find a user from that access token'  unless user?
     # Alias on the request object
     req.user = user
-    req.user.roles = jwtDecode(req.accessToken).roles
+    req.user?.roles = jwtDecode(req.accessToken).roles
 
     # If `me` is passed as a value for any params, replace it with the
     # current user's id to transparently allow routes like
@@ -48,5 +48,5 @@ jwtDecode = require 'jwt-decode'
   User.refresh req.accessToken, (err, user) ->
     res.err 404, 'Could not find a user from that access token' unless user?
     req.user = user
-    req.user.roles = jwtDecode(req.accessToken).roles
+    req.user?.roles = jwtDecode(req.accessToken).roles
     res.send present user

--- a/src/api/apps/users/test/routes.test.coffee
+++ b/src/api/apps/users/test/routes.test.coffee
@@ -11,6 +11,9 @@ describe 'routes', ->
     @User = routes.__get__ 'User'
     for method in @methods = ['fromAccessToken']
       sinon.stub @User, method
+
+    routes.__set__ 'jwtDecode', sinon.stub().returns('foo')
+
     @req = { query: {}, body: {}, params: {}, accessToken: 'test-access-token' }
     @res = { send: sinon.stub(), err: sinon.stub() }
     @next = sinon.stub()

--- a/src/api/apps/verticals/index.coffee
+++ b/src/api/apps/verticals/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, adminOnly } = require '../users/routes'
+{ setUser, authenticated, teamOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/verticals', routes.index
 app.get '/verticals/:id', routes.find, routes.show
-app.post '/verticals', setUser, authenticated, adminOnly, routes.save
-app.put '/verticals/:id', setUser, authenticated, adminOnly, routes.find, routes.update
-app.delete '/verticals/:id', setUser, authenticated, adminOnly, routes.find, routes.delete
+app.post '/verticals', setUser, authenticated, teamOnly, routes.save
+app.put '/verticals/:id', setUser, authenticated, teamOnly, routes.find, routes.update
+app.delete '/verticals/:id', setUser, authenticated, teamOnly, routes.find, routes.delete

--- a/src/client/apps/edit/components/admin/components/article/article_authors.tsx
+++ b/src/client/apps/edit/components/admin/components/article/article_authors.tsx
@@ -51,7 +51,7 @@ export class ArticleAuthors extends Component<AdminArticleProps> {
   }
 
   render() {
-    const { article, apiURL, isEditorial, onChangeArticleAction } = this.props
+    const { article, apiURL, isEditorial, isAdmin, onChangeArticleAction } = this.props
     const name = article.author ? article.author.name : ""
 
     return (
@@ -92,7 +92,7 @@ export class ArticleAuthors extends Component<AdminArticleProps> {
               />
             </Box>
           )}
-          {article.layout !== "news" && (
+          {article.layout !== "news" && isAdmin && (
             <AutocompleteListMetaphysics
               field="contributing_authors"
               label="Contributing Authors"
@@ -114,6 +114,7 @@ const mapStateToProps = state => ({
   article: state.edit.article,
   isEditorial: state.app.isEditorial,
   user: state.app.user,
+  isAdmin: state.app.isAdmin,
 })
 
 const mapDispatchToProps = {

--- a/src/client/apps/edit/components/admin/components/article/article_authors.tsx
+++ b/src/client/apps/edit/components/admin/components/article/article_authors.tsx
@@ -92,15 +92,16 @@ export class ArticleAuthors extends Component<AdminArticleProps> {
               />
             </Box>
           )}
-          {article.layout !== "news" && isAdmin && (
+          {article.layout !== "news" && (
             <AutocompleteListMetaphysics
               field="contributing_authors"
-              label="Contributing Authors"
+              label="Contributing Authors (admin role required)"
               model="users"
               isDraggable
               onDragEnd={items => {
                 onChangeArticleAction("contributing_authors", items)
               }}
+              disabled={!isAdmin}
             />
           )}
         </Box>

--- a/src/client/apps/edit/components/admin/components/article/index.tsx
+++ b/src/client/apps/edit/components/admin/components/article/index.tsx
@@ -25,6 +25,7 @@ export interface AdminArticleProps {
   article: ArticleData
   apiURL: string
   isEditorial: boolean
+  isAdmin: boolean
   onChangeArticleAction: (key: string, value: any) => void
   user: any
 }

--- a/src/client/apps/edit/components/admin/components/featuring/index.tsx
+++ b/src/client/apps/edit/components/admin/components/featuring/index.tsx
@@ -7,7 +7,7 @@ interface AdminFeaturingProps {
   isAdmin: boolean
 }
 
-export const AdminFeaturing = (props: AdminFeaturingProps) => {
+export const AdminFeaturing: React.SFC<AdminFeaturingProps> = props => {
   const { isAdmin } = props
   return (
     <div>

--- a/src/client/apps/edit/components/admin/components/featuring/index.tsx
+++ b/src/client/apps/edit/components/admin/components/featuring/index.tsx
@@ -3,16 +3,22 @@ import AutocompleteListMetaphysics from "client/components/autocomplete2/list_me
 import React from "react"
 import { FeaturingMentioned } from "./featuring_mentioned"
 
-export const AdminFeaturing = () => {
+interface AdminFeaturingProps {
+  isAdmin: boolean
+}
+
+export const AdminFeaturing = (props: AdminFeaturingProps) => {
+  const { isAdmin } = props
   return (
     <div>
       <Flex flexDirection={["column", "row"]}>
         <Box width={["100%", "50%"]} pr={[0, 2]}>
           <AutocompleteListMetaphysics
             field="partner_ids"
-            label="Partners"
+            label="Partners (admin role required)"
             model="partners"
             placeholder="Search by partner name..."
+            disabled={!isAdmin}
           />
         </Box>
 
@@ -30,18 +36,20 @@ export const AdminFeaturing = () => {
         <Box width={["100%", "50%"]} pr={[0, 2]}>
           <AutocompleteListMetaphysics
             field="show_ids"
-            label="Shows"
+            label="Shows (admin role required)"
             model="partner_shows"
             placeholder="Search by show name..."
+            disabled={!isAdmin}
           />
         </Box>
 
         <Box width={["100%", "50%"]} pl={[0, 2]}>
           <AutocompleteListMetaphysics
             field="auction_ids"
-            label="Auctions"
+            label="Auctions (admin role required)"
             model="sales"
             placeholder="Search by auction name..."
+            disabled={!isAdmin}
           />
         </Box>
       </Flex>

--- a/src/client/apps/edit/components/admin/index.tsx
+++ b/src/client/apps/edit/components/admin/index.tsx
@@ -15,6 +15,7 @@ interface EditAdminProps {
   isNews: boolean
   isEditorial: boolean
   isPartner: boolean
+  isAdmin: boolean
 }
 
 export class EditAdmin extends Component<EditAdminProps> {
@@ -47,7 +48,7 @@ export class EditAdmin extends Component<EditAdminProps> {
   }
 
   render() {
-    const { isNews, isEditorial, isPartner } = this.props
+    const { isNews, isEditorial, isPartner, isAdmin } = this.props
     const sections = this.getSections()
 
     return (
@@ -73,9 +74,11 @@ export class EditAdmin extends Component<EditAdminProps> {
             <AdminArticle />
           </Box>
 
+          {isAdmin && (
           <Box pt={4}>
             <AdminFeaturing />
           </Box>
+          )}
 
           {!isNews && (
             <Box pt={4}>
@@ -106,6 +109,7 @@ const mapStateToProps = state => ({
   isNews: state.edit.article.layout === "news",
   isEditorial: state.app.channel.type === "editorial",
   isPartner: state.app.channel.type === "partner",
+  isAdmin: state.app.isAdmin,
 })
 
 export default connect(mapStateToProps)(EditAdmin)

--- a/src/client/apps/edit/components/admin/index.tsx
+++ b/src/client/apps/edit/components/admin/index.tsx
@@ -74,11 +74,11 @@ export class EditAdmin extends Component<EditAdminProps> {
             <AdminArticle />
           </Box>
 
-          {isAdmin && (
           <Box pt={4}>
-            <AdminFeaturing />
+            <AdminFeaturing
+              isAdmin={isAdmin}
+            />
           </Box>
-          )}
 
           {!isNews && (
             <Box pt={4}>

--- a/src/client/apps/settings/index.coffee
+++ b/src/client/apps/settings/index.coffee
@@ -8,14 +8,14 @@ routes = require './routes'
 app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
-{ adminOnly } = require '../../lib/middleware.coffee'
+{ teamOnly, adminOnly } = require '../../lib/middleware.coffee'
 
-app.get '/settings', adminOnly, routes.index
-app.get '/settings/curations', adminOnly, routes.curations
-app.get '/settings/curations/:id/edit', adminOnly, routes.editCuration
-app.post '/settings/curations/:id', adminOnly, routes.saveCuration
+app.get '/settings', teamOnly, routes.index
+app.get '/settings/curations', teamOnly, routes.curations
+app.get '/settings/curations/:id/edit', teamOnly, routes.editCuration
+app.post '/settings/curations/:id', teamOnly, routes.saveCuration
 app.get '/settings/channels', adminOnly, routes.channels
 app.get '/settings/channels/:id/edit', adminOnly, routes.editChannel
 app.post '/settings/channels/:id', adminOnly, routes.saveChannel
-app.get '/settings/tags', adminOnly, routes.tags
-app.get '/settings/authors', adminOnly, routes.authors
+app.get '/settings/tags', teamOnly, routes.tags
+app.get '/settings/authors', teamOnly, routes.authors

--- a/src/client/apps/settings/index.coffee
+++ b/src/client/apps/settings/index.coffee
@@ -14,7 +14,7 @@ app.get '/settings', teamOnly, routes.index
 app.get '/settings/curations', teamOnly, routes.curations
 app.get '/settings/curations/:id/edit', teamOnly, routes.editCuration
 app.post '/settings/curations/:id', teamOnly, routes.saveCuration
-app.get '/settings/channels', adminOnly, routes.channels
+app.get '/settings/channels', teamOnly, routes.channels
 app.get '/settings/channels/:id/edit', adminOnly, routes.editChannel
 app.post '/settings/channels/:id', adminOnly, routes.saveChannel
 app.get '/settings/tags', teamOnly, routes.tags

--- a/src/client/apps/settings/templates/channels/channels_index.jade
+++ b/src/client/apps/settings/templates/channels/channels_index.jade
@@ -2,7 +2,7 @@ include ../../../../components/paginated_list/index
 extend ../../../../components/layout/templates/index
 
 block header
-  | Channels
+  | Channels (admin role required)
 
 block content
   .max-width-container

--- a/src/client/apps/settings/templates/index.jade
+++ b/src/client/apps/settings/templates/index.jade
@@ -8,7 +8,6 @@ block content
   .max-width-container
     .settings__items
       a.settings__item-link(href='/settings/curations') Curations
-      if user.get('type') == 'Admin'
-        a.settings__item-link(href='/settings/channels') Channels
+      a.settings__item-link(href='/settings/channels') Channels
       a.settings__item-link(href='/settings/tags') Tags
       a.settings__item-link(href='/settings/authors') Authors

--- a/src/client/apps/settings/templates/index.jade
+++ b/src/client/apps/settings/templates/index.jade
@@ -8,6 +8,7 @@ block content
   .max-width-container
     .settings__items
       a.settings__item-link(href='/settings/curations') Curations
-      a.settings__item-link(href='/settings/channels') Channels
+      if user.get('type') == 'Admin'
+        a.settings__item-link(href='/settings/channels') Channels
       a.settings__item-link(href='/settings/tags') Tags
       a.settings__item-link(href='/settings/authors') Authors

--- a/src/client/components/autocomplete2/list_metaphysics.tsx
+++ b/src/client/components/autocomplete2/list_metaphysics.tsx
@@ -228,6 +228,7 @@ export class AutocompleteListMetaphysics extends Component<
       onChangeArticleAction,
       placeholder,
       type,
+      disabled,
     } = this.props
 
     switch (type) {
@@ -249,6 +250,7 @@ export class AutocompleteListMetaphysics extends Component<
             article={this.props.article}
             model={this.props.model}
             field={this.props.field}
+            disabled={disabled}
           />
         )
       }
@@ -265,6 +267,7 @@ export class AutocompleteListMetaphysics extends Component<
             onSelect={results => onChangeArticleAction(field, results)}
             placeholder={placeholder || `Search ${model} by name...`}
             url={`${artsyURL}/api/v1/match/${model}?term=%QUERY`}
+            disabled={disabled}
           />
         )
       }

--- a/src/client/components/layout/templates/sidebar.jade
+++ b/src/client/components/layout/templates/sidebar.jade
@@ -34,7 +34,7 @@
         include ../public/icons/layout_queue.svg
         br
         | Queue
-    if user.get('type') == 'Admin'
+    if sd.USER.roles.includes("team")
       a#layout-sidebar-settings( href='/settings'
          class=(sd.URL.match('/settings') ? 'is-active' : '') )
         include ../public/icons/layout_settings.svg

--- a/src/client/components/layout/test/sidebar.test.js
+++ b/src/client/components/layout/test/sidebar.test.js
@@ -8,7 +8,7 @@ describe("sidebar template", () => {
     const html = jade.compileFile(
       path.resolve(__dirname, "../templates/sidebar.jade")
     )({
-      sd: { URL: "/" },
+      sd: { URL: "/", USER: { 'roles': '' } },
       user: new User({
         name: "Andy Foobar",
         channel_ids: ["123"],

--- a/src/client/lib/middleware.coffee
+++ b/src/client/lib/middleware.coffee
@@ -50,3 +50,11 @@ useragent = require 'useragent'
     next err
   else
     next()
+
+@teamOnly = (req, res, next) ->
+  if !req.user?.get('roles').includes("team")
+    err = new Error 'You must have "team" role'
+    err.status = 403
+    next err
+  else
+    next()

--- a/src/test/helpers/fixtures.coffee
+++ b/src/test/helpers/fixtures.coffee
@@ -285,6 +285,8 @@ module.exports = ->
     sd:
       PATH: '/'
       URL: '/'
+      USER:
+        roles: ''
     moment: require 'moment'
     sharify:
       script: -> '<script>var sharify = {}</script>'


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3048
https://artsy.slack.com/archives/CA8SANW3W/p1610051152084300

Access to SETTINGS (SETTINGS button on sidebar) is currently restricted based on `admin` role. Switch that to `team`. However, keep Channel Edit (SETTINGS->Channels->[Channel Name]) on `admin`. We intend for `team` to allow just enough privilege for article writing. Channel editing seems an access beyond that. On CHANNELS page (`SETTINGS->Channels`), say `admin role required` to make it obvious.

Update the access restriction on these routes which are called in SETTINGS:

`frontend` (mostly GET/POST)
/settings, /settings/curations, /settings/channels, /settings/tags, /settings/authors

`backend` (mostly PUT/POST/DELETE)
/api/authors, /api/curations, /api/tags

I made [similar](https://github.com/artsy/positron/pull/2893) change to Admin panel (the `Admin` tab when editing an article) and now see that some fields there query Gravity match endpoints which are restricted to `admin
` role:

`Article` section.
- Contributing Authors

`Featuring` section.
- Partners
- Shows
- Auctions

For now, we add `(admin role required)` to the field names to make it obvious, and disable the fields if user does not have `admin` role.

Also in Admin panel, found that toggling `Magazine Feed` to `yes` requires `admin` role in the [backend](https://github.com/artsy/positron/blob/28ca6c55d7258ed500e1864d7260eec3ad6be734/src/api/apps/articles/routes.coffee#L61). Switch to `team`.

Lastly, do the same for these backend routes. However, I don't know where they are actually called.
- /api/sections
- /api/verticals
