### PR TITLE
Add recommended indices to articles collection (PLATFORM-3169) #migration

### DIFF
--- a/scripts/db/20210225101205_add_articles_indices.js
+++ b/scripts/db/20210225101205_add_articles_indices.js
@@ -1,0 +1,25 @@
+// Run like:
+//
+// mongo "mongodb+srv://<host>/app29923450" --username positron2 --password <redacted> scripts/db/20210225101205_add_articles_indices.js
+
+db.articles.createIndex(
+  {
+    partner_channel_id: 1,
+    tags: 1,
+    featured: 1,
+    published: 1,
+    published_at: -1
+  },
+  { background: true }
+)
+
+db.articles.createIndex(
+  {
+    channel_id: 1,
+    tags: 1,
+    featured: 1,
+    published: 1,
+    published_at: -1
+  },
+  { background: true }
+)


### PR DESCRIPTION
As part of [PLATFORM-3169](https://artsyproduct.atlassian.net/browse/PLATFORM-3169) and https://github.com/artsy/gravity/pull/13855, we noticed that Atlas recommended 2 additional indices on the `articles` collection.

This PR follows the convention (introduced in https://github.com/artsy/positron/pull/1824 and [discussed here](https://artsy.slack.com/archives/C01ADJNCS5D/p1614262992060600)) of committing the migration to the `scripts/db` directory. I've already applied it to staging (via VPN) like:

```bash
mongo "mongodb+srv://staging.0txbf.mongodb.net/app29923450" --username positron2 --password [REDACTED] scripts/db/20210225101205_add_articles_indices.js
```

Migrations are _not_ automatically applied upon deploy, so a similar step will be necessary for production.

https://artsyproduct.atlassian.net/browse/PLATFORM-3169