### PR TITLE
fix: use correct field name for staging hokusai spec

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -50,7 +50,7 @@ spec:
         - yarn
         - production
         envFrom:
-        - configMarRef:
+        - configMapRef:
             name: secrets-config
         - configMapRef:
             name: positron-environment


### PR DESCRIPTION
Patches #3161 to correct `typo` in `hokusai/staging.yml`.