### PR TITLE
fix(DI-283): detect user channel_ids drift and refresh them

### DIFF
--- a/src/api/apps/users/model.coffee
+++ b/src/api/apps/users/model.coffee
@@ -29,7 +29,18 @@ jwtDecode = require 'jwt-decode'
         # Compare the user's partner access from the database vs JWT token to see if it needs a refresh
         savedPartnerIds = user.partner_ids.map((a) => a.toString())
         latestPartnerIds = jwtDecode(accessToken)?.partner_ids or []
-        return callback null, user if _.isEqual(savedPartnerIds, latestPartnerIds)
+        if _.isEqual(savedPartnerIds, latestPartnerIds)
+          # Also re-check channel membership in case access was granted since last login
+          return db.collection('channels').find({user_ids: new ObjectId(user._id)}).toArray (err, channels) ->
+            return callback err if err
+            latestChannelIds = _.pluck channels, '_id'
+            savedChannelIdsSorted = user.channel_ids.map((a) -> a.toString()).sort()
+            latestChannelIdsSorted = latestChannelIds.map((a) -> a.toString()).sort()
+            return callback null, user if _.isEqual(savedChannelIdsSorted, latestChannelIdsSorted)
+            db.collection('users').updateOne { _id: user._id }, { $set: { channel_ids: latestChannelIds } }, (err) ->
+              return callback err if err
+              user.channel_ids = latestChannelIds
+              callback null, user
       # Otherwise fetch data from Gravity and flatten it into a Positron user
       request
         .get("#{ARTSY_URL}/api/v1/me")

--- a/src/api/apps/users/test/model.test.coffee
+++ b/src/api/apps/users/test/model.test.coffee
@@ -93,6 +93,23 @@ describe 'User', ->
             user.channel_ids[0].toString().should.equal '5086df098523e60002000099'
             done()
 
+    it 'returns user unchanged when channel_ids are already in sync', (done) ->
+      channelId = new ObjectId '5086df098523e60002000099'
+      fabricate 'users', {
+        _id: new ObjectId '4d8cd73191a5c50ce200002a'
+        channel_ids: [channelId]
+        partner_ids: ['5086df098523e60002000012']
+      }, (err, user) ->
+        channel = {
+          _id: channelId
+          user_ids: [new ObjectId '4d8cd73191a5c50ce200002a']
+        }
+        db.collection('channels').insertOne channel, ->
+          User.fromAccessToken fixtures().users.access_token, (err, user) ->
+            user.channel_ids.length.should.equal 1
+            user.channel_ids[0].toString().should.equal '5086df098523e60002000099'
+            done()
+
   describe '#present', ->
 
     it 'converts _id to id', ->

--- a/src/api/apps/users/test/model.test.coffee
+++ b/src/api/apps/users/test/model.test.coffee
@@ -77,6 +77,22 @@ describe 'User', ->
           user.partner_ids[0].toString().should.equal '5086df098523e60002000012'
           done()
 
+    it 'syncs channel_ids when channel access is granted after first login', (done) ->
+      fabricate 'users', {
+        _id: new ObjectId '4d8cd73191a5c50ce200002a'
+        channel_ids: []
+        partner_ids: ['5086df098523e60002000012']
+      }, (err, user) ->
+        channel = {
+          _id: new ObjectId '5086df098523e60002000099'
+          user_ids: [new ObjectId '4d8cd73191a5c50ce200002a']
+        }
+        db.collection('channels').insertOne channel, ->
+          User.fromAccessToken fixtures().users.access_token, (err, user) ->
+            user.channel_ids.length.should.equal 1
+            user.channel_ids[0].toString().should.equal '5086df098523e60002000099'
+            done()
+
   describe '#present', ->
 
     it 'converts _id to id', ->


### PR DESCRIPTION
This PR adds a check for drift between a user's (cached) channel IDs and the (source of truth) user IDs registered to each channel, and updates the former to match the latter if necessary.

Stale cached channel IDs on user records were causing an issue where some users would login to Writer and be presented with an error message like this one:

<img width="1840" height="1098" alt="Screenshot 2026-05-13 at 5 09 31 PM" src="https://github.com/user-attachments/assets/5d2dc4d0-2556-4cba-919b-3338557a6ccf" />

This (correctly) happens when a user does not have the `editorial` role and no channel IDs. It also (incorrectly) happens after they have been assigned channel IDs since the cached channel IDs on their user account is still empty. This check fixes that second scenario by actively checking for drift between the cached and actual channel IDs on each request that calls `fromAccessToken` via the `setUser` middleware.

- [DI-283](https://www.notion.so/artsy/Positron-channel-user-management-broken-user-adds-permissions-are-incorrect-35fcab0764a080fb9e34cd1522926a7a?v=310cab0764a08156aa73000cda8f267f&source=copy_link)
- cc: @artsy/diamond-devs 