### PR TITLE
Migrate from asdf to mise

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,11 +12,11 @@ NO_COLOR=$(tput sgr0)
 echo "Installing project dependencies from Brewfile..."
 brew bundle
 
-if command -v asdf >/dev/null; then
-  echo "Installing language dependencies with asdf"
-  asdf install
+if command -v mise >/dev/null; then
+  echo "Installing language dependencies with mise"
+  mise install
 else
-  echo "Skipping language dependencies installation (asdf not found)"
+  echo "Skipping language dependencies installation (mise not found)"
 fi
 
 echo "Installing dependencies..."


### PR DESCRIPTION
## Summary
- Replace asdf commands with mise commands in scripts/setup.sh
- mise is compatible with existing .tool-versions file

## References
- https://github.com/artsy/README/issues/550