### PR TITLE
chore: fixes artsy urls with capitalized letters causing redirects

### DIFF
--- a/src/api/apps/articles/model/sanitize.js
+++ b/src/api/apps/articles/model/sanitize.js
@@ -29,6 +29,9 @@ export const sanitizeLink = urlString => {
     const result = str.replace(regex, subst);
     url.href = result
   }
+  if (url.hostname.includes("artsy.net")) {
+    url.href = url.href.toLowerCase()
+  }
 
   return url.href
 }

--- a/src/api/apps/articles/test/model/sanitize.test.ts
+++ b/src/api/apps/articles/test/model/sanitize.test.ts
@@ -57,4 +57,16 @@ describe("#sanitizeLink", () => {
       "http://www.notartsy.net/posts"
     )
   })
+
+  it("removes capital letters from artsy urls", () => {
+    expect(sanitizeLink("https://artsy.net/DutchPavilion")).toBe(
+      "https://www.artsy.net/dutchpavilion"
+    )
+  })
+
+  it("does not remove capital letters from non-artsy urls", () => {
+    expect(sanitizeLink("https://www.anotherwebsite.net/DutchPavilion")).toBe(
+      "https://www.anotherwebsite.net/DutchPavilion"
+    )
+  })
 })


### PR DESCRIPTION
Adds an additional check to the sanitize urls function to clean up redirects caused by capitalized letters in Artsy urls.

cc @artsy/purchase-devs 

e.g.
Before: `https://artsy.net/DutchPavilion`
After: `https://artsy.net/dutchpavilion`