### PR TITLE
chore: bump mongodb to 6.0.16

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -30,7 +30,7 @@ services:
       - 9300:9300
       - 9200:9200
   positron-mongodb:
-    image: mongo:5.0.23
+    image: mongo:6.0.16
     command: ["--quiet", "--nojournal"]
     ports:
       - 27017:27017

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "9200:9200"
   positron-mongodb:
-    image: mongo:5.0.23
+    image: mongo:6.0.16
     ports:
       - "27017:27017"
     command: ["--quiet", "--nojournal"]


### PR DESCRIPTION
This PR upgrades the mongo images used during testing and development (`5.0.x` -> `6.0.16`). 

Mongo version 5 reaches its [EOL date in October 2024](https://www.mongodb.com/legal/support-policy/lifecycles), at which point our Atlas clusters will be auto-updated. Let's perform the necessary updates to our systems with plenty of lead time to patch any resulting issues.

### Considerations

- `16.0.16` is the most [recent version](https://www.mongodb.com/docs/v6.0/release-notes/6.0/) of v6. 
- This will not change anything in `staging` or `production`. It only updates our `ci` and local development (when using `hokusai`) environments. 
- Developers will need to pull down a `mongodb@6` from `brew`. We will announce this in slack once this branch is merged. 

### Related PR
- https://github.com/artsy/gravity/pull/17943

[PHIRE-1058]

[PHIRE-1058]: https://artsyproduct.atlassian.net/browse/PHIRE-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ