### PR TITLE
feat: staging to use HPAv2

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -119,7 +119,7 @@ spec:
         emptyDir: {}
 
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: positron-web
@@ -131,7 +131,13 @@ spec:
     name: positron-web
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 70
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
[HPAv2](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/) is at GA status as of Kubernetes v1.23 which is our current version. v2 adds the ability to scale by memory, by custom metrics, and by combination of metrics. Let's switch to v2.

Jira: [PHIRE-3105](https://artsy.atlassian.net/browse/PHIRE-3105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PHIRE-3105]: https://artsyproduct.atlassian.net/browse/PHIRE-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ