### PR TITLE
test: fix container reference for hokusai v1.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,13 +71,13 @@ workflows:
             - run: mkdir -p ./coverage ./.nyc_output
             - run:
                 name: Copy jest coverage artifacts
-                command: docker cp hokusai_positron_1:/app/coverage ./
+                command: docker cp hokusai-positron-1:/app/coverage ./
                 when: always
             - codecov/upload:
                 file: ./coverage/lcov.info
             - run:
                 name: Copy mocha coverage artifacts
-                command: docker cp hokusai_positron_1:/app/.nyc_output ./
+                command: docker cp hokusai-positron-1:/app/.nyc_output ./
                 when: always
             - codecov/upload:
                 file: ./.nyc_output/lcov.info


### PR DESCRIPTION
Similar to https://github.com/artsy/volt/pull/6999. The new `No such container:path: hokusai_..._1:/app/rspec` error appears related to [hokusai's v1.2.0 release](https://github.com/artsy/hokusai/pull/364) and specifically its docker-compose upgrade.
