### PR TITLE
feat: link pr to notion task when id is in desc

### DIFF
--- a/.github/workflows/link-pr-to-notion.yml
+++ b/.github/workflows/link-pr-to-notion.yml
@@ -1,0 +1,10 @@
+name: Link PR to Notion
+on:
+  pull_request:
+    types: [opened, edited]
+jobs:
+  link:
+    uses: artsy/duchamp/.github/workflows/link-pr-to-notion.yml@main
+    secrets:
+      notion-token: ${{ secrets.NOTION_TOKEN }}
+      root-page-id: ${{ secrets.NOTION_ROOT_PAGE_ID }}


### PR DESCRIPTION
This PR resolves DI-50

When a pr contains a notion task ID in commit, description or title, the PR link gets added to the task's list of PRs.