### PR TITLE
chore: use mongodb@6.0 in Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
 tap 'artsy/formulas'
 tap 'mongodb/brew'
-brew 'mongodb-community@5.0', link: true, restart_service: true
+brew 'mongodb-community@6.0', link: true, restart_service: true
 brew 'artsy/formulas/elasticsearch@6', restart_service: true


### PR DESCRIPTION
This PR patches #3152 to bump the `mongodb` version used in the `Brewfile` to `6.0`