### PR TITLE
fix: revert yarn/node orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.2.5
   hokusai: artsy/hokusai@volatile
-  yarn: artsy/yarn@volatile
+  yarn: artsy/yarn@6.1.0
   horizon: artsy/release@volatile
 
 jobs:


### PR DESCRIPTION
bumped these orbs version to latest in https://github.com/artsy/positron/pull/3047, not realizing they carry node version. undo.