### PR TITLE
fix(dx): update webpack config, add some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ yarn start
 
 #### Using staging database
 
-In order to write articles, you will need to be a member of a channel. If you are an Artsy dev, you can point MONGOHQ_URL env to the staging database. Connecting to staging database requires VPN, please see details on [setting up a VPN connection here](https://github.com/artsy/infrastructure/blob/master/README.md#vpn).
+In order to write articles, you will need to be a member of a channel. If you are an Artsy dev, you can point `MONGOHQ_URL` env to the staging database.
+
+Connecting to staging database requires…
+
+- **VPN access**: Please see details on [setting up a VPN connection here](https://www.notion.so/artsy/VPN-Configuration-60798c292185407687356997bf251d8c)
+
+- **Staging credentials**: These can be obtained from Vault. Follow [the Vault instructions here](https://www.notion.so/artsy/Hashicorp-Vault-developer-instructions-77d94af51f714d51bb44049f4f2027bc) in order to retrieve the staging value for the `MONGOHQ_URL` env var.
+
+- **Staging search url**: Also obtain the `SEARCH_URL` env var via `hokusai staging env` in order to search staging data locally.
 
 #### Using a local database
 

--- a/webpack/config/base.js
+++ b/webpack/config/base.js
@@ -18,17 +18,17 @@ const config = {
     rules: [
       {
         test: /\.coffee$/,
-        include: /src/,
+        include: path.resolve(__dirname, "../../src"),
         loader: "coffee-loader",
       },
       {
         test: /\.jade$/,
-        include: /src/,
+        include: path.resolve(__dirname, "../../src"),
         loader: "jade-loader",
       },
       {
         test: /\.(js|ts)x?$/,
-        include: /src/,
+        include: path.resolve(__dirname, "../../src"),
         use: [
           {
             loader: "babel-loader",
@@ -40,17 +40,17 @@ const config = {
       },
       {
         test: /\.json$/,
-        include: /src/,
+        include: path.resolve(__dirname, "../../src"),
         loader: "json-loader",
       },
       {
         test: /\.css$/,
-        include: /src/,
+        include: path.resolve(__dirname, "../../src"),
         use: [{ loader: "style-loader" }, { loader: "css-loader" }],
       },
       {
         test: /\.styl$/,
-        include: /src/,
+        include: path.resolve(__dirname, "../../src"),
         use: [
           { loader: "style-loader" },
           { loader: "css-loader" },


### PR DESCRIPTION
[DI-59](https://www.notion.so/artsy/positron-Fix-webpack-src-targeting-32ccab0764a0802fb731f9cae716f352) and [DI-61](https://www.notion.so/artsy/positron-Document-or-even-default-to-staging-env-setup-for-local-development-32ccab0764a08052bb84c165b484d52c)

Fixes the webpack config for users (like me) who keep their Artsy repos in a path like `~/src/artsy`. 

This fixes a false match on that `src` string which was causing Webpack to overeagerly try to compile _everything_ in the positron directory — including <code>\~/src/artsy/positron/node_modules</code> — instead of just the stuff in <code>\~/src/artsy/positron/<b>src</b></code> i.e. that last subdirectory.

Also adds some instructions on how to properly connect to the staging env in order to be able to work with realistic data.

## Before

<img width="600" alt="before" src="https://github.com/user-attachments/assets/60d948ce-2e41-416c-8714-5c985bc9348e" />

## After (local env)

<img width="600" alt="after" src="https://github.com/user-attachments/assets/0d57bd13-3294-4a76-ae89-118ab1197c13" />

## After (staging env)

<img width="600" alt="after staging" src="https://github.com/user-attachments/assets/bae91dd8-be26-4b10-8ec2-323d850fd9d9" />

