### PR TITLE
Transition from legacy dependabot to native github security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,6 @@ updates:
     # Limit to 0 to enable only security updates:
     open-pull-requests-limit: 0
     assignees:
-      - sweir27
+      - jonallured
     reviewers:
       - artsy/grow-devs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    # Limit to 0 to enable only security updates:
+    open-pull-requests-limit: 0
+    assignees:
+      - sweir27
+    reviewers:
+      - artsy/grow-devs


### PR DESCRIPTION
This transitions security updates from dependabot (which is [pending retirement](https://github.blog/2021-04-29-goodbye-dependabot-preview-hello-dependabot/)) to Github-managed.

**Step 1** (already complete): Enable "Dependabot security updates" under the repo's [Security & analysis settings](https://github.com/artsy/watt/settings/security_analysis).

**Step 2** (this PR): Commit a minimal `.github/dependabot.yml` specifying `open-pull-requests-limit: 0` (this is [a hack to enable only security updates](https://stackoverflow.com/a/68254421), which can't otherwise be configured), the same assignee as currently specified [in dependabot's UI](https://app.dependabot.com/accounts/artsy/projects/104975), and the associated team as reviewers.

Note that Positron previously had non-security updates enabled as well. Those aggressive updates have piled up, and without anyone actively working on the repo or reviewing the many upgrades, I thought it most practical to switch to security updates only.

https://artsyproduct.atlassian.net/browse/PLATFORM-3470

