### PR TITLE
feat: add dependabot alert config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    # Limit to 0 to enable only security updates:
+    open-pull-requests-limit: 0
+    assignees:
+      - jonallured
+    reviewers:
+      - artsy/grow-devs


### PR DESCRIPTION
This enables security alerts for Github-native dependabot and puts it in line with the 🔒 [security alert playbook](https://www.notion.so/artsy/Security-alerts-and-updates-for-repositories-dependabot-114369231d854ce89b104ea0da5d0c65) 

**Step 1** (already complete): Enable "Dependabot security updates" under the repo's [Security & analysis settings](https://github.com/artsy/exchange/settings/security_analysis).

**Step 2** (this PR): Commit a minimal `.github/dependabot.yml` specifying `open-pull-requests-limit: 0` (this is [a hack to enable only security updates](https://stackoverflow.com/a/68254421), which can't otherwise be configured), the team lead has been made the assignee, and the associated team as reviewers.

https://artsyproduct.atlassian.net/browse/PLATFORM-3570