### PR TITLE
Rename master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,11 @@ not_staging_or_release: &not_staging_or_release
         - staging
         - release
 
-only_master: &only_master
+only_main: &only_main
   context: hokusai
   filters:
     branches:
-      only: master
+      only: main
 
 only_release: &only_release
   context: hokusai
@@ -51,7 +51,7 @@ only_dev: &only_dev
   filters:
     branches:
       ignore:
-        - master
+        - main
         - staging
         - release
 
@@ -85,12 +85,12 @@ workflows:
       # Staging
       - hokusai/push:
           name: push-staging-image
-          <<: *only_master
+          <<: *only_main
           requires:
             - test
 
       - hokusai/deploy-staging:
-          <<: *only_master
+          <<: *only_main
           project-name: positron
           requires:
             - push-staging-image

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
   - [Staging](https://app.datadoghq.com/apm/service/positron/express.request?end=1545136799180&env=staging&paused=false&start=1545133199180)
 - **MongoDB:** [Atlas](https://cloud.mongodb.com/v2/5be44a7aff7a254a8327cd3a#clusters)
 - **Github:** [https://github.com/artsy/positron/](https://github.com/artsy/positron/)
-- **CI:** [CircleCI](https://circleci.com/gh/artsy/positron); merged PRs to artsy/positron#master are automatically deployed to staging. PRs from `staging` to `release` are automatically deployed to production. [Start a deploy...](https://github.com/artsy/positron/compare/release...staging?expand=1)
+- **CI:** [CircleCI](https://circleci.com/gh/artsy/positron); merged PRs to artsy/positron#main are automatically deployed to staging. PRs from `staging` to `release` are automatically deployed to production. [Start a deploy...](https://github.com/artsy/positron/compare/release...staging?expand=1)
 - **Point Person:** N/A
 
-[![Build Status](https://circleci.com/gh/artsy/positron/tree/master.svg?style=svg)](https://circleci.com/gh/artsy/positron/tree/master) [![codecov](https://codecov.io/gh/artsy/positron/branch/master/graph/badge.svg)](https://codecov.io/gh/artsy/positron)
+[![Build Status](https://circleci.com/gh/artsy/positron/tree/main.svg?style=svg)](https://circleci.com/gh/artsy/positron/tree/main) [![codecov](https://codecov.io/gh/artsy/positron/branch/main/graph/badge.svg)](https://codecov.io/gh/artsy/positron)
 
 ## Setup
 

--- a/doc/distribution.md
+++ b/doc/distribution.md
@@ -20,7 +20,7 @@ In [Force](https://github.com/artsy/force), we've separated the main article bod
 
 > ##### Aside on Channels
 >
-> We typically think of Channels as groups of people. A [Channel](https://github.com/artsy/positron/blob/master/api/apps/channels/model.coffee) contains some metadata and an array of Users. Users can be in multiple Channels. Depending on which Channel you're writing articles in, you'll see different layout options and administrative settings. A long time ago, we only had Users and our entire Artsy Editorial staff had to use a single login.
+> We typically think of Channels as groups of people. A [Channel](https://github.com/artsy/positron/blob/main/api/apps/channels/model.coffee) contains some metadata and an array of Users. Users can be in multiple Channels. Depending on which Channel you're writing articles in, you'll see different layout options and administrative settings. A long time ago, we only had Users and our entire Artsy Editorial staff had to use a single login.
 
 Bored? Here are some great Artsy Editorial (Channel) articles:
 
@@ -47,7 +47,7 @@ Bored? Here are the same Artsy Editorial articles in AMP:
 - [GIPHY Is Helping Get Artists’ Works Viewed 100 Million Times](https://www.artsy.net/article/artsy-editorial-giphy-artists-works-viewed-100-million-times/amp)
 - [What Makes "Bad" Art Good?](https://www.artsy.net/article/artsy-editorial-bad-art-good/amp)
 
-There are many reasons [why](https://medium.com/@cramforce/why-amp-is-fast-7d2ff1f48597) AMP is fast, but the 50KB CSS limit seems to be the hardest to deal with. We created an [AMP-specific stylesheet](https://github.com/artsy/force/blob/master/desktop/apps/article/stylesheets/amp.styl) that is picky about which stylesheets to require. In the cases where we only need one or two CSS rules from a file, we rewrite it instead of requiring the entire file.
+There are many reasons [why](https://medium.com/@cramforce/why-amp-is-fast-7d2ff1f48597) AMP is fast, but the 50KB CSS limit seems to be the hardest to deal with. We created an [AMP-specific stylesheet](https://github.com/artsy/force/blob/main/desktop/apps/article/stylesheets/amp.styl) that is picky about which stylesheets to require. In the cases where we only need one or two CSS rules from a file, we rewrite it instead of requiring the entire file.
 
 ## Google News
 
@@ -57,7 +57,7 @@ We use sitemaps to manage distribution of Artsy's editorial content to Google Se
 
 The [articles sitemap](https://www.artsy.net/sitemap-articles-2018.xml) is generated daily. It is housed by S3, served by Force, and configured via Cinder and Fulcrum, with the help of a few external services.
 
-Changes to the sitemap itself are made in Cinder via the [ArticleSitemapJob](https://github.com/artsy/cinder/blob/master/src/main/scala/net/artsy/jobs/sitemaps/ArticleSitemapJob.scala). A more detailed description of the Artsy's sitemap processes can be found in the [Cinder docs](https://github.com/artsy/cinder/blob/master/doc/sitemaps.md).
+Changes to the sitemap itself are made in Cinder via the [ArticleSitemapJob](https://github.com/artsy/cinder/blob/main/src/main/scala/net/artsy/jobs/sitemaps/ArticleSitemapJob.scala). A more detailed description of the Artsy's sitemap processes can be found in the [Cinder docs](https://github.com/artsy/cinder/blob/main/doc/sitemaps.md).
 
 If additional fields are added to the article sitemap, we must also fetch the new field from Positron via [Fulcrum's positron-tables.yml](https://github.com/artsy/fulcrum/blob/master/config/positron-tables.yml).
 
@@ -78,7 +78,7 @@ Because of these requirements, unlike the rest of the sitemaps, we generate our 
 
 Once crawled, news articles should appear on search results as Top stories (results may vary depending on the query.) They should also appear on [https://news.google.com](https://news.google.com) as well.
 
-![google-news](https://raw.githubusercontent.com/artsy/positron/master/doc/images/google-news.png)
+![google-news](https://raw.githubusercontent.com/artsy/positron/main/doc/images/google-news.png)
 
 Articles can be excluded from this process on a case-by-case basis when the `exclude_google_news` field is marked `true`.
 
@@ -97,7 +97,7 @@ Now that we've dispersed all of our content, how do we know it's working?
 - **[Looker](https://artsy.looker.com)**: combines multiple data sources, great for drilling, making inferences
 - **[Segment.io](https://segment.io)**: this is not a dashboard, but an event bus that passes analytics events from Force, GA, and others to Redshift, our data warehouse. Looker then pulls data from Redshift.
 
-Our Editorial Team uses [Airtable](https://airtable.com) to organize and plan stories. We run a [data transfer script](https://github.com/artsy/positron/blob/master/scripts/ga_airtable_transfer.js) every hour on the half hour. The script simply takes article analytics from GA and saves them into a table in Airtable.
+Our Editorial Team uses [Airtable](https://airtable.com) to organize and plan stories. We run a [data transfer script](https://github.com/artsy/positron/blob/main/scripts/ga_airtable_transfer.js) every hour on the half hour. The script simply takes article analytics from GA and saves them into a table in Airtable.
 
 #### FAQ
 

--- a/doc/editorial-features.md
+++ b/doc/editorial-features.md
@@ -15,7 +15,7 @@ Some examples of articles created with the `EditorialFeature` component include:
 
 ### Force
 
-Whether an article requires a custom layout is determined in Force’s [article routing](https://github.com/artsy/force/blob/master/src/desktop/apps/article/routes.ts). This is achieved by passing the prop `customEditorial`-- a string shorthand for a specific article-- to Reaction’s top-level `Article` component. The `customEditorial` prop is pulled from Force’s editorial feature "[master list](https://github.com/artsy/force/blob/master/src/desktop/apps/article/editorial_features.ts)", which ties an `article._id` to a communicative string that will be received by Reaction. In addition to data saved to an article model, the component will also receive all data displayed in the footer including related articles and display ads. Custom articles are rendered as a standalone page, meaning they are excluded from infinite scroll and do not render the main site header.
+Whether an article requires a custom layout is determined in Force’s [article routing](https://github.com/artsy/force/blob/master/src/desktop/apps/article/routes.ts). This is achieved by passing the prop `customEditorial`-- a string shorthand for a specific article-- to Reaction’s top-level `Article` component. The `customEditorial` prop is pulled from Force’s [editorial features list](https://github.com/artsy/force/blob/master/src/desktop/apps/article/editorial_features.ts), which ties an `article._id` to a communicative string that will be received by Reaction. In addition to data saved to an article model, the component will also receive all data displayed in the footer including related articles and display ads. Custom articles are rendered as a standalone page, meaning they are excluded from infinite scroll and do not render the main site header.
 
 ### Reaction
 
@@ -29,7 +29,7 @@ Because `EditorialFeature` accepts an article data-model, it can be edited using
 
 **A custom layout is enabled via three steps:**
 
-- Add a new object to the `customEditorialArticles` [master list](https://github.com/artsy/force/blob/master/src/desktop/apps/article/editorial_features.ts), indicating the `article._id` and `name`. Names are usually a shorthand for the content, and used because they are descriptive (unlike an `_id`), and will not change over time like a title or slug has potential to do.
+- Add a new object to the [`customEditorialArticles` list](https://github.com/artsy/force/blob/master/src/desktop/apps/article/editorial_features.ts), indicating the `article._id` and `name`. Names are usually a shorthand for the content, and used because they are descriptive (unlike an `_id`), and will not change over time like a title or slug has potential to do.
 
 ```javascript
     {
@@ -55,9 +55,9 @@ Previously we have used multiple strategies to implement these features, using t
 
 ### Curations:
 
-A [Curation](https://github.com/artsy/positron/tree/master/src/api/apps/curations) is a model in Positron’s API that has no schema-- meaning it accepts any data shape. This can be a handy solution for content that does not conform to the existing article model. However, this strategy comes with significant overhead and a few quirks:
+A [Curation](https://github.com/artsy/positron/tree/main/src/api/apps/curations) is a model in Positron’s API that has no schema-- meaning it accepts any data shape. This can be a handy solution for content that does not conform to the existing article model. However, this strategy comes with significant overhead and a few quirks:
 
-- A [custom edit UI must be created](https://github.com/artsy/positron/tree/master/src/client/apps/settings/client/curations) and maintained indefinitely
+- A [custom edit UI must be created](https://github.com/artsy/positron/tree/main/src/client/apps/settings/client/curations) and maintained indefinitely
 - A custom Express app is required by Force to render the content
 - Because data is in a unique shape, components often must be fully custom
 - It is difficult to track visual changes over time


### PR DESCRIPTION
As per [docs](https://github.com/artsy/README/blob/main/playbooks/rename-master-to-main.md).

Positron docs have lots of deep links into other repos' (Force, Reaction, Potential, Fulcrum) source. Since those haven't been updated yet and I didn't want to break the links, I left `master` within those URLs. If they _are_ renamed in the future, Github will redirect these URLs to the updated location.

To update local checkouts, developers should do:

```
git checkout master
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```