### PR TITLE
fix: model persistence

### DIFF
--- a/src/api/apps/articles/model/save.coffee
+++ b/src/api/apps/articles/model/save.coffee
@@ -163,7 +163,6 @@ removeStopWords = (title) ->
   article = setOnPublishFields article if article.published or article.scheduled_publish_at
   indexForSearch(article, ->) if article.indexable
   if article._id
-    inputData = _.omit(article, '_id')
     db.collection('articles').updateOne { _id: article._id }, { $set: sanitize(article) }, (err, res) ->
       db.collection('articles').findOne { _id: article._id }, callback
   else

--- a/src/api/apps/authors/model.coffee
+++ b/src/api/apps/authors/model.coffee
@@ -76,8 +76,12 @@ Joi = require '../../lib/joi'
     return callback err if err
     data = extend omit(input, 'id'),
       _id: input.id
-    db.collection("authors").insertOne data, (err, res) ->
-      db.collection("authors").findOne { _id: res.insertedId }, callback
+    if data._id
+      db.collection("authors").updateOne { _id: data._id }, { $set: data }, (err, res) ->
+        db.collection("authors").findOne { _id: data._id }, callback
+    else
+      db.collection("authors").insertOne data, (err, res) ->
+        db.collection("authors").findOne { _id: res.insertedId }, callback
 
 @destroy = (id, callback) ->
   db.collection("authors").removeOne { _id: new ObjectId(id) }, callback

--- a/src/api/apps/authors/test/model.test.coffee
+++ b/src/api/apps/authors/test/model.test.coffee
@@ -64,6 +64,9 @@ describe 'Author', ->
         author.image_url.should.equal 'https://artsy-media/owen.jpg'
         author.twitter_handle.should.equal '@owendodd'
         author.bio.should.equal 'Designer based in NYC'
+        Author.save { id: author._id.toString(), name: 'Jane Doe'}, (err, updatedAuthor) ->
+          updatedAuthor._id.toString().should.equal author._id.toString()
+          updatedAuthor.name.should.equal 'Jane Doe'
         db.collection('authors').count (err, count) ->
           count.should.equal 11
           done()

--- a/src/api/apps/channels/model.coffee
+++ b/src/api/apps/channels/model.coffee
@@ -97,8 +97,12 @@ sortParamToQuery = (input) ->
     data = _.extend _.omit(input, 'id'),
       _id: input.id
       slug: _s.slugify(input.slug) if input.slug
-    db.collection('channels').insertOne data, (err, res) ->
-      db.collection('channels').findOne { _id: res.insertedId }, callback
+    if data._id
+      db.collection('channels').updateOne { _id: data._id }, { $set: data }, (err, res) ->
+        db.collection('channels').findOne { _id: data._id }, callback
+    else
+      db.collection('channels').insertOne data, (err, res) ->
+        db.collection('channels').findOne { _id: res.insertedId }, callback
 
 @destroy = (id, callback) ->
   db.collection('channels').remove { _id: new ObjectId(id) }, callback

--- a/src/api/apps/channels/test/model.test.coffee
+++ b/src/api/apps/channels/test/model.test.coffee
@@ -129,6 +129,9 @@ describe 'Channel', ->
         channel.slug.should.equal 'editorial'
         channel.pinned_articles[0].id.toString().should.equal '5086df098523e60002000015'
         channel.pinned_articles[1].id.toString().should.equal '5086df098523e60002000011'
+        Channel.save({id: channel._id.toString(), name: 'New Name'}, (err, updatedChannel) ->
+          updatedChannel._id.toString().should.equal channel._id.toString()
+          updatedChannel.name.should.equal 'New Name')
         done()
 
   describe '#present', ->

--- a/src/api/apps/curations/model.coffee
+++ b/src/api/apps/curations/model.coffee
@@ -67,8 +67,12 @@ OPTIONS = { allowUnknown: true, stripUnknown: false }
     return callback err if err
     data = _.extend _.omit(input, 'id'),
       _id: input.id
-    db.collection('curations').insertOne data, (err, res) ->
-      db.collection('curations').findOne {_id: res.insertedId}, callback
+    if data._id
+      db.collection("curations").updateOne { _id: data._id }, { $set: data }, (err, res) ->
+        db.collection("curations").findOne { _id: data._id }, callback
+    else
+      db.collection("curations").insertOne data, (err, res) ->
+        db.collection("curations").findOne { _id: res.insertedId }, callback
 
 @destroy = (id, callback) ->
   db.collection('curations').deleteOne { _id: new ObjectId(id) }, callback

--- a/src/api/apps/curations/test/model.test.coffee
+++ b/src/api/apps/curations/test/model.test.coffee
@@ -36,6 +36,9 @@ describe 'Curations', ->
         name: 'The General Title'
       }, (err, curation) ->
         curation.name.should.equal 'The General Title'
+        Curations.save {id: curation._id.toString(), name: 'The Updated Title'}, (err, updatedCuration) ->
+          updatedCuration._id.toString().should.equal curation.id.toString()
+          updatedCuration.name.should.equal 'The Updated Title'
         db.collection('curations').count (err, count) ->
           count.should.equal 11
           done()

--- a/src/api/apps/curations/test/model.test.coffee
+++ b/src/api/apps/curations/test/model.test.coffee
@@ -37,7 +37,7 @@ describe 'Curations', ->
       }, (err, curation) ->
         curation.name.should.equal 'The General Title'
         Curations.save {id: curation._id.toString(), name: 'The Updated Title'}, (err, updatedCuration) ->
-          updatedCuration._id.toString().should.equal curation.id.toString()
+          updatedCuration._id.toString().should.equal curation._id.toString()
           updatedCuration.name.should.equal 'The Updated Title'
         db.collection('curations').count (err, count) ->
           count.should.equal 11

--- a/src/api/apps/graphql/resolvers.js
+++ b/src/api/apps/graphql/resolvers.js
@@ -183,7 +183,7 @@ export const relatedArticles = (root, args, req) => {
 }
 
 export const relatedArticlesPanel = root => {
-  let omittedIds = [ObjectId(root.id)]
+  let omittedIds = [new ObjectId(root.id)]
   if (root.related_article_ids) {
     omittedIds = omittedIds.concat(root.related_article_ids)
   }
@@ -193,7 +193,7 @@ export const relatedArticlesPanel = root => {
     omit: omittedIds,
     published: true,
     featured: true,
-    channel_id: ObjectId(root.channel_id),
+    channel_id: new ObjectId(root.channel_id),
     tags: tags,
     limit: 3,
     sort: "-published_at",
@@ -236,20 +236,20 @@ export const relatedArticlesPanel = root => {
 }
 
 export const relatedArticlesCanvas = root => {
-  let omittedIds = [ObjectId(root.id)]
+  let omittedIds = [new ObjectId(root.id)]
   if (root.related_article_ids) {
     omittedIds = omittedIds.concat(root.related_article_ids)
   }
 
   const vertical =
-    root.vertical && root.vertical.id ? ObjectId(root.vertical.id) : null
+    root.vertical && root.vertical.id ? new ObjectId(root.vertical.id) : null
 
   const args = {
     omit: omittedIds,
     published: true,
     featured: true,
     in_editorial_feed: true,
-    channel_id: ObjectId(root.channel_id),
+    channel_id: new ObjectId(root.channel_id),
     vertical,
     limit: 4,
     sort: "-published_at",

--- a/src/api/apps/sections/model.coffee
+++ b/src/api/apps/sections/model.coffee
@@ -82,8 +82,12 @@ querySchema = (->
     return callback err if err
     data = _.extend _.omit(input, 'id'),
       _id: input.id
-    db.collection('sections').insertOne data, (err, res) ->
-      db.collection('sections').findOne {_id: res.insertedId}, callback
+    if data._id
+      db.collection("sections").updateOne { _id: data._id }, { $set: data }, (err, res) ->
+        db.collection("sections").findOne { _id: data._id }, callback
+    else
+      db.collection("sections").insertOne data, (err, res) ->
+        db.collection("sections").findOne { _id: res.insertedId }, callback
 
 @destroy = (id, callback) ->
   db.collection('sections').remove { _id: new ObjectId(id) }, callback

--- a/src/api/apps/sections/test/model.test.coffee
+++ b/src/api/apps/sections/test/model.test.coffee
@@ -39,7 +39,7 @@ describe 'Section', ->
         section.title.should.equal 'Top Ten Shows'
         section.description.should.equal 'Hello World'
         Section.save {id: section._id.toString(), title: 'Top Ten Shows Updated'}, (err, updatedSection) ->
-          updatedSection._id.toString().should.equal section.id.toString()
+          updatedSection._id.toString().should.equal section._id.toString()
           updatedSection.title.should.equal 'Top Ten Shows Updated'
         db.collection('sections').count (err, count) ->
           count.should.equal 11

--- a/src/api/apps/sections/test/model.test.coffee
+++ b/src/api/apps/sections/test/model.test.coffee
@@ -38,6 +38,9 @@ describe 'Section', ->
       }, (err, section) ->
         section.title.should.equal 'Top Ten Shows'
         section.description.should.equal 'Hello World'
+        Section.save {id: section._id.toString(), title: 'Top Ten Shows Updated'}, (err, updatedSection) ->
+          updatedSection._id.toString().should.equal section.id.toString()
+          updatedSection.title.should.equal 'Top Ten Shows Updated'
         db.collection('sections').count (err, count) ->
           count.should.equal 11
           done()

--- a/src/api/apps/tags/model.coffee
+++ b/src/api/apps/tags/model.coffee
@@ -74,8 +74,12 @@ Joi = require '../../lib/joi'
     return callback err if err
     data = _.extend _.omit(input, 'id'),
       _id: input.id
-    db.collection('tags').insertOne data, (err, res) ->
-      db.collection('tags').findOne {_id: res.insertedId}, callback
+    if data._id
+      db.collection("tags").updateOne { _id: data._id }, { $set: data }, (err, res) ->
+        db.collection("tags").findOne { _id: data._id }, callback
+    else
+      db.collection("tags").insertOne data, (err, res) ->
+        db.collection("tags").findOne { _id: res.insertedId }, callback
 
 @destroy = (id, callback) ->
   db.collection('tags').remove { _id: new ObjectId(id) }, callback

--- a/src/api/apps/tags/test/model.test.coffee
+++ b/src/api/apps/tags/test/model.test.coffee
@@ -39,6 +39,10 @@ describe 'Tag', ->
       }, (err, tag) ->
         tag.name.should.equal 'Berlin'
         tag.public.should.be.true()
+        Tag.save {id: tag._id.toString(), name: 'New York', public: false}, (err, updatedTag) ->
+          updatedTag._id.toString().should.equal tag.id.toString()
+          updatedTag.name.should.equal 'New York'
+          updatedTag.public.should.be.false()
         db.collection('tags').count (err, count) ->
           count.should.equal 11
           done()

--- a/src/api/apps/tags/test/model.test.coffee
+++ b/src/api/apps/tags/test/model.test.coffee
@@ -40,7 +40,7 @@ describe 'Tag', ->
         tag.name.should.equal 'Berlin'
         tag.public.should.be.true()
         Tag.save {id: tag._id.toString(), name: 'New York', public: false}, (err, updatedTag) ->
-          updatedTag._id.toString().should.equal tag.id.toString()
+          updatedTag._id.toString().should.equal tag._id.toString()
           updatedTag.name.should.equal 'New York'
           updatedTag.public.should.be.false()
         db.collection('tags').count (err, count) ->

--- a/src/api/apps/users/model.coffee
+++ b/src/api/apps/users/model.coffee
@@ -52,7 +52,7 @@ jwtDecode = require 'jwt-decode'
 save = (user, accessToken, callback) ->
   async.parallel [
     (cb) ->
-      db.collection('users').findOne {_id: ObjectId(user.id)}, cb
+      db.collection('users').findOne {user_ids: ObjectId(user.id)}, cb
     (cb) ->
       bcrypt.hash accessToken, SALT, cb
   ], (err, results) ->

--- a/src/api/apps/users/model.coffee
+++ b/src/api/apps/users/model.coffee
@@ -61,16 +61,16 @@ save = (user, accessToken, callback) ->
     user.partner_ids = _.map partner_ids, ObjectId
     user.channel_ids = _.pluck results[0], '_id'
     encryptedAccessToken = results[1]
-    db.collection('users').insertOne {
-      _id: ObjectId(user.id)
+    data = {
       name: user.name
       email: user.email
       type: user.type
       access_token: encryptedAccessToken
       partner_ids: user.partner_ids
       channel_ids: user.channel_ids
-    }, (err, res) ->
-      db.collection('users').findOne {_id: res.insertedId}, callback
+    }
+    db.collection('users').updateOne { _id: ObjectId(user.id) }, { $set: data }, { upsert: true }, (err, res) ->
+      db.collection('users').findOne {_id: res.upsertedId || user._id}, callback
 #
 # Utility
 #

--- a/src/api/apps/verticals/model.coffee
+++ b/src/api/apps/verticals/model.coffee
@@ -68,8 +68,12 @@ Joi = require '../../lib/joi'
     return callback err if err
     data = _.extend _.omit(input, 'id'),
       _id: input.id
-    db.collection('verticals').insertOne data, (err, res) ->
-      db.collection('verticals').findOne {_id: res.insertedId}, callback
+    if data._id
+      db.collection("verticals").updateOne { _id: data._id }, { $set: data }, (err, res) ->
+        db.collection("verticals").findOne { _id: data._id }, callback
+    else
+      db.collection("verticals").insertOne data, (err, res) ->
+        db.collection("verticals").findOne { _id: res.insertedId }, callback
 
 @destroy = (id, callback) ->
   db.collection('verticals').remove { _id: new ObjectId(id) }, callback

--- a/src/api/apps/verticals/test/model.test.coffee
+++ b/src/api/apps/verticals/test/model.test.coffee
@@ -36,6 +36,9 @@ describe 'Vertical', ->
         name: 'Art Market'
       }, (err, vertical) ->
         vertical.name.should.equal 'Art Market'
+        Vertical.save {id: vertical._id.toString(), name: 'Art Market Updated'}, (err, updatedVertical) ->
+          updatedVertical._id.toString().should.equal vertical.id.toString()
+          updatedVertical.name.should.equal 'Art Market Updated'
         db.collection('verticals').count (err, count) ->
           count.should.equal 11
           done()


### PR DESCRIPTION
This PR is a follow-up to #3134 refactors the `save` method of the `authors`, `channels`, `curations`, `sections`, `tags`, and `users` models to support `update`, not just `insert`, operations. There were no assertions about updating in the previous test suite, so these have been added.
