### PR TITLE
fix: use collection.countDocuments instead of cursor.count

### DIFF
--- a/src/api/apps/articles/model/index.js
+++ b/src/api/apps/articles/model/index.js
@@ -60,7 +60,7 @@ export const mongoFetch = (input, callback) => {
         if (!count) {
           return cb()
         }
-        return cursor.count(cb)
+        return db.collection("articles").countDocuments(query, cb)
       },
     ],
     (err, results) => {
@@ -99,7 +99,7 @@ export const promisedMongoFetch = input => {
           if (!count) {
             return cb()
           }
-          return cursor.count(cb)
+          return db.collection("articles").countDocuments(query, cb)
         },
       ],
       (err, results) => {

--- a/src/api/apps/articles/test/model/index/index.spec.ts
+++ b/src/api/apps/articles/test/model/index/index.spec.ts
@@ -251,4 +251,27 @@ describe("Article", () => {
             results.length.should.equal(1)
           })
       )))
+
+  describe("#mongoFetch", () =>
+    it("returns results, counts, and totals", done =>
+      fabricate(
+        "articles",
+        { _id: new ObjectId("5086df098523e60002000018"), layout: "video" },
+        () =>
+          Article.mongoFetch(
+            {
+              count: true,
+              limit: 5,
+              offset: 0,
+              layout: "standard",
+            },
+            // @ts-ignore
+            (err, res) => {
+              res.results.length.should.equal(5)
+              res.total.should.equal(11)
+              res.count.should.equal(10)
+              done()
+            }
+          )
+      )))
 })

--- a/src/api/apps/authors/model.coffee
+++ b/src/api/apps/authors/model.coffee
@@ -57,7 +57,7 @@ Joi = require '../../lib/joi'
     (cb) -> cursor.toArray cb
     (cb) ->
       return cb() unless input.count
-      cursor.count cb
+      db.collection("authors").countDocuments query, cb
     (cb) ->
       return cb() unless input.count
       db.collection("authors").count cb

--- a/src/api/apps/channels/model.coffee
+++ b/src/api/apps/channels/model.coffee
@@ -69,7 +69,7 @@ request = require 'superagent'
     .skip(input.offset or 0)
   async.parallel [
     (cb) -> cursor.toArray cb
-    (cb) -> cursor.count cb
+    (cb) -> db.collection('channels').countDocuments query, cb
     (cb) -> db.collection('channels').count cb
   ], (err, [channels, count, total]) =>
     callback err, {

--- a/src/api/apps/curations/model.coffee
+++ b/src/api/apps/curations/model.coffee
@@ -50,7 +50,7 @@ OPTIONS = { allowUnknown: true, stripUnknown: false }
     .skip(input.offset or 0)
   async.parallel [
     (cb) -> cursor.toArray cb
-    (cb) -> cursor.count cb
+    (cb) -> db.collection('curations').countDocuments(query, cb)
     (cb) -> db.collection('curations').count cb
   ], (err, [curations, count, total]) =>
     callback err, {

--- a/src/api/apps/sections/model.coffee
+++ b/src/api/apps/sections/model.coffee
@@ -65,7 +65,7 @@ querySchema = (->
       .skip(input.offset or 0)
     async.parallel [
       (cb) -> cursor.toArray cb
-      (cb) -> cursor.count cb
+      (cb) -> db.collection('sections').countDocuments(query, cb)
       (cb) -> db.collection('sections').count cb
     ], (err, [sections, count, total]) =>
       callback err, {

--- a/src/api/apps/tags/model.coffee
+++ b/src/api/apps/tags/model.coffee
@@ -55,7 +55,7 @@ Joi = require '../../lib/joi'
     (cb) -> cursor.toArray cb
     (cb) ->
       return cb() unless input.count
-      cursor.count cb
+      db.collection('tags').countDocuments(query, cb)
     (cb) ->
       return cb() unless input.count
       db.collection('tags').count cb

--- a/src/api/apps/verticals/model.coffee
+++ b/src/api/apps/verticals/model.coffee
@@ -49,7 +49,7 @@ Joi = require '../../lib/joi'
     (cb) -> cursor.toArray cb
     (cb) ->
       return cb() unless input.count
-      cursor.count cb
+      db.collection('verticals').countDocuments(query, cb)
     (cb) ->
       return cb() unless input.count
       db.collection('verticals').count cb


### PR DESCRIPTION
This patches #3131 to use `collection.countDocuments` instead of  `cursor.count` which has a different behavior in the native `mongodb@4.10` driver than the previously used `mongojs` library. Additionally, [support it is deprecated](https://my.papertrailapp.com/groups/3675843/events?q=program%3Apositron+cursor.count).

`cursor.count()` will return the count of the artworks returned from the `find` cursor. However, what our clients are expecting is the total number of documents that will be returned from a passed-in query. This currently breaks pagination, as flagged by the editorial team 🔒 [here](https://artsy.slack.com/archives/C03N12SR0RK/p1707168354368809).

```javascript
const cursor = db
    .collection("articles")
    .find(query)
    .skip(offset || 0)
    .sort(sort)
    .limit(limit)
    
    // Will return the # of documents returned from the above query, factoring in the `limit`.  
    // If the value of `limit` is `15`, it will return `15` (or less if there are not `15` documents matching the query). 
    return cursor.count(cb)
    
    // Will return the total # of documents matching the query in the whole collection 
    return db.collection("articles").countDocuments(query, cb)
   ```