### PR TITLE
fix: run test suite sequentially

### DIFF
--- a/scripts/jest.sh
+++ b/scripts/jest.sh
@@ -6,4 +6,4 @@ trap "exit" INT
 
 jest \
   $@ \
-  --maxWorkers=2 --detectOpenHandles --forceExit
+  --runInBand --detectOpenHandles --forceExit


### PR DESCRIPTION
This PR updates Jest to run with `--runInBand` instead of `--maxWorkers=2` so that CI runs the tests sequentially in one process instead of running them in parallel on 2 child processes.

The goal of this change is to eliminate the test failures that I have been seeing in CI that indicate tests are tripping up on each other, such as:

```
1) Article Retrieval "before each" hook for "can  all articles along with total and counts":
   TypeError: Cannot read properties of undefined (reading 'call')
    at processImmediate (node:internal/timers:483:21)
```

This `beforeEach` hooks empties and adds 10 articles to the test database. I think that an error at this stage of the test is telling me that the test database is in an unexpected state - possibly because of a race condition with another parallel test. (For example, a test in one process has emptied the database that a test in another process is trying to read from.)

```
3) Save "before all" hook:
   Uncaught Error: listen EADDRINUSE: address already in use :::5000
    at Server.setupListenHandle [as _listen2] (node:net:1902:16)
    at listenInCluster (node:net:1959:12)
    at Server.listen (node:net:2061:7)
    at Function.listen (node_modules/express/lib/application.js:618:24)
    at Context.<anonymous> (src/api/apps/articles/test/model/distribute.spec.ts:18:18)
    at processImmediate (node:internal/timers:483:21)
```

When this error happens on my local machine I know that it's caused by macOS running AirDrop on port 5000. But when it happens in CI I think it's telling me that a test is trying to start a test server when one is already running from another test on another process.

cc: @artsy/diamond-devs 