### PR TITLE
fix: insufficient wait for article index

### DIFF
--- a/src/api/apps/articles/test/model/index/persistence.spec.ts
+++ b/src/api/apps/articles/test/model/index/persistence.spec.ts
@@ -699,7 +699,7 @@ describe("Article Persistence", () => {
                   done()
                 }
               ),
-            1000
+            2000
           )
         }
       ))


### PR DESCRIPTION
To fix this test's intermittent failing:

[#1](https://app.circleci.com/pipelines/github/artsy/positron/5007/workflows/53b8faa7-7099-40a3-88bc-9782fb8b1f88/jobs/10880)
[#2](https://app.circleci.com/pipelines/github/artsy/positron/4850/workflows/a46c5925-6efa-464c-ae68-40419ad12491/jobs/10474)

Local testing shows that a timeout of 2000 makes the test pass consistently.

We thought the failure has something to do with this [PR](https://github.com/artsy/positron/pull/3054), but looks like it's not the case. Looks like it's just that the test has been flaky.

Relevant thread:

https://artsy.slack.com/archives/CA8SANW3W/p1651503794642089