### PR TITLE
feat(websockets): Add ability to reconnect

### DIFF
--- a/src/client/apps/websocket/client.js
+++ b/src/client/apps/websocket/client.js
@@ -4,7 +4,10 @@ import { messageTypes } from "./messageTypes"
 let socket
 
 const init = (store, rootURL) => {
-  socket = io(rootURL)
+  socket = io(rootURL, {
+    reconnection: true,
+  })
+
   // add listeners to socket messages so we can re-dispatch them as actions
   Object.keys(messageTypes).forEach(key =>
     socket.on(key, data => {


### PR DESCRIPTION
This attempts to add some resiliency to our websocket connection for long-running browser tabs. When the tab sleeps, it drops the connection; but with reconnect=true it will reconnect. 

cc @artsy/grow-devs 