### PR TITLE
feat: updates to support indexing to ES v7

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -19,7 +19,8 @@ services:
     ports:
       - 3005:3005
   positron-elasticsearch:
-    image: artsy/elasticsearch:6.8.23
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
+    user: elasticsearch
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -14,7 +14,8 @@ services:
       - positron-mongodb
       - positron-elasticsearch
   positron-elasticsearch:
-    image: artsy/elasticsearch:6.8.23
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
+    user: elasticsearch
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false


### PR DESCRIPTION
Positron is fully compatible with either v6 _or_ v7 so this can be merged whenever.