### PR TITLE
feat: production to use HPAv2

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -118,7 +118,7 @@ spec:
       - name: secrets
         emptyDir: {}
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: positron-web
@@ -130,7 +130,13 @@ spec:
     name: positron-web
   minReplicas: 2
   maxReplicas: 6
-  targetCPUUtilizationPercentage: 70
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
HPAv2 is at GA status as of Kubernetes v1.23 which is our current version. v2 adds the ability to scale by memory, by custom metrics, and by combination of metrics. Let us switch to v2.

Jira: PHIRE-3107