### PR TITLE
toolchain: Fix dev env by updating react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "react-dom-factories": "1.0.2",
-    "react-hot-loader": "4.0.0",
+    "react-hot-loader": "4.8.3",
     "react-redux": "5.0.6",
     "react-sizeme": "2.6.10",
     "react-tracking": "5.6.0",

--- a/src/client/apps/articles_list/components/articles_list.tsx
+++ b/src/client/apps/articles_list/components/articles_list.tsx
@@ -5,7 +5,7 @@ import { Channel } from "client/typings"
 import $ from "jquery"
 import { debounce } from "lodash"
 import React, { Component } from "react"
-import { hot } from "react-hot-loader"
+import { hot } from "react-hot-loader/root"
 import { connect } from "react-redux"
 import Waypoint from "react-waypoint"
 import styled from "styled-components"
@@ -177,7 +177,7 @@ const mapDispatchToProps = {
   viewArticlesAction: viewArticles,
 }
 
-export default hot(module)(
+export default hot(
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/client/apps/edit/components/content/article_layouts/news.tsx
+++ b/src/client/apps/edit/components/content/article_layouts/news.tsx
@@ -5,7 +5,7 @@ import { onChangeArticle } from "client/actions/edit/articleActions"
 import { EditSourceControls } from "client/apps/edit/components/content/sections/news/EditSourceControls"
 import { PlainText } from "client/components/draft/plain_text/plain_text"
 import React, { Component } from "react"
-import { hot } from "react-hot-loader"
+import { hot } from "react-hot-loader/root"
 import { connect } from "react-redux"
 import styled from "styled-components"
 import SectionList from "../section_list"
@@ -88,7 +88,7 @@ const mapDispatchToProps = {
   onChangeArticleAction: onChangeArticle,
 }
 
-export default hot(module)(
+export default hot(
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/client/apps/edit/components/edit_container.tsx
+++ b/src/client/apps/edit/components/edit_container.tsx
@@ -14,7 +14,7 @@ import {
 } from "client/typings"
 import { once } from "lodash"
 import React, { Component } from "react"
-import { hot } from "react-hot-loader"
+import { hot } from "react-hot-loader/root"
 import { connect } from "react-redux"
 import styled from "styled-components"
 import EditAdmin from "./admin"
@@ -238,7 +238,7 @@ const mapDispatchToProps = {
   toggleSpinnerAction: toggleSpinner,
 }
 
-export default hot(module)(
+export default hot(
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/webpack/config/development.js
+++ b/webpack/config/development.js
@@ -15,5 +15,14 @@ module.exports = merge(common, {
     ],
     ...getEntrypoints(),
   },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx|ts|tsx)$/,
+        use: "react-hot-loader/webpack",
+        include: /node_modules/,
+      },
+    ],
+  },
   plugins: [new webpack.HotModuleReplacementPlugin()],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6771,7 +6771,7 @@ hoist-non-react-statics@^1.0.5:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
   integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
 
-hoist-non-react-statics@^2.2.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.2.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -8657,7 +8657,7 @@ loader-utils@1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.2.3:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -10718,7 +10718,7 @@ prop-types@15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@15.x, prop-types@^15.0.0, prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.x, prop-types@^15.0.0, prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -11142,16 +11142,20 @@ react-head@^3.0.0:
   dependencies:
     "@babel/runtime" "^7.8.3"
 
-react-hot-loader@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.0.0.tgz#3452fa9bc0d0ba9dfc5b0ccfa25101ca8dbd2de2"
-  integrity sha512-TxgvDJj/EuY05VXyPBYSWuGVGNd2g0K6WJxaOwjgAl1/1Hqni1BmMXnw6k/DGYeB1prh0jpB1N1x15ZEVytSSw==
+react-hot-loader@4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.8.3.tgz#14f018777a60ea9cfa60496c7341c2f967311253"
+  integrity sha512-Is8bKbSxuDLTqsWu1yjr+o1yA6yGDGjEQ2i1E8t/Nj1xJYC6QBRbyoofTn1xkMoKpcgXHuTJTqBhK0RY6moFJA==
   dependencies:
     fast-levenshtein "^2.0.6"
     global "^4.3.0"
-    hoist-non-react-statics "^2.5.0"
-    prop-types "^15.6.0"
+    hoist-non-react-statics "^3.3.0"
+    loader-utils "^1.1.0"
+    lodash "^4.17.11"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
+    source-map "^0.7.3"
 
 react-is@^16.10.2, react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.0"
@@ -12673,6 +12677,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 sourcemap-codec@^1.4.4:
   version "1.4.8"


### PR DESCRIPTION
Noticed that booting Positron in local dev was broken (seemingly since Jan 2020), but turns out the fix was easy -- we just needed to bump `react-hot-loader`'s version, per [these instructions](https://github.com/gaearon/react-hot-loader/issues/1227#issuecomment-482518698) 

cc @artsy/grow-devs 