### PR TITLE
fix(PHIRE-3246): validate redirect-to in switch_channel to prevent open redirect

### DIFF
--- a/src/client/apps/switch_channel/index.coffee
+++ b/src/client/apps/switch_channel/index.coffee
@@ -10,6 +10,12 @@ Channel = require '../../models/channel.coffee'
 
 app = module.exports = express()
 
+# Only permit same-origin, local redirect targets.
+LOCAL_PATH = /^\/(?![\/\\])[^\x00-\x1f]*$/
+
+safeRedirect = (target) ->
+  if typeof target is 'string' and LOCAL_PATH.test target then target else '/'
+
 app.get '/switch_channel/:id', switchChannel = (req, res, next) ->
   new Channel(id: req.params.id).fetchChannelOrPartner
     success: (channel) =>
@@ -24,6 +30,6 @@ app.get '/switch_channel/:id', switchChannel = (req, res, next) ->
       req.user.set 'current_channel', channel.denormalized()
       req.login req.user, (err) ->
         return next err if err
-        res.redirect req.query['redirect-to'] or '/'
+        res.redirect safeRedirect(req.query['redirect-to'])
     error: (err) ->
       return next err

--- a/src/client/apps/switch_channel/test/index.test.coffee
+++ b/src/client/apps/switch_channel/test/index.test.coffee
@@ -60,6 +60,56 @@ describe 'authorized switch_channel (partner)', ->
     @req.user.get('current_channel').name.should.equal 'Gagosian'
     @req.user.get('current_channel').type.should.equal 'partner'
 
+describe 'switch_channel redirect-to validation', ->
+
+  beforeEach ->
+    user = new User fixtures().users
+    user.set channel_ids: ['1234']
+    user.set partner_ids: []
+    user.set type: 'Admin'
+    @channel = new Channel(
+      name: 'Artsy Editorial'
+      id: '1234'
+      type: 'editorial'
+    )
+    sinon.stub(Channel.prototype,'fetchChannelOrPartner').yieldsTo('success', @channel)
+    @res = redirect: sinon.stub()
+    @next = sinon.stub()
+    app.__set__ 'Channel', Channel
+    @switch_user = app.__get__ 'switchChannel'
+    # login must invoke its callback for the redirect to run
+    @switchTo = (redirectTo) =>
+      req = user: user, login: ((u, cb) -> cb()), params: id: '1234'
+      req.query = 'redirect-to': redirectTo
+      @switch_user req, @res, @next
+
+  afterEach ->
+    Channel.prototype.fetchChannelOrPartner.restore()
+
+  it 'redirects to a local path', ->
+    @switchTo '/articles/123/edit'
+    @res.redirect.args[0][0].should.equal '/articles/123/edit'
+
+  it 'preserves the query string on a local path', ->
+    @switchTo '/articles/123/edit?foo=bar'
+    @res.redirect.args[0][0].should.equal '/articles/123/edit?foo=bar'
+
+  it "defaults to '/' when redirect-to is absent", ->
+    @switchTo undefined
+    @res.redirect.args[0][0].should.equal '/'
+
+  it 'rejects absolute external URLs', ->
+    @switchTo 'https://example.com/security-test'
+    @res.redirect.args[0][0].should.equal '/'
+
+  it 'rejects scheme-relative URLs', ->
+    @switchTo '//example.com'
+    @res.redirect.args[0][0].should.equal '/'
+
+  it 'rejects backslash scheme-relative variants', ->
+    @switchTo '/\\example.com'
+    @res.redirect.args[0][0].should.equal '/'
+
 describe 'non authorized switch_channel', ->
 
   beforeEach ->


### PR DESCRIPTION
## Summary

The `/switch_channel/:id` route passed the `redirect-to` query parameter straight to `res.redirect()`, allowing an authenticated user to be redirected off `writer.artsy.net` to an arbitrary external URL (bounty GF657).

Add a safeRedirect allow-list that only permits **local same-origin** paths and rejects absolute URLs, scheme-relative URLs (`//host`, `/\host`) and control-character smuggling, falling back to '/'. The only legitimate producer of `redirect-to` (apps/edit) always passes a local path, so no existing flow is affected.

## Reproduction 

Preconditions: authenticated Writer user with access to a channel/partner (the three gates requireLogin → requireChannel → hasChannel/hasPartner must pass).

1. Log in to https://stagingwriter.artsy.net/ as a Writer user.
2. Get an authorized channel id (devtools console: `sd.USER.current_channel.id`).
1. Visit:
<[https://stagingwriter.artsy.net/switch_channel/<AUTHORIZED_ID>>?redirect-to=](https://stagingwriter.artsy.net/switch_channel/%3CAUTHORIZED_ID%3E%3E?redirect-to=)https://example.com/security-test E.g. https://stagingwriter.artsy.net/switch_channel/5759e4f3b5989e6f98f77998?redirect-to=https://example.com/security-test
1. Observed: HTTP 302 with Location: https://example.com/security-test
(redirected off-domain to the attacker-controlled URL).

## Ticket

https://artsyproduct.atlassian.net/browse/PHIRE-3246

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>