### PR TITLE
feat: replace team role with editorial role 

### DIFF
--- a/src/api/apps/articles/routes.coffee
+++ b/src/api/apps/articles/routes.coffee
@@ -58,8 +58,8 @@ User = require '../users/model.coffee'
     res.send present req.article
 
 @restrictFeature = (req, res, next) ->
-  if !req.user?.roles?.includes("team") and req.body.featured
-    res.err 401, 'You must have team role to feature an article.'
+  if !req.user?.roles?.includes("editorial") and req.body.featured
+    res.err 401, 'You must have editorial role to feature an article.'
   else
     next()
 

--- a/src/api/apps/articles/test/integration.spec.ts
+++ b/src/api/apps/articles/test/integration.spec.ts
@@ -88,7 +88,7 @@ describe("articles endpoints", () => {
         .send({ featured: true })
         .end((err, res) => {
           err.status.should.equal(401)
-          res.body.message.should.containEql("must have team role")
+          res.body.message.should.containEql("must have editorial role")
           done()
         })
     })

--- a/src/api/apps/authors/index.coffee
+++ b/src/api/apps/authors/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, teamOnly } = require '../users/routes'
+{ setUser, authenticated, editorialOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/authors', routes.index
 app.get '/authors/:id', routes.find, routes.show
-app.post '/authors', setUser, authenticated, teamOnly, routes.save
-app.put '/authors/:id', setUser, authenticated, teamOnly, routes.find, routes.save
-app.delete '/authors/:id', setUser, authenticated, teamOnly, routes.find, routes.delete
+app.post '/authors', setUser, authenticated, editorialOnly, routes.save
+app.put '/authors/:id', setUser, authenticated, editorialOnly, routes.find, routes.save
+app.delete '/authors/:id', setUser, authenticated, editorialOnly, routes.find, routes.delete

--- a/src/api/apps/channels/index.coffee
+++ b/src/api/apps/channels/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, adminOnly } = require '../users/routes'
+{ setUser, authenticated, editorialOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/channels', routes.index
 app.get '/channels/:id', routes.find, routes.show
-app.post '/channels', setUser, authenticated, adminOnly, routes.save
-app.put '/channels/:id', setUser, authenticated, adminOnly, routes.find, routes.save
-app.delete '/channels/:id', setUser, authenticated, adminOnly, routes.find, routes.delete
+app.post '/channels', setUser, authenticated, editorialOnly, routes.save
+app.put '/channels/:id', setUser, authenticated, editorialOnly, routes.find, routes.save
+app.delete '/channels/:id', setUser, authenticated, editorialOnly, routes.find, routes.delete

--- a/src/api/apps/curations/index.coffee
+++ b/src/api/apps/curations/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, teamOnly } = require '../users/routes'
+{ setUser, authenticated, editorialOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/curations', routes.index
 app.get '/curations/:id', routes.find, routes.show
-app.post '/curations', setUser, authenticated, teamOnly, routes.save
-app.put '/curations/:id', setUser, authenticated, teamOnly, routes.find, routes.save
-app.delete '/curations/:id', setUser, authenticated, teamOnly, routes.find, routes.delete
+app.post '/curations', setUser, authenticated, editorialOnly, routes.save
+app.put '/curations/:id', setUser, authenticated, editorialOnly, routes.find, routes.save
+app.delete '/curations/:id', setUser, authenticated, editorialOnly, routes.find, routes.delete

--- a/src/api/apps/search/index.js
+++ b/src/api/apps/search/index.js
@@ -1,7 +1,7 @@
 import express from "express"
 import { index } from "api/apps/search/routes"
-import { setUser, authenticated, adminOnly } from "api/apps/users/routes.coffee"
+import { setUser, authenticated, editorialOnly } from "api/apps/users/routes.coffee"
 
 const app = (module.exports = express())
 
-app.get("/search", setUser, authenticated, adminOnly, index)
+app.get("/search", setUser, authenticated, editorialOnly, index)

--- a/src/api/apps/sections/index.coffee
+++ b/src/api/apps/sections/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, teamOnly } = require '../users/routes'
+{ setUser, authenticated, editorialOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/sections', routes.index
 app.get '/sections/:id', routes.find, routes.show
-app.post '/sections', setUser, authenticated, teamOnly, routes.save
-app.put '/sections/:id', setUser, authenticated, teamOnly, routes.find, routes.save
-app.delete '/sections/:id', setUser, authenticated, teamOnly, routes.find, routes.delete
+app.post '/sections', setUser, authenticated, editorialOnly, routes.save
+app.put '/sections/:id', setUser, authenticated, editorialOnly, routes.find, routes.save
+app.delete '/sections/:id', setUser, authenticated, editorialOnly, routes.find, routes.delete

--- a/src/api/apps/tags/index.coffee
+++ b/src/api/apps/tags/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, teamOnly } = require '../users/routes'
+{ setUser, authenticated, editorialOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/tags', routes.index
 app.get '/tags/:id', routes.find, routes.show
-app.post '/tags', setUser, authenticated, teamOnly, routes.save
-app.put '/tags/:id', setUser, authenticated, teamOnly, routes.find, routes.update
-app.delete '/tags/:id', setUser, authenticated, teamOnly, routes.find, routes.delete
+app.post '/tags', setUser, authenticated, editorialOnly, routes.save
+app.put '/tags/:id', setUser, authenticated, editorialOnly, routes.find, routes.update
+app.delete '/tags/:id', setUser, authenticated, editorialOnly, routes.find, routes.delete

--- a/src/api/apps/users/routes.coffee
+++ b/src/api/apps/users/routes.coffee
@@ -18,8 +18,8 @@ jwtDecode = require 'jwt-decode'
   next()
 
 # Require team role middleware
-@teamOnly = (req, res, next) ->
-  return res.err 401, 'Must have team role' unless req.user?.roles?.includes("team")
+@editorialOnly = (req, res, next) ->
+  return res.err 401, 'Must have editorial role' unless req.user?.roles?.includes("editorial")
   next()
 
 # Set the user from an access token and alias the `me` param

--- a/src/api/apps/verticals/index.coffee
+++ b/src/api/apps/verticals/index.coffee
@@ -1,11 +1,11 @@
 express = require 'express'
 routes = require './routes'
-{ setUser, authenticated, teamOnly } = require '../users/routes'
+{ setUser, authenticated, editorialOnly } = require '../users/routes'
 
 app = module.exports = express()
 
 app.get '/verticals', routes.index
 app.get '/verticals/:id', routes.find, routes.show
-app.post '/verticals', setUser, authenticated, teamOnly, routes.save
-app.put '/verticals/:id', setUser, authenticated, teamOnly, routes.find, routes.update
-app.delete '/verticals/:id', setUser, authenticated, teamOnly, routes.find, routes.delete
+app.post '/verticals', setUser, authenticated, editorialOnly, routes.save
+app.put '/verticals/:id', setUser, authenticated, editorialOnly, routes.find, routes.update
+app.delete '/verticals/:id', setUser, authenticated, editorialOnly, routes.find, routes.delete

--- a/src/client/apps/articles_list/routes.ts
+++ b/src/client/apps/articles_list/routes.ts
@@ -40,7 +40,7 @@ export const articles_list = (req, res, next) => {
     .catch(error => {
       if (error) {
         console.warn(error)
-        next()
+        return next()
       }
       // If the user is authenticated and valid but not a member of the channel, redirect them to the settings page.
       return res.redirect("/settings")

--- a/src/client/apps/articles_list/routes.ts
+++ b/src/client/apps/articles_list/routes.ts
@@ -5,7 +5,7 @@ import { ArticlesListQuery as query } from "./query"
 
 const { API_URL } = process.env
 
-export const articles_list = (req, res, next) => {
+export const articles_list = (req, res) => {
   let published
   const channel_id = req.user.get("current_channel").id
 

--- a/src/client/apps/articles_list/routes.ts
+++ b/src/client/apps/articles_list/routes.ts
@@ -5,7 +5,7 @@ import { ArticlesListQuery as query } from "./query"
 
 const { API_URL } = process.env
 
-export const articles_list = (req, res) => {
+export const articles_list = (req, res, next) => {
   let published
   const channel_id = req.user.get("current_channel").id
 
@@ -37,7 +37,11 @@ export const articles_list = (req, res) => {
         })
       }
     })
-    .catch(() => {
+    .catch(error => {
+      if (error) {
+        console.warn(error)
+        next()
+      }
       // If the user is authenticated and valid but not a member of the channel, redirect them to the settings page.
       return res.redirect("/settings")
     })

--- a/src/client/apps/articles_list/routes.ts
+++ b/src/client/apps/articles_list/routes.ts
@@ -38,7 +38,8 @@ export const articles_list = (req, res, next) => {
       }
     })
     .catch(() => {
-      return next()
+      // If the user is authenticated and valid but not a member of the channel, redirect them to the settings page.
+      return res.redirect("/settings")
     })
 }
 

--- a/src/client/apps/articles_list/test/routes.test.ts
+++ b/src/client/apps/articles_list/test/routes.test.ts
@@ -145,6 +145,15 @@ describe("routes", () => {
       expect(next).toBeCalled()
     })
 
+    it("redirects to settings if no error", async () => {
+      res.redirect = jest.fn()
+      LokkaMock.mockImplementationOnce(() => ({
+        query: jest.fn().mockReturnValue(Promise.reject()),
+      }))
+      await articles_list(req, res, next)
+      expect(res.redirect).toBeCalled()
+    })
+
     describe("queries", () => {
       it("sets sd.HAS_PUBLISHED to true by default", async () => {
         await articles_list(req, res, next)

--- a/src/client/apps/articles_list/test/routes.test.ts
+++ b/src/client/apps/articles_list/test/routes.test.ts
@@ -139,7 +139,7 @@ describe("routes", () => {
 
     it("calls next if error is thrown", async () => {
       LokkaMock.mockImplementationOnce(() => ({
-        query: jest.fn().mockReturnValue(Promise.reject()),
+        query: jest.fn().mockReturnValue(Promise.reject({ error: "error" })),
       }))
       await articles_list(req, res, next)
       expect(next).toBeCalled()

--- a/src/client/apps/edit/components/header/index.tsx
+++ b/src/client/apps/edit/components/header/index.tsx
@@ -20,7 +20,7 @@ interface Props {
   deleteArticleAction: () => void
   edit: Edit
   forceURL: string
-  hasTeamRole: boolean
+  hasEditorialRole: boolean
   publishArticleAction: () => void
   saveArticleAction: () => void
 }
@@ -168,7 +168,7 @@ export class EditHeader extends Component<Props> {
       channel,
       edit,
       forceURL,
-      hasTeamRole,
+      hasEditorialRole,
     } = this.props
 
     const { isDeleting } = edit
@@ -186,7 +186,7 @@ export class EditHeader extends Component<Props> {
           >
             <Tab name="Content" />
             <Tab name="Display" />
-            {hasTeamRole && (<Tab name="Admin" /> as any)}
+            {hasEditorialRole && (<Tab name="Admin" /> as any)}
           </Tabs>
         </TabContainer>
 
@@ -264,7 +264,7 @@ const mapStateToProps = state => ({
   channel: state.app.channel,
   edit: state.edit,
   forceURL: state.app.forceURL,
-  hasTeamRole: state.app.hasTeamRole
+  hasEditorialRole: state.app.hasEditorialRole,
 })
 
 const mapDispatchToProps = {

--- a/src/client/apps/edit/components/header/test/index.test.tsx
+++ b/src/client/apps/edit/components/header/test/index.test.tsx
@@ -38,7 +38,7 @@ describe("Edit Header Controls", () => {
         isSaving: false,
         isPublishing: false,
       },
-      hasTeamRole: false,
+      hasEditorialRole: false,
       publishArticleAction: jest.fn(),
       saveArticleAction: jest.fn(),
     }
@@ -51,7 +51,7 @@ describe("Edit Header Controls", () => {
   })
 
   it("renders admin button for team users", () => {
-    props.hasTeamRole = true
+    props.hasEditorialRole = true
     const component = getWrapper()
 
     expect(component.find("TabButton").length).toBe(2)

--- a/src/client/apps/queue/index.coffee
+++ b/src/client/apps/queue/index.coffee
@@ -8,6 +8,6 @@ routes = require './routes'
 app = module.exports = express()
 app.set 'views', __dirname
 app.set 'view engine', 'jade'
-{ adminOnly } = require '../../lib/middleware.coffee'
+{ editorialOnly } = require '../../lib/middleware.coffee'
 
-app.get '/queue', adminOnly, routes.queue
+app.get '/queue', editorialOnly, routes.queue

--- a/src/client/apps/settings/index.coffee
+++ b/src/client/apps/settings/index.coffee
@@ -8,14 +8,14 @@ routes = require './routes'
 app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
-{ teamOnly, adminOnly } = require '../../lib/middleware.coffee'
+{ editorialOnly } = require '../../lib/middleware.coffee'
 
-app.get '/settings', teamOnly, routes.index
-app.get '/settings/curations', teamOnly, routes.curations
-app.get '/settings/curations/:id/edit', teamOnly, routes.editCuration
-app.post '/settings/curations/:id', teamOnly, routes.saveCuration
-app.get '/settings/channels', teamOnly, routes.channels
-app.get '/settings/channels/:id/edit', adminOnly, routes.editChannel
-app.post '/settings/channels/:id', adminOnly, routes.saveChannel
-app.get '/settings/tags', teamOnly, routes.tags
-app.get '/settings/authors', teamOnly, routes.authors
+app.get '/settings', editorialOnly, routes.index
+app.get '/settings/curations', editorialOnly, routes.curations
+app.get '/settings/curations/:id/edit', editorialOnly, routes.editCuration
+app.post '/settings/curations/:id', editorialOnly, routes.saveCuration
+app.get '/settings/channels', editorialOnly, routes.channels
+app.get '/settings/channels/:id/edit', editorialOnly, routes.editChannel
+app.post '/settings/channels/:id', editorialOnly, routes.saveChannel
+app.get '/settings/tags', editorialOnly, routes.tags
+app.get '/settings/authors', editorialOnly, routes.authors

--- a/src/client/components/layout/templates/sidebar.jade
+++ b/src/client/components/layout/templates/sidebar.jade
@@ -34,7 +34,7 @@
         include ../public/icons/layout_queue.svg
         br
         | Queue
-    if sd.USER.roles.includes("team")
+    if sd.USER.roles.includes("editorial")
       a#layout-sidebar-settings( href='/settings'
          class=(sd.URL.match('/settings') ? 'is-active' : '') )
         include ../public/icons/layout_settings.svg

--- a/src/client/lib/middleware.coffee
+++ b/src/client/lib/middleware.coffee
@@ -51,9 +51,9 @@ useragent = require 'useragent'
   else
     next()
 
-@teamOnly = (req, res, next) ->
-  if !req.user?.get('roles').includes("team")
-    err = new Error 'You must have "team" role'
+@editorialOnly = (req, res, next) ->
+  if !req.user?.get('roles').includes("editorial")
+    err = new Error 'You must have "editorial" role'
     err.status = 403
     next err
   else

--- a/src/client/lib/setup/auth.coffee
+++ b/src/client/lib/setup/auth.coffee
@@ -25,7 +25,7 @@ setupPassport = ->
       success: (user) ->
         user.set 'roles', jwtDecode(accessToken).roles
         id = user.get('channel_ids').concat(user.get('partner_ids'))[0]
-        id = process.env.DEFAULT_PARTNER_ID if not id and user.get('type') is 'Admin'
+        id = process.env.DEFAULT_PARTNER_ID if not id and user.get('roles').includes('editorial')
         new Channel(id: id).fetchChannelOrPartner
           headers: 'X-Access-Token': accessToken
           error: (m, err) ->

--- a/src/client/reducers/appReducer.ts
+++ b/src/client/reducers/appReducer.ts
@@ -24,7 +24,7 @@ export interface AppState {
   channel: ChannelState
   forceURL: string
   isAdmin: boolean
-  hasTeamRole: boolean
+  hasEditorialRole: boolean
   isEditorial: boolean
   isPartnerChannel: boolean
   metaphysicsURL: string
@@ -44,7 +44,8 @@ export const getInitialState = () =>
     channel: sd.CURRENT_CHANNEL,
     forceURL: sd.FORCE_URL,
     isAdmin: sd.USER && sd.USER.type === "Admin",
-    hasTeamRole: sd.USER && sd.USER.roles && sd.USER.roles.includes("team"),
+    hasEditorialRole:
+      sd.USER && sd.USER.roles && sd.USER.roles.includes("editorial"),
     isEditorial: sd.CURRENT_CHANNEL && sd.CURRENT_CHANNEL.type === "editorial",
     isPartnerChannel:
       sd.CURRENT_CHANNEL && sd.CURRENT_CHANNEL.type === "partner",


### PR DESCRIPTION
This pull request removes the 'team' and 'admin' roles and replaces them with the 'editorial' role.

[DIA-230]

[Gravity PR](https://github.com/artsy/gravity/pull/17223) for enabling the Editorial roles

[DIA-230]: https://artsyproduct.atlassian.net/browse/DIA-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

@artsy/diamond-devs 