### PR TITLE
fix: adds author_ids to the schema

### DIFF
--- a/src/api/apps/articles/model/schema.coffee
+++ b/src/api/apps/articles/model/schema.coffee
@@ -267,6 +267,7 @@ ImageCollectionSection = (->
   artwork_id: @string().objectid()
   auction_id: @string().objectid()
   author_id: @string().objectid()
+  author_ids: @string().objectid()
   biography_for_artist_id: @string().objectid()
   channel_id: @string().objectid()
   count: @boolean().default(false)


### PR DESCRIPTION
So: I'm going to first push this simpler fix and see if that solves my problem.

I wrote a script to generate some test data and I _think_ that might have caused a discrepancy between ids that are stored as `ObjectId` vs `string`s. I have some code that handles it in both cases, but I'm realizing the reason it's failing for me locally is possibly different from the reason in production. So let's see (I also needed to add this field to the schema or Joi would strip it).

Anyway, I'll verify this in staging and then possibly open up a follow up PR if needed.

cc @artsy/diamond-devs 
