### PR TITLE
fix: Add the new filter param to Joi schema list

### DIFF
--- a/src/api/apps/articles/model/schema.coffee
+++ b/src/api/apps/articles/model/schema.coffee
@@ -289,6 +289,7 @@ ImageCollectionSection = (->
   omit: @array().items(@string())
   partner_id: @string().objectid()
   published: @boolean().default(true)
+  published_since: @date().allow(null)
   q: @string().allow('')
   scheduled: @boolean()
   section_id: @string().objectid()


### PR DESCRIPTION
Fast follow from: https://github.com/artsy/positron/commit/04ecc4cd1fd9491e4443db88fc1c683ba501a00c


Not having the new filter param in this allow list was removing it before we made it to the database
`Line 32: { stripUnknown: true }` — Joi validates the input against querySchema and strips any unknown fields before passing to toQuery. 