### PR TITLE
refactor: use load-secrets-and-run script from updated docker image

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -305,10 +305,6 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
-            - name: scripts
-              mountPath: /usr/local/bin/load_secrets_and_run.sh
-              subPath: load_secrets_and_run.sh
-            command: ["/usr/local/bin/load_secrets_and_run.sh"]
             args:
             - sh
             - ./export-db.sh
@@ -327,27 +323,6 @@ spec:
           volumes:
           - name: secrets
             emptyDir: {}
-          - name: scripts
-            configMap:
-              name: positron-scripts
-              defaultMode: 0755
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: positron-scripts
-  namespace: default
-data:
-  load_secrets_and_run.sh: |
-    #!/bin/bash
-    CMD="$@"
-    if [ ! -z "$SECRETS_FILE" ]
-    then
-      echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
-      source "$SECRETS_FILE"
-    fi
-    echo "Running command: $CMD"
-    $CMD
 ---
 apiVersion: v1
 kind: Service

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -306,10 +306,6 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
-            - name: scripts
-              mountPath: /usr/local/bin/load_secrets_and_run.sh
-              subPath: load_secrets_and_run.sh
-            command: ["/usr/local/bin/load_secrets_and_run.sh"]
             args:
             - sh
             - ./import-db.sh
@@ -328,27 +324,6 @@ spec:
           volumes:
           - name: secrets
             emptyDir: {}
-          - name: scripts
-            configMap:
-              name: positron-scripts
-              defaultMode: 0755
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: positron-scripts
-  namespace: default
-data:
-  load_secrets_and_run.sh: |
-    #!/bin/bash
-    CMD="$@"
-    if [ ! -z "$SECRETS_FILE" ]
-    then
-      echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
-      source "$SECRETS_FILE"
-    fi
-    echo "Running command: $CMD"
-    $CMD
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR removes the use of a `configMap` to store and mount the `load-secrets-and-run.sh` script. Once [these updated images](https://github.com/artsy/docker-images/pull/113) are pushed to our docker hub, we can rely on the script included in the containers. 

I'll need to sequence the roll out, so am assigning to myself.

### Related PR(s)
- https://github.com/artsy/docker-images/pull/113