### PR TITLE
fix: raise memory limit for assets pipeline

### DIFF
--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -6,7 +6,7 @@ set -e -x
 
 yarn clean
 
-NODE_ENV=production node --max_old_space_size=4096 node_modules/.bin/webpack --config ./webpack
+NODE_ENV=production node --max_old_space_size=8192 node_modules/.bin/webpack --config ./webpack
 stylus \
   $(find src/client/assets -name '*.styl') \
   --compress \


### PR DESCRIPTION
`main` build has been failing due to [what looks like](https://app.circleci.com/pipelines/github/artsy/positron/6028/workflows/324080c0-daa9-411d-b6ff-6e227b0d3255/jobs/13134) memory exhaustion. Let's try raising memory limit.