### PR TITLE
fix: run mocha tests sequentially

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,6 +2,6 @@
 
 set -e -x
 
-yarn mocha $(find src -name '*.test.coffee')
-yarn mocha $(find src -name '*.spec.*')
-yarn jest
+yarn mocha --runInBand $(find src -name '*.test.coffee')
+yarn mocha --runInBand $(find src -name '*.spec.*')
+yarn jest --runInBand


### PR DESCRIPTION
This PR follows-up on #3200 by also making the mocha tests run in parallel. I was still seeing flaky errors in the CI test runs after merging that previous PR, and found that these might be additional places to run tests sequentially.
