### PR TITLE
feat: setup, test and dev uses mongodb 4.2

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
 tap 'artsy/formulas'
 tap 'mongodb/brew'
-brew 'mongodb-community@4.0', link: true, restart_service: true
+brew 'mongodb-community@4.2', link: true, restart_service: true
 brew 'elasticsearch@5.6', restart_service: true

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -29,8 +29,8 @@ services:
       - 9300:9300
       - 9200:9200
   positron-mongodb:
-    image: mongo:4.0
-    command: ["--storageEngine=mmapv1", "--quiet", "--nojournal"]
+    image: mongo:4.2
+    command: ["--quiet", "--nojournal"]
     ports:
       - 27017:27017
     volumes:

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "9200:9200"
   positron-mongodb:
-    image: mongo:4.0
+    image: mongo:4.2
     ports:
       - "27017:27017"
-    command: ["--storageEngine=mmapv1", "--quiet", "--nojournal"]
+    command: ["--quiet", "--nojournal"]


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3942

In preparation for upgrading Mongo Atlas staging/prod to 4.2 this CL updates both test and development `compose` configuration files to use mongodb v4.2.

Note that the [test suite passed](https://app.circleci.com/pipelines/github/artsy/positron?branch=ovasdi%2FPLATFORM-3942%2Fmongo-4-2&filter=all) using mongodb 4.2 image. I have also validated by standing up local dev via `hokusai dev start` and executing CRUD actions using a test article.

This CL also updates the [Brewfile](https://github.com/artsy/positron/compare/ovasdi/PLATFORM-3942/mongo-4-2?expand=1#diff-1b33d9c13a9a1b0c5d5bc83697ba7b4d36e6cf45f78184c3a28527ffc4418e2dR3) to install `mongodb-community@4.2` which will require developers to re-run setup script. Unfortunately during testing we have experienced some issues with having both versions running and so to streamline the process our recommendation is to:

```sh
# remove 4.0
brew uninstall mongodb-community@4.0

# delete the mongo data directories and files
rm -rf /usr/local/var/mongodb/*

# re-run setup
scripts/setup.sh
```

This PR will be merged along with [Kaws](https://github.com/artsy/kaws/pull/402#pullrequestreview-868470740) and [Gravity](https://github.com/artsy/gravity/pull/14938) PRs followed by an announcement that those contributors working in these projects need to remove v4.0, clean local mongo data and rerun setup scripts.