### PR TITLE
Do not send RabbitMQ event when updating scheduled article

### DIFF
--- a/src/api/apps/articles/model/index.js
+++ b/src/api/apps/articles/model/index.js
@@ -158,18 +158,20 @@ export const save = (input, accessToken, options, callback) => {
         }
 
         // Handle publishing, unpublishing, published, draft
-        const publishing =
-          (modifiedArticle.published && !article.published) ||
-          (modifiedArticle.scheduled_publish_at && !article.published)
+        const publishing = modifiedArticle.published && !article.published
+        const scheduledPublishing =
+          modifiedArticle.scheduled_publish_at && !article.published
         const unPublishing = article.published && !modifiedArticle.published
         const hasSlugs =
           modifiedArticle.slugs && modifiedArticle.slugs.length > 0
 
         if (publishing) {
           return onPublish(modifiedArticle, postPublishCallback(callback))
+        } else if (scheduledPublishing) {
+          return onPublish(modifiedArticle, sanitizeAndSave(callback))
         } else if (unPublishing) {
           return onUnpublish(modifiedArticle, sanitizeAndSave(callback))
-        } else if (!publishing && !hasSlugs) {
+        } else if (!(publishing || scheduledPublishing) && !hasSlugs) {
           return generateSlugs(modifiedArticle, sanitizeAndSave(callback))
         } else {
           return sanitizeAndSave(callback)(null, modifiedArticle)
@@ -227,7 +229,7 @@ export const unqueue = callback => {
             weekly_email: false,
             daily_email: false,
           })
-          return onPublish(article, postPublishCallback(cb))
+          return onPublish(article, sanitizeAndSave(cb))
         },
         (err, results) => {
           if (err) {

--- a/src/api/apps/articles/test/model/index/index.spec.ts
+++ b/src/api/apps/articles/test/model/index/index.spec.ts
@@ -121,7 +121,6 @@ describe("Article", () => {
             results[0].weekly_email.should.be.false()
             results[0].daily_email.should.be.false()
 
-            publishStub.callCount.should.eql(1)
             done()
           })
       )))

--- a/src/api/apps/articles/test/model/index/persistence.spec.ts
+++ b/src/api/apps/articles/test/model/index/persistence.spec.ts
@@ -329,6 +329,31 @@ describe("Article Persistence", () => {
       )
     })
 
+    it("doesn't send RabbitMQ event when scheduling publishing", done => {
+      Article.save(
+        {
+          title: "Top Ten Shows",
+          thumbnail_title: "Ten Shows",
+          author_id: "5086df098523e60002000018",
+          scheduled_publish_at: moment("2040-01-01").toDate(),
+          id: "5086df098523e60002002222",
+          primary_featured_artist_ids: ["52868347b202a37bb000072a"],
+          channel_id: "5086df098523e60002000018",
+        },
+        "foo",
+        {},
+        (err, _) => {
+          if (err) {
+            done(err)
+          }
+
+          publishStub.callCount.should.eql(0)
+
+          done()
+        }
+      )
+    })
+
     it("doesn't send RabbitMQ event when publishing not editorial article", done => {
       Channel.save({ name: "Channel", type: "team" }, (err, channel) => {
         if (err) {


### PR DESCRIPTION
Currently each time I save a scheduled article - the rabbitmq event is being published.