### PR TITLE
fix: uses unica for og:image generation

### DIFF
--- a/src/client/components/image_generator/index.tsx
+++ b/src/client/components/image_generator/index.tsx
@@ -44,7 +44,7 @@ export class ImageGenerator extends Component<Props, State> {
       ctx.font = '32px "Unica77LLWebMedium"'
       ctx.fillText("News", 120, 62)
       ctx.fillText(date, 490, 62)
-      ctx.font = '50px "Adobe Garamond W08"'
+      ctx.font = '50px "Unica77LLWebMedium"'
       this.wrapText(ctx, text, 120, 130, 840, 50)
 
       // Create image blob and upload to s3


### PR DESCRIPTION
Closes [DIA-292](https://artsyproduct.atlassian.net/browse/DIA-292)

Sort of just blindly changing to use Unica here. Not sure what this looks like as I can't get Positron to install/run but this should be _fine_.

[DIA-292]: https://artsyproduct.atlassian.net/browse/DIA-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ