### PR TITLE
fix: use find instead of findOne for user collections

### DIFF
--- a/src/api/apps/users/model.coffee
+++ b/src/api/apps/users/model.coffee
@@ -52,7 +52,7 @@ jwtDecode = require 'jwt-decode'
 save = (user, accessToken, callback) ->
   async.parallel [
     (cb) ->
-      db.collection('channels').findOne {user_ids: ObjectId(user.id)}, cb
+      db.collection('channels').find({user_ids: ObjectId(user.id)}).toArray cb
     (cb) ->
       bcrypt.hash accessToken, SALT, cb
   ], (err, results) ->


### PR DESCRIPTION
Patch #3135 to use the correct operator when setting up the `channel_ids` on the `user`. 