### PR TITLE
feat(dia-1401): supports querying articles by inclusion in author_ids

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,4 +2,4 @@
 
 set -e -x
 
-DEBUG=app,client,api node --inspect ./src/index.js
+NODE_OPTIONS="--openssl-legacy-provider --no-experimental-fetch" DEBUG=app,client,api node --inspect ./src/index.js

--- a/src/api/apps/articles/model/retrieve.js
+++ b/src/api/apps/articles/model/retrieve.js
@@ -25,6 +25,7 @@ export const toQuery = input => {
     "channel_id",
     "all_by_author",
     "artist_id",
+    "author_ids",
     "has_video",
     "has_published_media",
     "fair_ids",
@@ -70,6 +71,9 @@ export const toQuery = input => {
   }
   if (input.tracking_tags) {
     query.tracking_tags = { $in: input.tracking_tags }
+  }
+  if (input.author_ids) {
+    query.author_ids = { $in: input.author_ids }
   }
 
   // Convert query for super article for article


### PR DESCRIPTION
Writer already supports querying by `author_id` but weirdly that's not the one we use to display the author of the article... which is: `author_ids` 🤷 

cc @artsy/diamond-devs 