### PR TITLE
hokusai orb update (canary build)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@1.1.3
-  hokusai: artsy/hokusai@0.7.8
+  hokusai: artsy/hokusai@dev:512d4f329b766a5371bb719c356186a3
   yarn: artsy/yarn@6.0.0
   horizon: artsy/release@0.0.1
 


### PR DESCRIPTION
Use hokusai orb canary build to test the latest hokusai version.

https://github.com/artsy/orbs/pull/134