### PR TITLE
Create additional articles index as recommended by Atlas (PLATFORM-3169)

### DIFF
--- a/scripts/db/20210302105100_add_articles_index.js
+++ b/scripts/db/20210302105100_add_articles_index.js
@@ -1,0 +1,12 @@
+// Run like:
+//
+// mongo "mongodb+srv://<host>/app29923450" --username positron2 --password <redacted> scripts/db/<filename>
+
+db.articles.createIndex(
+  {
+    fair_ids: 1,
+    published: 1,
+    published_at: -1
+  },
+  { background: true }
+)


### PR DESCRIPTION
As part of the monitoring follow-up of [PLATFORM-3169](https://artsyproduct.atlassian.net/browse/PLATFORM-3169), we noticed a freshly recommended index in Atlas's UI. There are ~150 queries by `fair_ids` per hour, but no corresponding indices.

See https://github.com/artsy/positron/pull/2925 for migration steps.