### PR TITLE
chore: allow kubernetes+cloudfare for ingress connections::PLATFORM-1308

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -232,7 +232,7 @@ kind: Ingress
 metadata:
   name: positron
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:
   ingressClassName: nginx
   rules:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -232,7 +232,7 @@ kind: Ingress
 metadata:
   name: positron
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
More info here: https://artsyproduct.atlassian.net/browse/PLATFORM-1308
This PR is a dependence of this [one](https://github.com/artsy/substance/pull/263)
As we are trying between services to happens internally, this change is required, as kubernetes IP's might be allowed for incoming connections
