### PR TITLE
feat: Sends published_at timestamp in article publish event payload

### DIFF
--- a/src/api/apps/articles/test/model/index/persistence.spec.ts
+++ b/src/api/apps/articles/test/model/index/persistence.spec.ts
@@ -298,12 +298,14 @@ describe("Article Persistence", () => {
       ))
 
     it("sends RabbitMQ event when publishing", done => {
+      const published_at = new Date("2024-01-15T12:00:00.000Z")
       Article.save(
         {
           title: "Top Ten Shows",
           thumbnail_title: "Ten Shows",
           author_id: "5086df098523e60002000018",
           published: true,
+          published_at,
           id: "5086df098523e60002002222",
           primary_featured_artist_ids: ["52868347b202a37bb000072a"],
           channel_id: "5086df098523e60002000018",
@@ -321,7 +323,7 @@ describe("Article Persistence", () => {
               title: "Top Ten Shows",
               featured_artist_ids: [new ObjectId("52868347b202a37bb000072a")],
               href: "/article/undefined-ten-shows",
-              published_at: sinon.match.instanceOf(Date),
+              published_at,
             })
             .callCount.should.eql(1)
 

--- a/src/api/apps/articles/test/model/index/persistence.spec.ts
+++ b/src/api/apps/articles/test/model/index/persistence.spec.ts
@@ -321,6 +321,7 @@ describe("Article Persistence", () => {
               title: "Top Ten Shows",
               featured_artist_ids: [new ObjectId("52868347b202a37bb000072a")],
               href: "/article/undefined-ten-shows",
+              published_at: sinon.match.instanceOf(Date),
             })
             .callCount.should.eql(1)
 

--- a/src/api/models/article.coffee
+++ b/src/api/models/article.coffee
@@ -78,6 +78,7 @@ module.exports = class Article extends Backbone.Model
       featured_artist_ids: @get('primary_featured_artist_ids')
       href: @href()
       title: @get('title')
+      published_at: @get('published_at')
 
     amqp.publish("editorial", "article.published", payload)
 


### PR DESCRIPTION
feat: Sends `published_at` timestamp in article publish event payload

Addressing: https://artsyproduct.atlassian.net/browse/TOP-403


Adding the `published_at` timestamp of the article being published over the Gravity as part of the event payload

We want to ingest this timestamp on Gravity's side vs infer it when the event gets processed


- https://github.com/artsy/gravity/pull/20480