### PR TITLE
fix: renamed title to name for algolia

### DIFF
--- a/src/api/apps/articles/model/distribute.coffee
+++ b/src/api/apps/articles/model/distribute.coffee
@@ -126,7 +126,7 @@ moment = require 'moment'
 
   algoliaSearch.index.saveObject({
     objectID: article.id?.toString()
-    title: article.title
+    name: article.title
     description: article.description
     author: article.author and article.author.name or ''
     slug: article.slug


### PR DESCRIPTION
# Description

This pr resolves [FX-3598](https://artsyproduct.atlassian.net/browse/FX-3598)

- changes `title` -> `name` in order for titles to be visible from the algolia components in eigen.