### PR TITLE
fix: load secrets in data-sync cron containers

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -305,6 +305,10 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
+            - name: scripts
+              mountPath: /usr/local/bin/load_secrets_and_run.sh
+              subPath: load_secrets_and_run.sh
+            command: ["/usr/local/bin/load_secrets_and_run.sh"]
             args:
             - sh
             - ./export-db.sh
@@ -323,6 +327,27 @@ spec:
           volumes:
           - name: secrets
             emptyDir: {}
+          - name: scripts
+            configMap:
+              name: positron-scripts
+              defaultMode: 0755
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: positron-scripts
+  namespace: default
+data:
+  load_secrets_and_run.sh: |
+    #!/bin/bash
+    CMD="$@"
+    if [ ! -z "$SECRETS_FILE" ]
+    then
+      echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
+      source "$SECRETS_FILE"
+    fi
+    echo "Running command: $CMD"
+    $CMD
 ---
 apiVersion: v1
 kind: Service

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -306,6 +306,10 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
+            - name: scripts
+              mountPath: /usr/local/bin/load_secrets_and_run.sh
+              subPath: load_secrets_and_run.sh
+            command: ["/usr/local/bin/load_secrets_and_run.sh"]
             args:
             - sh
             - ./import-db.sh
@@ -324,6 +328,27 @@ spec:
           volumes:
           - name: secrets
             emptyDir: {}
+          - name: scripts
+            configMap:
+              name: positron-scripts
+              defaultMode: 0755
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: positron-scripts
+  namespace: default
+data:
+  load_secrets_and_run.sh: |
+    #!/bin/bash
+    CMD="$@"
+    if [ ! -z "$SECRETS_FILE" ]
+    then
+      echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
+      source "$SECRETS_FILE"
+    fi
+    echo "Running command: $CMD"
+    $CMD
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Yet another patch #3161. We need to make the script available to the data sync cron jobs. This follows the pattern set out in https://github.com/artsy/artsy-unleash/pull/15 to store the script in a configMap and load into a volume mounted on the cronjob.