### PR TITLE
fix: articles and sessions save functions

### DIFF
--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -162,9 +162,13 @@ removeStopWords = (title) ->
   return callback err if err
   article = setOnPublishFields article if article.published or article.scheduled_publish_at
   indexForSearch(article, ->) if article.indexable
-  inputData = _.omit(article, '_id')
-  db.collection('articles').updateOne { _id: article._id }, { $set: sanitize(inputData)}, { upsert: true }, (err, res) ->
-    db.collection('articles').findOne { _id: article._id || res.upsertedId }, callback
+  if article._id
+    inputData = _.omit(article, '_id')
+    db.collection('articles').updateOne { _id: article._id }, { $set: sanitize(article) }, (err, res) ->
+      db.collection('articles').findOne { _id: article._id }, callback
+  else
+    db.collection('articles').insertOne sanitize(article), (err, res) ->
+      db.collection('articles').findOne { _id: res.insertedId }, callback
 
 # TODO: Create a Joi plugin for this https://github.com/hapijs/joi/issues/577
 sanitize = (article) ->

--- a/src/api/apps/articles/test/model/save.spec.ts
+++ b/src/api/apps/articles/test/model/save.spec.ts
@@ -418,16 +418,13 @@ describe("Save", () => {
 
   describe("#sanitizeAndSave", () => {
     it("skips sanitizing links that do not have an href", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.sections[0].body.should.containEql("<a></a>")
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.sections[0].body.should.containEql("<a></a>")
+        done()
+      })(null, {
         sections: [
           {
             type: "text",
@@ -437,18 +434,15 @@ describe("Save", () => {
       }))
 
     it("sanitizes non artsy links", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.sections[0].body.should.containEql(
-            '<a href="http://insecure-website.com/">link</a><a href="https://insecure-website.com/">link</a>'
-          )
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.sections[0].body.should.containEql(
+          '<a href="http://insecure-website.com/">link</a><a href="https://insecure-website.com/">link</a>'
+        )
+        done()
+      })(null, {
         sections: [
           {
             type: "text",
@@ -459,18 +453,15 @@ describe("Save", () => {
       }))
 
     it("sanitizes www.artsy.net links", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.sections[0].body.should.containEql(
-            '<a href="https://www.artsy.net/artist/andy-warhol">link</a>'
-          )
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.sections[0].body.should.containEql(
+          '<a href="https://www.artsy.net/artist/andy-warhol">link</a>'
+        )
+        done()
+      })(null, {
         sections: [
           {
             type: "text",
@@ -480,18 +471,15 @@ describe("Save", () => {
       }))
 
     it("sanitizes *.artsy.net links", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.sections[0].body.should.containEql(
-            '<a href="https://folio.artsy.net/">link</a>'
-          )
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.sections[0].body.should.containEql(
+          '<a href="https://folio.artsy.net/">link</a>'
+        )
+        done()
+      })(null, {
         sections: [
           {
             type: "text",
@@ -501,70 +489,58 @@ describe("Save", () => {
       }))
 
     it("sanitizes lead_paragraph", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.lead_paragraph.should.containEql(
-            '<a href="https://insecure-website.com/">link</a><a href="https://www.artsy.net/artist/andy-warhol">artsy link</a>'
-          )
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.lead_paragraph.should.containEql(
+          '<a href="https://insecure-website.com/">link</a><a href="https://www.artsy.net/artist/andy-warhol">artsy link</a>'
+        )
+        done()
+      })(null, {
         lead_paragraph:
           '<a href="insecure-website.com">link</a><a href="http://artsy.net/artist/andy-warhol">artsy link</a>',
       }))
 
     it("sanitizes postscript", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.postscript.should.containEql(
-            '<a href="https://insecure-website.com/">link</a><a href="https://www.artsy.net/artist/andy-warhol">artsy link</a>'
-          )
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.postscript.should.containEql(
+          '<a href="https://insecure-website.com/">link</a><a href="https://www.artsy.net/artist/andy-warhol">artsy link</a>'
+        )
+        done()
+      })(null, {
         postscript:
           '<a href="insecure-website.com">link</a><a href="http://artsy.net/artist/andy-warhol">artsy link</a>',
       }))
 
     it("sanitizes news_source", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.news_source.url.should.containEql(
-            "https://www.artsy.net/artist/andy-warhol"
-          )
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.news_source.url.should.containEql(
+          "https://www.artsy.net/artist/andy-warhol"
+        )
+        done()
+      })(null, {
         news_source: {
           url: "http://artsy.net/artist/andy-warhol",
         },
       }))
 
     it("can save follow artist links (allowlist data-id)", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.sections[0].body.should.containEql(
-            '<a data-id="andy-warhol"></a>'
-          )
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.sections[0].body.should.containEql(
+          '<a data-id="andy-warhol"></a>'
+        )
+        done()
+      })(null, {
         sections: [
           {
             type: "text",
@@ -574,16 +550,13 @@ describe("Save", () => {
       }))
 
     it("can save layouts on text sections", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.sections[0].layout.should.eql("blockquote")
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.sections[0].layout.should.eql("blockquote")
+        done()
+      })(null, {
         sections: [
           {
             type: "text",
@@ -594,49 +567,40 @@ describe("Save", () => {
       }))
 
     it("indexes articles that are indexable", done => {
-      Save.sanitizeAndSave(() => {
-        Article.find("5086df098523e60002000011", (err, _article) => {
-          if (err) {
-            done(err)
-          }
-          indexForSearch.callCount.should.eql(1)
-          done()
-        })
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        indexForSearch.callCount.should.eql(1)
+        done()
       })(null, {
         indexable: true,
         published: true,
-        _id: new ObjectId("5086df098523e60002000011"),
       })
     })
 
     it("skips indexing articles that are not indexable", done => {
-      Save.sanitizeAndSave(() => {
-        Article.find("5086df098523e60002000011", (err, _article) => {
-          if (err) {
-            done(err)
-          }
-          indexForSearch.callCount.should.eql(0)
-          done()
-        })
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        indexForSearch.callCount.should.eql(0)
+        done()
       })(null, {
         indexable: false,
-        _id: new ObjectId("5086df098523e60002000011"),
       })
     })
 
     it("saves email metadata", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.email_metadata.image_url.should.containEql("foo.png")
-          article.email_metadata.author.should.containEql("Kana")
-          article.email_metadata.headline.should.containEql("Thumbnail Title")
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.email_metadata.image_url.should.containEql("foo.png")
+        article.email_metadata.author.should.containEql("Kana")
+        article.email_metadata.headline.should.containEql("Thumbnail Title")
+        done()
+      })(null, {
         thumbnail_title: "Thumbnail Title",
         thumbnail_image: "foo.png",
         scheduled_publish_at: "123",
@@ -646,18 +610,15 @@ describe("Save", () => {
       }))
 
     it("does not override email metadata", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.email_metadata.image_url.should.containEql("bar.png")
-          article.email_metadata.author.should.containEql("Artsy Editorial")
-          article.email_metadata.headline.should.containEql("Custom Headline")
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.email_metadata.image_url.should.containEql("bar.png")
+        article.email_metadata.author.should.containEql("Artsy Editorial")
+        article.email_metadata.headline.should.containEql("Custom Headline")
+        done()
+      })(null, {
         thumbnail_title: "Thumbnail Title",
         thumbnail_image: "foo.png",
         email_metadata: {
@@ -669,74 +630,62 @@ describe("Save", () => {
       }))
 
     it("saves generated descriptions", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.description.should.containEql("Testing 123")
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.description.should.containEql("Testing 123")
+        done()
+      })(null, {
         published: true,
         sections: [{ type: "text", body: "<p>Testing 123</p>" }],
       }))
 
     it("does not override description", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.description.should.containEql("Do not override me")
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.description.should.containEql("Do not override me")
+        done()
+      })(null, {
         sections: [{ type: "text", body: "<p>Testing 123</p>" }],
         description: "Do not override me",
       }))
 
     it("Strips linebreaks from titles", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.title.should.containEql("A new title")
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.title.should.containEql("A new title")
+        done()
+      })(null, {
         thumbnail_title: "Thumbnail Title",
         sections: [{ type: "text", body: "<p>Testing 123</p>" }],
         title: "A new title \n",
       }))
 
     it("saves media", done =>
-      Save.sanitizeAndSave(() =>
-        Article.find("5086df098523e60002000011", (err, article) => {
-          if (err) {
-            done(err)
-          }
-          article.media.url.should.equal("https://media.artsy.net/video.mp4")
-          article.media.cover_image_url.should.equal(
-            "https://media.artsy.net/images.jpg"
-          )
-          article.media.duration.should.equal(1000)
-          article.media.release_date.should.equal("2017-01-01")
-          article.media.published.should.equal(false)
-          article.media.description.should.equal(
-            "<p>This video is about kittens.</p>"
-          )
-          article.media.credits.should.equal(
-            "<p><b>Director</b><br>Marina Cashdan</p>"
-          )
-          done()
-        })
-      )(null, {
-        _id: new ObjectId("5086df098523e60002000011"),
+      Save.sanitizeAndSave((err, article) => {
+        if (err) {
+          done(err)
+        }
+        article.media.url.should.equal("https://media.artsy.net/video.mp4")
+        article.media.cover_image_url.should.equal(
+          "https://media.artsy.net/images.jpg"
+        )
+        article.media.duration.should.equal(1000)
+        article.media.release_date.should.equal("2017-01-01")
+        article.media.published.should.equal(false)
+        article.media.description.should.equal(
+          "<p>This video is about kittens.</p>"
+        )
+        article.media.credits.should.equal(
+          "<p><b>Director</b><br>Marina Cashdan</p>"
+        )
+        done()
+      })(null, {
         media: {
           url: "https://media.artsy.net/video.mp4",
           cover_image_url: "https://media.artsy.net/images.jpg",

--- a/src/api/apps/articles/test/model/save.spec.ts
+++ b/src/api/apps/articles/test/model/save.spec.ts
@@ -1,9 +1,7 @@
 import moment from "moment"
-import { ObjectId } from "mongodb"
 import rewire from "rewire"
 import sinon from "sinon"
 import { times } from "underscore"
-import * as Article from "../../model"
 const { fabricate, empty } = require("../../../../test/helpers/db.coffee")
 const Save = rewire("../../model/save.coffee")
 const gravity = require("@artsy/antigravity").server
@@ -567,7 +565,7 @@ describe("Save", () => {
       }))
 
     it("indexes articles that are indexable", done => {
-      Save.sanitizeAndSave((err, article) => {
+      Save.sanitizeAndSave(err => {
         if (err) {
           done(err)
         }
@@ -580,7 +578,7 @@ describe("Save", () => {
     })
 
     it("skips indexing articles that are not indexable", done => {
-      Save.sanitizeAndSave((err, article) => {
+      Save.sanitizeAndSave(err => {
         if (err) {
           done(err)
         }

--- a/src/api/apps/sessions/model.js
+++ b/src/api/apps/sessions/model.js
@@ -68,14 +68,18 @@ export const save = (inputData, callback) => {
       _id: id,
     }
 
-    db.collection("sessions").updateOne(
-      { _id: data._id },
-      { $set: inputData },
-      { upsert: true },
-      (err, res) => {
-        db.collection("sessions").findOne({ _id: res.upsertedId }, callback)
-      }
-    )
+    if (data._id)
+      db.collection("sessions").updateOne(
+        { _id: data._id },
+        { $set: inputData },
+        (err, res) => {
+          db.collection("sessions").findOne({ _id: data._id }, callback)
+        }
+      )
+    else
+      db.collection("sessions").insertOne(inputData, (err, res) => {
+        db.collection("sessions").findOne({ _id: res.insertedId }, callback)
+      })
   })
 }
 

--- a/src/api/apps/sessions/test/model.spec.js
+++ b/src/api/apps/sessions/test/model.spec.js
@@ -19,8 +19,6 @@ describe("Sessions Model", () => {
   it("#save", done => {
     save(
       {
-        _id: "59fa424574132b001d917253",
-        id: "59fa424574132b001d917253",
         timestamp: "2018-02-20T21:13:09.358Z",
         user: { id: "586ff4069c18db5923002ca6", name: "Luc Succes" },
         article: "59fa424574132b001d917253",
@@ -31,7 +29,7 @@ describe("Sessions Model", () => {
         },
       },
       (_, session) => {
-        session._id.should.equal("59fa424574132b001d917253")
+        session.article.should.equal("59fa424574132b001d917253")
         done()
       }
     )
@@ -40,8 +38,6 @@ describe("Sessions Model", () => {
   it("Can #save without username (partners)", done => {
     save(
       {
-        _id: "59fa424574132b001d917253",
-        id: "59fa424574132b001d917253",
         timestamp: "2018-02-20T21:13:09.358Z",
         user: { id: "586ff4069c18db5923002ca6" },
         article: "59fa424574132b001d917253",
@@ -52,7 +48,7 @@ describe("Sessions Model", () => {
         },
       },
       (_, session) => {
-        session._id.should.equal("59fa424574132b001d917253")
+        session.article.should.equal("59fa424574132b001d917253")
         done()
       }
     )


### PR DESCRIPTION
This PR patches #3131 after testing on staging exposed a regression. 

### Problem
Users were unable to create or edit articles as a bug in the save logic meant that documents were being persisted with a `_id` of `null` when `upserted`.

### Solution
Change the implementation of the `articles` and `sessions`' `save` method to check for an existing `_id` of the object to be persisted, use `updateOne` when it exists, and use `insertOne` (instead of an `upsert` on a `updateOne`) when it doesn't. 

### Considerations
- I**n the existing implementation (i.e. pre #3131), the save method accepts explicitly setting an `_id` value for documents rather than always relying on `mongodb` to generate them upon creation. So, for example, if I called `Article.save` while passing an object with a key-value pair of `_id: 123`, it would respect this and persist an `article` with `123` as the `_id`. It would also except `null` or `undefined` as values, which is what is causing the bug.** 
- With refactors of this kind, I aim to not change test implementations as they can easily result in false positives, however, it felt warranted in this case. My read of the code is that the tests I have modified were relying on this behavior as a test convenience rather than an assertion that it would explicitly set the `_id` field with whatever value is passed in. 

If I am missing something in the code, or using bad assumptions, then please let me know. 