### PR TITLE
feat: Support filtering articles by published at timestamp

### DIFF
--- a/scripts/db/20260825000001_add_primary_featured_artist_published_at_index.js
+++ b/scripts/db/20260825000001_add_primary_featured_artist_published_at_index.js
@@ -1,0 +1,12 @@
+// Run like:
+//
+// mongo "mongodb+srv://<host>/app29923450" --username positron2 --password <redacted> scripts/db/<filename>
+
+db.articles.createIndex(
+  {
+    primary_featured_artist_ids: 1,
+    published: 1,
+    published_at: -1,
+  },
+  { background: true }
+)

--- a/src/api/apps/articles/model/retrieve.js
+++ b/src/api/apps/articles/model/retrieve.js
@@ -34,7 +34,8 @@ export const toQuery = input => {
     "scheduled",
     "access_token",
     "omit",
-    "in_editorial_feed"
+    "in_editorial_feed",
+    "published_since"
   )
   if (input.fair_id) {
     query.fair_ids = input.fair_id
@@ -141,6 +142,11 @@ export const toQuery = input => {
       { featured_artist_ids: input.artist_id },
       { biography_for_artist_id: input.artist_id }
     )
+  }
+
+  // Filter articles published since a given date
+  if (input.published_since) {
+    query.published_at = { $gte: new Date(input.published_since) }
   }
 
   // Convert query for articles that have video sections

--- a/src/api/apps/articles/test/model/retrieve.test.ts
+++ b/src/api/apps/articles/test/model/retrieve.test.ts
@@ -138,5 +138,15 @@ describe("Retrieve", () => {
       })
       query._id.should.have.keys("$nin")
     })
+
+    it("filters articles by published_since", () => {
+      const date = "2024-01-01T00:00:00.000Z"
+      const { query } = toQuery({
+        published_since: date,
+        published: true,
+      })
+      query.published_at.should.have.keys("$gte")
+      query.published_at.$gte.should.eql(new Date(date))
+    })
   })
 })


### PR DESCRIPTION
feat: Support filtering articles by published at timestamp


Topaz team is working on this 3 week Shape Up bet: https://app.notion.com/p/artsy/Artist-Editorial-Feature-Callout-3bbcab0764a080b6b2fdddf4533a02a4

Where we want to surface to CMS partners when an artist of theirs has been in an article, like so:


<img width="2048" height="918" alt="Screenshot 2026-08-25 at 3 30 06 PM" src="https://github.com/user-attachments/assets/84b87d24-4e8d-4f1f-9ede-a26206223864" />


We've recently threaded in the ability in MP to query for articles of a given artist to flag editorial activity to partners in CMS behind a feature flag:

- https://github.com/artsy/metaphysics/pull/7841
- https://github.com/artsy/volt/pull/12003


So far it is pretty snappy and we have been monitoring performance here:
- https://app.datadoghq.com/apm/resource/metaphysics.graphql/graphql.execute/52f6f0df91e574ec?dependencyMap.showNetworkMetrics=false&env=staging&errors=qson%3A%28data%3A%28issueSort%3ATOTAL_COUNT%29%2Cversion%3A%210%29&fromUser=false&graphType=flamegraph&groupMapByOperation=null&historicalData=true&shouldShowLegend=true&spanID=9069286734317013602&traceQuery=&start=1787667142013&end=1787670742013&paused=false
- https://artsy.slack.com/archives/C0A5Z9S1BTJ/p1787669940718769


## Why this change?

While playing with the spike on staging, I noticed we are displaying a lot of articles from the far past

 

https://github.com/user-attachments/assets/78db136f-c728-4633-923b-7410a040eb4d

We want to be able to filter this and only display articles published in the last year for example

*What do you think?*


⚠️ I am a bit weary to modify Positron though as I have never worked in it and looks like migrations might need to be run manually? ⚠️ 



## Another option ?!
I keep going back and forth on where this should live a simple filter seems like a nice stepping stone to learn more, especially as this is a fast paced shape up "bet". 

I feel like it might be too early to be modeling an "artist signal" type table to track artist activity in editorial 
Spiking here: https://github.com/artsy/gravity/compare/jpotts244/spike-use-article-locally?expand=1

The small amount of code changes require to add filtering support here is just too tempting

cc @artsy/topaz-devs 

