### PR TITLE
fix: include legacy OpenSSL and no experimental fetch in NODE_OPTIONS

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -11,6 +11,7 @@ services:
       - ELASTICSEARCH_INDEX_SUFFIX=development
       # SALT is an oss value. The '$' is escaped.
       - SALT=$$2a$$10$$PJrPMBadu1NPdmnshBgFbe
+      - NODE_OPTIONS=--openssl-legacy-provider --no-experimental-fetch
     env_file:
       - ../.env.shared
       - ../.env

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -66,7 +66,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: NODE_OPTIONS
-          value: --max_old_space_size=256
+          value: "--max_old_space_size=256 --openssl-legacy-provider --no-experimental-fetch"
         - name: DD_VERSION
           valueFrom:
             fieldRef:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -66,7 +66,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: NODE_OPTIONS
-          value: --max_old_space_size=256
+          value: "--max_old_space_size=256 --openssl-legacy-provider --no-experimental-fetch"
         - name: DD_VERSION
           valueFrom:
             fieldRef:


### PR DESCRIPTION
This PR patches #3183 to include the required `NODE_OPTIONS` `--openssl-legacy-provider --no-experimental-fetch` when the service is run with `hokusai`. 