### PR TITLE
fix use ObjectId class in users save method

### DIFF
--- a/scripts/count.coffee
+++ b/scripts/count.coffee
@@ -8,7 +8,7 @@ env = require 'node-env-file'
 client = new MongoClient(process.env.MONGOHQ_URL)
 await client.connect()
 db = await client.db()
-collection = await db.collection('articles')
+articles = await db.collection('articles')
 
 articles.find(indexable: true).count (err, count) ->
   console.log(count)

--- a/src/api/apps/users/model.coffee
+++ b/src/api/apps/users/model.coffee
@@ -70,7 +70,7 @@ save = (user, accessToken, callback) ->
       channel_ids: user.channel_ids
     }
     db.collection('users').updateOne { _id: ObjectId(user.id) }, { $set: data }, { upsert: true }, (err, res) ->
-      db.collection('users').findOne {_id: res.upsertedId || user._id}, callback
+      db.collection('users').findOne {_id: res.upsertedId || ObjectId(user.id)}, callback
 #
 # Utility
 #


### PR DESCRIPTION
This PR patches #3135 to use the `ObjectId` class when looking for the updated document in the `users`' `save` function. previously it was returning `null` causing the page to throw `Error: Could not find a user from that access token`.