### PR TITLE
feat: put a feature flag to switch Elasticsearch to OpenSearch

### DIFF
--- a/src/api/apps/articles/model/distribute.coffee
+++ b/src/api/apps/articles/model/distribute.coffee
@@ -61,11 +61,14 @@ moment = require 'moment'
   )
 
 @removeFromSearch = (id) ->
-  search.client.delete(
+  deleteParams =
     index: search.index
-    type: 'article'
     id: id
-  , (error, response) ->
+
+  # Only include type parameter for Elasticsearch
+  deleteParams.type = if search.isOpenSearch then '_doc' else 'article'
+
+  search.client.delete(deleteParams, (error, response) ->
     console.log(error) if error
   )
 

--- a/src/api/lib/elasticsearch.coffee
+++ b/src/api/lib/elasticsearch.coffee
@@ -1,8 +1,8 @@
 elasticsearch = require('elasticsearch')
-{ ELASTICSEARCH_URL, ELASTICSEARCH_INDEX_SUFFIX } = process.env
+{ ELASTICSEARCH_URL, OPENSEARCH_URL, ELASTICSEARCH_INDEX_SUFFIX, USE_OPENSEARCH } = process.env
 
 client = new elasticsearch.Client
-          host: ELASTICSEARCH_URL
+          host: if USE_OPENSEARCH == 'true' then OPENSEARCH_URL else ELASTICSEARCH_URL
           maxRetries: 2
           keepAlive: true
           maxSockets: 10
@@ -10,3 +10,4 @@ client = new elasticsearch.Client
 module.exports =
   index: 'articles_' + (ELASTICSEARCH_INDEX_SUFFIX or 'production')
   client: client
+  isOpenSearch: USE_OPENSEARCH == 'true'


### PR DESCRIPTION
# Summary
The PR introduces a feature flag to switch Elasticsearch to OpenSearch to test OepnSearch in the staging, which is the same approach as https://github.com/artsy/gravity/pull/19128

You can see there are no failing tests in [this PR](https://github.com/artsy/positron/pull/3217) after switching ES to OS.